### PR TITLE
Automated annotations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,16 +1,8 @@
-/* Declaring global variables */
+/* Root Variables */
 :root {
   --primary: #4d59a2;
   --secondary: #51a993;
   --accent: #28bacb;
-  --main-color: #0C86C6;
-  --main-color-light: #d6e0f5;
-  --main-color-dark: #1c497d;
-  --alt-color-1: #00BAAF;
-  --alt-color-2: #00BED1;
-  --alt-color-3: #0099B9;
-  --main-color-green: #009973;
-
   --greyXLight: #F4F4F1;
   --greyLight: #E9E8E3;
   --grey: #D9D9DF;
@@ -21,17 +13,32 @@
   --handled: #F7A112;
   --approved: #3DCA77;
   --denied: #E74C3C;
+  --deniedDark: #9f2214;
   --resolved: var(--greyMedium);
 }
 
+/* Global Styling */
 html {
+  height: 100vh;
   font-size: 16px;
-  background-color: #F9FAFC;
 }
 
 body {
-  overflow: hidden;
+  height: 100%;
   margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  color: #333333;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  margin: 0;
+  background-color: #F9FAFC;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
 }
 
 .root {
@@ -59,11 +66,6 @@ p {
   margin: 0;
 }
 
-.textOverflow {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
 
 /* Scroll Bars */
 
@@ -89,7 +91,7 @@ p {
 }
 
 
-/* Custom additional styling */
+/* Custom classes */
 
 /* Width */
 .w-0 {
@@ -99,19 +101,19 @@ p {
 /* Color */
 
 .c-primary {
-  color: var(--primary) !important;
+  color: var(--primary);
 }
 
 .c-secondary {
-  color: var(--secondary) !important;
+  color: var(--secondary);
 }
 
 .c-accent {
-  color: var(--accent) !important;
+  color: var(--accent);
 }
 
-.c-backdrop {
-  color: #404040;
+.c-white {
+  color: white;
 }
 
 /* Font Weight */
@@ -125,24 +127,20 @@ p {
   background-color: #F9FAFC;
 }
 
-.bg-primary-blue {
-  background-color: var(--main-color);
+.bgc-primary {
+  background-color: var(--primary);
 }
 
-.bg-primary-light {
-  background-color: var(--main-color-light);
+.bgc-secondary {
+  background-color: var(--secondary);
 }
 
-.bg-primary-dark {
-  background-color: var(--main-color-dark);
+.bgc-accent {
+  background-color: var(--accent);
 }
 
-.bg-green {
-  background-color: var(--main-color-green);
-}
-
-.bg-backdrop {
-  background-color: #404040;
+.bgc-greyLight {
+  background-color: var(--greyLight);
 }
 
 /* Border */
@@ -258,6 +256,13 @@ p {
   box-shadow: 5px 2px 11px 2px rgba(0, 0, 0, 0.54);
 }
 
+/* Text overflow */
+.textOverflow {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 /* Hover underline */
 .h-underline:hover {
   text-decoration: underline !important;
@@ -274,7 +279,7 @@ p {
 }
 
 
-/* Custom Component Styling */
+/* Global Components Styling */
 
 .primaryButton {
   background-color: var(--primary);
@@ -291,6 +296,42 @@ p {
 
 .primaryButton.cancel {
   background-color: #CBCCD4;
+}
+
+.secondaryButton {
+  background-color: var(--secondary);
+  color: white;
+  border: none;
+  border-radius: 999px;
+  transition: 0.4s;
+  font-weight: 500;
+}
+
+.secondaryButton:hover {
+  background-color: var(--accent);
+}
+
+.removeButton {
+  background-color: var(--denied);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  transition: 0.4s;
+  font-weight: 500;
+}
+
+.removeButton:hover {
+  background-color: var(--deniedDark);
+}
+
+.formField {
+  border: 1px solid var(--grey);
+  border-radius: 8px;
+}
+
+.formFieldTitle {
+  font-size: 15px;
+  font-weight: 500;
 }
 
 

--- a/src/App.css
+++ b/src/App.css
@@ -32,7 +32,6 @@ body {
   color: #333333;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  margin: 0;
   background-color: #F9FAFC;
 }
 

--- a/src/api/digitalMedia/GetDigitalMediaMAS.ts
+++ b/src/api/digitalMedia/GetDigitalMediaMAS.ts
@@ -1,0 +1,33 @@
+/* Import Dependencies */
+import axios from 'axios';
+
+/* Import Types */
+import { JSONResultArray, Dict } from 'global/Types';
+
+
+const GetDigitalMediaMAS = async (handle: string) => {
+    let digitalMediaMAS: Dict[] = [];
+
+    if (handle) {
+        const endPoint: string = `/digitalmedia/${handle}/mas`;
+
+        try {
+            const result = await axios({
+                method: "get",
+                url: endPoint,
+                responseType: 'json'
+            });
+
+            /* Set Digital Media MAS */
+            const data: JSONResultArray = result.data;
+
+            digitalMediaMAS = data.data;
+        } catch (error) {
+            console.warn(error);
+        }
+    }
+
+    return digitalMediaMAS;
+}
+
+export default GetDigitalMediaMAS;

--- a/src/api/digitalMedia/GetDigitalMediaVersions.ts
+++ b/src/api/digitalMedia/GetDigitalMediaVersions.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 const GetDigitalMediaVersions = async (handle: string) => {
     let digitalMediaVersions = [] as number[];
 
-    const endPoint: string = `digitalMedia/${handle}/versions`;
+    const endPoint: string = `digitalmedia/${handle}/versions`;
 
     try {
         const result = await axios({

--- a/src/api/digitalMedia/ScheduleDigitalMediaMAS.ts
+++ b/src/api/digitalMedia/ScheduleDigitalMediaMAS.ts
@@ -1,0 +1,38 @@
+/* Import Dependencies */
+import axios from 'axios';
+
+/* Import Types */
+import { JSONResultArray, Dict } from 'global/Types';
+
+
+const ScheduleDigitalMediaMAS = async (handle: string, MASRequest: Dict, token?: string) => {
+    let digitalMediaMAS: Dict[] = [];
+
+    if (handle && token) {
+        const endPoint: string = `/digitalmedia/${handle.replace('https://hdl.handle.net/', '')}/mas`;
+
+        try {
+            const result = await axios({
+                method: "post",
+                url: endPoint,
+                data: MASRequest,
+                responseType: 'json',
+                headers: {
+                    'Content-type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                },
+            });
+
+            /* Set Digital Media MASl */
+            const data: JSONResultArray = result.data;
+
+            digitalMediaMAS = data.data;
+        } catch (error) {
+            console.warn(error);
+        }
+    }
+
+    return digitalMediaMAS;
+}
+
+export default ScheduleDigitalMediaMAS;

--- a/src/api/specimen/GetSpecimenMAS.ts
+++ b/src/api/specimen/GetSpecimenMAS.ts
@@ -1,0 +1,33 @@
+/* Import Dependencies */
+import axios from 'axios';
+
+/* Import Types */
+import { JSONResultArray, Dict } from 'global/Types';
+
+
+const GetSpecimenMAS = async (handle: string) => {
+    let specimenMAS: Dict[] = [];
+
+    if (handle) {
+        const endPoint: string = `/specimens/${handle}/mas`;
+
+        try {
+            const result = await axios({
+                method: "get",
+                url: endPoint,
+                responseType: 'json'
+            });
+
+            /* Set Specimen MAS */
+            const data: JSONResultArray = result.data;
+
+            specimenMAS = data.data;
+        } catch (error) {
+            console.warn(error);
+        }
+    }
+
+    return specimenMAS;
+}
+
+export default GetSpecimenMAS;

--- a/src/api/specimen/ScheduleSpecimenMAS.ts
+++ b/src/api/specimen/ScheduleSpecimenMAS.ts
@@ -1,0 +1,38 @@
+/* Import Dependencies */
+import axios from 'axios';
+
+/* Import Types */
+import { JSONResultArray, Dict } from 'global/Types';
+
+
+const ScheduleSpecimenMAS = async (handle: string, MASRequest: Dict, token?: string) => {
+    let specimenMAS: Dict[] = [];
+
+    if (handle && token) {
+        const endPoint: string = `/specimens/${handle.replace('https://hdl.handle.net/', '')}/mas`;
+
+        try {
+            const result = await axios({
+                method: "post",
+                url: endPoint,
+                data: MASRequest,
+                responseType: 'json',
+                headers: {
+                    'Content-type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                },
+            });
+
+            /* Set Specimen MAS */
+            const data: JSONResultArray = result.data;
+
+            specimenMAS = data.data;
+        } catch (error) {
+            console.warn(error);
+        }
+    }
+
+    return specimenMAS;
+}
+
+export default ScheduleSpecimenMAS;

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 import KeycloakService from 'keycloak/Keycloak';
-import Select from 'react-select';
 import { Container, Row, Col } from 'react-bootstrap';
 
 /* Import Store */
@@ -25,6 +24,7 @@ import IDCard from './components/IDCard/IDCard';
 import VersionSelect from 'components/general/versionSelect/VersionSelect';
 import DigitalMediaFrame from './components/digitalMedia/DigitalMediaFrame';
 import DigitalMediaList from './components/digitalMedia/DigitalMediaList';
+import ActionsDropdown from 'components/general/actionsDropdown/ActionsDropdown';
 import AutomatedAnnotationsModal from '../general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal';
 import Footer from 'components/general/footer/Footer';
 
@@ -94,7 +94,7 @@ const DigitalMedia = () => {
     }, [digitalMedia, params]);
 
     /* Function for executing Digital Media Actions */
-    const DigitalMediaAction = (action: string) => {
+    const DigitalMediaActions = (action: string) => {
         switch (action) {
             case 'json':
                 window.open(`https://sandbox.dissco.tech/api/v1/digitalmedia/${digitalMedia.id.replace('https://hdl.handle.net/', '')}`);
@@ -141,26 +141,8 @@ const DigitalMedia = () => {
                                                 </Col>
                                                 <Col />
                                                 <Col className="col-md-auto">
-                                                    <Select
-                                                        value={{ value: 'Actions', label: 'Actions' }}
-                                                        options={digitalMediaActions}
-                                                        className="text-white"
-                                                        isSearchable={false}
-                                                        styles={{
-                                                            control: provided => ({
-                                                                ...provided, backgroundColor: '#4d59a2', border: 'none',
-                                                                borderRadius: '999px', fontWeight: '500', fontSize: '15px'
-                                                            }),
-                                                            menu: provided => ({
-                                                                ...provided, zIndex: 100000, fontSize: '15px', width: 'max-content',
-                                                                position: 'absolute', right: '0', color: '#333333'
-                                                            }),
-                                                            dropdownIndicator: provided => ({ ...provided, color: 'white', fontSize: '15px' }),
-                                                            singleValue: provided => ({
-                                                                ...provided, color: 'white'
-                                                            })
-                                                        }}
-                                                        onChange={(option) => { option?.value && DigitalMediaAction(option.value) }}
+                                                    <ActionsDropdown actions={digitalMediaActions}
+                                                        Actions={(action: string) => DigitalMediaActions(action)}
                                                     />
                                                 </Col>
                                             </Row>

--- a/src/components/digitalMedia/components/TitleBar.tsx
+++ b/src/components/digitalMedia/components/TitleBar.tsx
@@ -2,7 +2,7 @@
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
-import { useAppSelector } from 'app/hooks';
+import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { getDigitalMedia } from 'redux/digitalMedia/DigitalMediaSlice';
 
 /* Import Styles */
@@ -17,6 +17,7 @@ import BreadCrumbs from 'components/general/breadCrumbs/BreadCrumbs';
 
 
 const TitleBar = () => {
+    /* Base variables */
     const digitalMedia = useAppSelector(getDigitalMedia);
 
     return (

--- a/src/components/digitalMedia/components/TitleBar.tsx
+++ b/src/components/digitalMedia/components/TitleBar.tsx
@@ -2,7 +2,7 @@
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
-import { useAppSelector, useAppDispatch } from 'app/hooks';
+import { useAppSelector } from 'app/hooks';
 import { getDigitalMedia } from 'redux/digitalMedia/DigitalMediaSlice';
 
 /* Import Styles */

--- a/src/components/general/actionsDropdown/ActionsDropdown.tsx
+++ b/src/components/general/actionsDropdown/ActionsDropdown.tsx
@@ -1,0 +1,40 @@
+/* Import Dependencies */
+import Select from 'react-select';
+
+
+/* Props typing */
+interface Props {
+    actions: { value: string, label: string }[],
+    Actions: Function
+};
+
+
+const ActionsDropdown = (props: Props) => {
+    const { actions, Actions } = props;
+
+    return (
+        <Select
+            value={{ value: 'Actions', label: 'Actions' }}
+            options={actions}
+            className="text-white"
+            isSearchable={false}
+            styles={{
+                control: provided => ({
+                    ...provided, backgroundColor: '#4d59a2', border: 'none',
+                    borderRadius: '999px', fontWeight: '500', fontSize: '15px'
+                }),
+                menu: provided => ({
+                    ...provided, zIndex: 100000, fontSize: '15px', width: 'max-content',
+                    position: 'absolute', right: '0', color: '#333333'
+                }),
+                dropdownIndicator: provided => ({ ...provided, color: 'white', fontSize: '15px' }),
+                singleValue: provided => ({
+                    ...provided, color: 'white'
+                })
+            }}
+            onChange={(option) => { option?.value && Actions(option.value) }}
+        />
+    );
+}
+
+export default ActionsDropdown;

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
@@ -1,0 +1,29 @@
+/* Import Dependencies */
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Styles */
+import styles from 'components/specimen/specimen.module.scss';
+
+
+const AutomatedAnnotationsOverview = () => {
+    return (
+        <Row>
+            <Col>
+                {/* Overview headers */}
+                <Row>
+                    <Col md={{span: 6}}>
+                        <p className={styles.automatedAnnotationsHeader}> Service name </p>
+                    </Col>
+                    <Col md={{span: 4}}>
+                        <p className={styles.automatedAnnotationsHeader}> Issued </p>
+                    </Col>
+                    <Col md={{span: 2}}>
+                        <p className={styles.automatedAnnotationsHeader}> State </p>
+                    </Col>
+                </Row>
+            </Col>
+        </Row>
+    );
+}
+
+export default AutomatedAnnotationsOverview;

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
@@ -1,0 +1,197 @@
+/* Import Dependencies */
+import { useLocation } from 'react-router-dom';
+import { Formik, Form, Field, FieldArray } from 'formik';
+import KeycloakService from 'keycloak/Keycloak';
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Store */
+import { useAppSelector } from 'app/hooks';
+import { getMASTarget } from 'redux/annotate/AnnotateSlice';
+
+/* Import Types */
+import { Dict } from 'global/Types';
+
+/* Import Styles */
+import styles from 'components/specimen/specimen.module.scss';
+
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faX } from '@fortawesome/free-solid-svg-icons';
+
+/* Import API */
+import ScheduleSpecimenMAS from 'api/specimen/ScheduleSpecimenMAS';
+import ScheduleDigitalMediaMAS from 'api/digitalMedia/ScheduleDigitalMediaMAS';
+
+
+/* Props Typing */
+interface Props {
+    availableMASList: Dict[],
+    HideAutomatedAnnotationsModal: Function
+};
+
+
+const AutomatedAnnotationsForm = (props: Props) => {
+    const { availableMASList, HideAutomatedAnnotationsModal } = props;
+
+    /* Hooks */
+    const location = useLocation();
+
+    /* Base variables */
+    const target = useAppSelector(getMASTarget);
+
+    /* Function for scheduling Machine Annotation Services */
+    const ScheduleMachineAnnotations = (selectedMAS: string[]) => {
+        /* Create MAS request */
+        const MASRecord = {
+            data: {
+                type: "MasRequest",
+                attributes: {
+                    mass: selectedMAS
+                }
+            }
+        };
+
+        /* Schedule MAS */
+        if (location.pathname.includes('ds')) {
+            ScheduleSpecimenMAS(target.id, MASRecord, KeycloakService.GetToken()).then((specimenMAS) => {
+                /* Do something when the machine annotation service finishes */
+                console.log(specimenMAS);
+            }).catch(error => {
+                console.warn(error);
+            });
+        } else if (location.pathname.includes('dm')) {
+            ScheduleDigitalMediaMAS(target.id, MASRecord, KeycloakService.GetToken()).then((digitalMediaMAS) => {
+                /* Do something when the machine annotation service finishes */
+                console.log(digitalMediaMAS);
+            }).catch(error => {
+                console.warn(error);
+            });
+        }
+
+        /* Hide MAS Modal */
+        HideAutomatedAnnotationsModal();
+    }
+
+    return (
+
+        <Formik initialValues={{
+            selectedMAS: [] as string[],
+            MASList: ""
+        }}
+            onSubmit={async (values) => {
+                await new Promise((resolve) => setTimeout(resolve, 100));
+
+                /* Schedule Machine Annotation Services */
+                ScheduleMachineAnnotations(values.selectedMAS);
+            }}
+        >
+            {({ values }) => (
+                <Form className="h-100">
+                    <div className="h-100 d-flex flex-column">
+                        <Row className="flex-grow-1">
+                            <Col>
+
+                                {/* Machine Annotation Services explanation */}
+                                <Row>
+                                    <Col>
+                                        <div className={`${styles.automatedAnnotationsDescription} bgc-greyLight px-3 py-2`}>
+                                            Machine Annotation Services (MAS) are automated services that can be deployed upon different objects like
+                                            specimens and images. The services have the general purpose of enriching the object data by running
+                                            different algorithms or AI over the data to detect certain kind of traits. The identified traits will be treated
+                                            as annotations to the object, which can be viewed in the annotations overview.
+                                        </div>
+                                    </Col>
+                                </Row>
+                                <Row className="mt-4">
+                                    <Col>
+                                        <FieldArray name="selectedMAS">
+                                            {({ push, remove }) => (
+                                                <>
+                                                    <Row>
+                                                        <Col>
+                                                            <p className="formFieldTitle"> Choose MAS to schedule </p>
+                                                            <Field name="MASList" as="select"
+                                                                className="formField w-75 mt-1"
+                                                            >
+                                                                {availableMASList.length > 0 ?
+                                                                    <>
+                                                                        <option value="" disabled={true}>
+                                                                            Select MAS
+                                                                        </option>
+
+                                                                        {availableMASList.map((MASOption) => {
+                                                                            if (!(values.selectedMAS.includes(MASOption.id))) {
+                                                                                return (
+                                                                                    <option key={MASOption.id} value={MASOption.id}
+                                                                                        onClick={() => {
+                                                                                            push(MASOption.id);
+                                                                                        }}
+                                                                                    >
+                                                                                        {MASOption.attributes.mas.name}
+                                                                                    </option>
+                                                                                );
+                                                                            }
+                                                                        })}
+                                                                    </>
+                                                                    : <option value="" disabled={true}> No MAS available </option>
+                                                                }
+                                                            </Field>
+                                                        </Col>
+                                                    </Row>
+                                                    <Row className="mt-3">
+                                                        <Col>
+                                                            {/* Show all chosen Machine annotation services */}
+                                                            {values.selectedMAS.map((MASid, index) => {
+                                                                const MAS = availableMASList.find(MASOption => MASOption.id === MASid) as Dict;
+
+                                                                return (
+                                                                    <div key={MASid}
+                                                                        className={`${styles.automatedAnnotationsSelectedBlock} px-3 py-2`}
+                                                                    >
+                                                                        <Row>
+                                                                            <Col>
+                                                                                <p className="fw-lightBold"> {MAS.attributes.mas.name} </p>
+                                                                            </Col>
+                                                                            <Col className="col-md-auto">
+                                                                                <button type="button" className="removeButton">
+                                                                                    <FontAwesomeIcon icon={faX} className="px-2"
+                                                                                        onClick={() => remove(index)}
+                                                                                    />
+                                                                                </button>
+                                                                            </Col>
+                                                                        </Row>
+                                                                        <Row>
+                                                                            <Col md={{ span: 8 }}>
+                                                                                <p className={styles.automatedAnnotationsDescription}>
+                                                                                    {MAS.attributes.mas.serviceDescription}
+                                                                                </p>
+                                                                            </Col>
+                                                                        </Row>
+                                                                    </div>
+                                                                );
+                                                            })}
+                                                        </Col>
+                                                    </Row>
+                                                </>
+                                            )}
+                                        </FieldArray>
+                                    </Col>
+                                </Row>
+
+                            </Col>
+                        </Row>
+                        <Row>
+                            <Col>
+                                <button type="submit" className="secondaryButton px-3 py-1">
+                                    Schedule
+                                </button>
+                            </Col>
+                        </Row>
+                    </div>
+                </Form>
+            )}
+        </Formik>
+    );
+}
+
+export default AutomatedAnnotationsForm;

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
@@ -41,7 +41,6 @@ const AutomatedAnnotationsModal = (props: Props) => {
     const location = useLocation();
 
     /* Base variables */
-    // const specimen = useAppSelector(getSpecimen);
     const target: Specimen | DigitalMedia = useAppSelector(getMASTarget);
     const [targetMAS, setTargetMAS] = useState<Dict[]>([]);
 

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
@@ -1,0 +1,116 @@
+/* Import Depdencies */
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import classNames from 'classnames';
+import { Row, Col, Modal } from 'react-bootstrap';
+
+/* Import Store */
+import { useAppSelector } from 'app/hooks';
+import { getMASTarget } from 'redux/annotate/AnnotateSlice';
+
+/* Impor Types */
+import { Dict, Specimen, DigitalMedia } from 'global/Types';
+
+/* Import Styles */
+import styles from 'components/specimen/specimen.module.scss';
+
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faX } from '@fortawesome/free-solid-svg-icons';
+
+/* Import API */
+import GetSpecimenMAS from 'api/specimen/GetSpecimenMAS';
+import GetDigitalMediaMAS from 'api/digitalMedia/GetDigitalMediaMAS';
+
+/* Import Components */
+import AutomatedAnnotationsForm from './AutomatedAnnotationsForm';
+
+
+/* Props Typing */
+interface Props {
+    automatedAnnotationsToggle: boolean,
+    HideAutomatedAnnotationsModal: Function
+};
+
+
+const AutomatedAnnotationsModal = (props: Props) => {
+    const { automatedAnnotationsToggle, HideAutomatedAnnotationsModal } = props;
+
+    /* Hooks */
+    const location = useLocation();
+
+    /* Base variables */
+    // const specimen = useAppSelector(getSpecimen);
+    const target: Specimen | DigitalMedia = useAppSelector(getMASTarget);
+    const [targetMAS, setTargetMAS] = useState<Dict[]>([]);
+
+    /* OnLoad: Fetch Specimen MAS */
+    useEffect(() => {
+        if (automatedAnnotationsToggle) {
+            if (location.pathname.includes('ds')) {
+                GetSpecimenMAS(target.id.replace('https://hdl.handle.net/', '')).then((specimenMAS) => {
+                    setTargetMAS(specimenMAS);
+                }).catch(error => {
+                    console.warn(error);
+                });
+            } else if (location.pathname.includes('dm')) {
+                GetDigitalMediaMAS(target.id.replace('https://hdl.handle.net/', '')).then((digitalMediaMAS) => {
+                    setTargetMAS(digitalMediaMAS);
+                }).catch(error => {
+                    console.warn(error);
+                });
+            }
+        }
+    }, [automatedAnnotationsToggle]);
+
+    /* Class Name for Tabs */
+    const classTabsList = classNames({
+        [`${styles.tabsList}`]: true
+    });
+
+    const classTab = classNames({
+        'react-tabs__tab': true,
+        [`${styles.tab}`]: true
+    });
+
+    return (
+        <Modal show={automatedAnnotationsToggle} size="lg" dialogClassName={styles.automatedAnnotationsDialog}
+            contentClassName={styles.automatedAnnotationsContent}
+        >
+            <Modal.Header className="bgc-primary c-white fw-lightBold">
+                <Row className="w-100">
+                    <Col>
+                        <p> Automated Annotation Services </p>
+                    </Col>
+                    <Col className="col-md-auto pe-0">
+                        <FontAwesomeIcon icon={faX}
+                            className="c-pointer"
+                            onClick={() => HideAutomatedAnnotationsModal()}
+                        />
+                    </Col>
+                </Row>
+            </Modal.Header>
+            <Modal.Body>
+                <Row className="h-100">
+                    <Col>
+                        <Tabs className="h-100 d-flex flex-column">
+                            <TabList className={classTabsList}>
+                                <Tab className={classTab} selectedClassName={styles.active}> Schedule new Service </Tab>
+                            </TabList>
+
+                            {/* Run a new automated annotation service */}
+                            <TabPanel className="pt-1 px-3 d-flex flex-grow-1">
+                                <AutomatedAnnotationsForm availableMASList={targetMAS}
+                                    HideAutomatedAnnotationsModal={() => HideAutomatedAnnotationsModal()}
+                                />
+                            </TabPanel>
+                        </Tabs>
+                    </Col>
+                </Row>
+            </Modal.Body>
+        </Modal>
+    );
+}
+
+export default AutomatedAnnotationsModal;

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -22,6 +22,7 @@ import Header from 'components/general/header/Header';
 import TitleBar from './components/TitleBar';
 import IDCard from './components/IDCard/IDCard';
 import ContentBlock from './components/contentBlock/ContentBlock';
+import AutomatedAnnotationsModal from '../general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal';
 import AnnotateModal from 'components/annotate/modal/AnnotateModal';
 import Footer from 'components/general/footer/Footer';
 
@@ -44,6 +45,7 @@ const Specimen = () => {
     const specimen = useAppSelector(getSpecimen);
     const specimenAnnotations = useAppSelector(getSpecimenAnnotations);
     const annotateTarget = useAppSelector(getAnnotateTarget);
+    const [automatedAnnotationsToggle, setAutomatedAnnotationToggle] = useState(false);
 
     /* Onload / Version change: Check for Specimen, otherwise grab full (specific version) from database */
     useEffect(() => {
@@ -148,7 +150,9 @@ const Specimen = () => {
                             <div className="h-100 d-flex flex-column">
                                 <Row className={styles.titleBar}>
                                     <Col>
-                                        <TitleBar />
+                                        <TitleBar
+                                            ToggleAutomatedAnnotations={() => setAutomatedAnnotationToggle(!automatedAnnotationsToggle)}
+                                        />
                                     </Col>
                                 </Row>
                                 <Row className="py-4 flex-grow-1 overflow-hidden">
@@ -168,6 +172,11 @@ const Specimen = () => {
                             </div>
                         </Col>
                     </Row>
+
+                    {/* Automated Annotations Modal */}
+                    <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
+                        HideAutomatedAnnotationsModal={() => setAutomatedAnnotationToggle(false)}
+                    />
                 </Container>
             }
 

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -1,18 +1,19 @@
 /* Import Dependencies */
-import { useState } from 'react';
 import Select from 'react-select';
+import KeycloakService from 'keycloak/Keycloak';
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
-import { useAppSelector } from 'app/hooks';
+import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { getSpecimen, getSpecimenVersions } from 'redux/specimen/SpecimenSlice';
+import { setMASTarget } from 'redux/annotate/AnnotateSlice';
 
 /* Import Styles */
 import styles from 'components/specimen/specimen.module.scss';
 
 /* Import Icons */
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faDiamond, faCircleInfo, faMessage } from '@fortawesome/free-solid-svg-icons';
+import { faDiamond, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 
 /* Import Components */
 import BreadCrumbs from 'components/general/breadCrumbs/BreadCrumbs';
@@ -20,15 +21,25 @@ import VersionSelect from '../../general/versionSelect/VersionSelect';
 import Tooltip from 'components/general/tooltip/Tooltip';
 
 
-const TitleBar = () => {
+/* Props Typing */
+interface Props {
+    ToggleAutomatedAnnotations: Function
+};
+
+
+const TitleBar = (props: Props) => {
+    const { ToggleAutomatedAnnotations } = props;
+
+    /* Hooks */
+    const dispatch = useAppDispatch();
+
     /* Base variables */
     const specimen = useAppSelector(getSpecimen);
     const specimenVersions = useAppSelector(getSpecimenVersions);
-    const [automatedAnnotationToggle, setAutomatedAnnotationToggle] = useState(false);
 
     const specimenActions = [
         { value: 'json', label: 'View JSON' },
-        { value: 'automatedAnnotations', label: 'Trigger Automated Annotations' }
+        { value: 'automatedAnnotations', label: 'Trigger Automated Annotations', isDisabled: !KeycloakService.IsLoggedIn() }
     ];
 
     /* Function for executing Specimen Actions */
@@ -38,8 +49,12 @@ const TitleBar = () => {
                 window.open(`https://sandbox.dissco.tech/api/v1/specimens/${specimen.id.replace('https://hdl.handle.net/', '')}`);
 
                 return;
-            case 'automatedAnnotation':
-                setAutomatedAnnotationToggle(true);
+            case 'automatedAnnotations':
+                /* Set MAS Target */
+                dispatch(setMASTarget(specimen));
+
+                /* Open MAS Modal */
+                ToggleAutomatedAnnotations();
 
                 return;
             default:
@@ -139,11 +154,6 @@ const TitleBar = () => {
                                 />
                             </Col>
                         </Row>
-                        {/* <Row className="position-absolute bottom-0">
-                            <Col className="col-md-auto">
-
-                            </Col>
-                        </Row> */}
                     </Col>
                 </Row>
             </Col>

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -1,4 +1,6 @@
 /* Import Dependencies */
+import { useState } from 'react';
+import Select from 'react-select';
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
@@ -22,6 +24,28 @@ const TitleBar = () => {
     /* Base variables */
     const specimen = useAppSelector(getSpecimen);
     const specimenVersions = useAppSelector(getSpecimenVersions);
+    const [automatedAnnotationToggle, setAutomatedAnnotationToggle] = useState(false);
+
+    const specimenActions = [
+        { value: 'json', label: 'View JSON' },
+        { value: 'automatedAnnotations', label: 'Trigger Automated Annotations' }
+    ];
+
+    /* Function for executing Specimen Actions */
+    const SpecimenAction = (action: string) => {
+        switch (action) {
+            case 'json':
+                window.open(`https://sandbox.dissco.tech/api/v1/specimens/${specimen.id.replace('https://hdl.handle.net/', '')}`);
+
+                return;
+            case 'automatedAnnotation':
+                setAutomatedAnnotationToggle(true);
+
+                return;
+            default:
+                return;
+        }
+    }
 
     return (
         <Row>
@@ -83,19 +107,43 @@ const TitleBar = () => {
                     {/* Specimen Versions */}
                     <Col md={{ span: 9 }} className="position-relative ps-4">
                         <Row>
-                            <Col className="d-flex justify-content-end">
-                                <button type="button" className={`${styles.annotationTriggerButton} mt-2 px-3 py-1`}>
-                                    <FontAwesomeIcon icon={faMessage} className={`${styles.annotationTriggerIcon} me-1`} /> Annotations
-                                </button>
-                            </Col>
-                        </Row>
-                        <Row className="position-absolute bottom-0">
                             <Col className="col-md-auto">
                                 <VersionSelect target={specimen}
                                     versions={specimenVersions}
                                 />
                             </Col>
+                            <Col>
+
+                            </Col>
+                            <Col className="col-md-auto d-flex justify-content-end">
+                                <Select
+                                    value={{ value: 'Actions', label: 'Actions' }}
+                                    options={specimenActions}
+                                    className="text-white"
+                                    isSearchable={false}
+                                    styles={{
+                                        control: provided => ({
+                                            ...provided, backgroundColor: '#4d59a2', border: 'none',
+                                            borderRadius: '999px', fontWeight: '500', fontSize: '15px'
+                                        }),
+                                        menu: provided => ({
+                                            ...provided, zIndex: 100000, fontSize: '15px', width: 'max-content',
+                                            position: 'absolute', right: '0', color: '#333333'
+                                        }),
+                                        dropdownIndicator: provided => ({ ...provided, color: 'white', fontSize: '15px' }),
+                                        singleValue: provided => ({
+                                            ...provided, color: 'white'
+                                        })
+                                    }}
+                                    onChange={(option) => { option?.value && SpecimenAction(option.value) }}
+                                />
+                            </Col>
                         </Row>
+                        {/* <Row className="position-absolute bottom-0">
+                            <Col className="col-md-auto">
+
+                            </Col>
+                        </Row> */}
                     </Col>
                 </Row>
             </Col>

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -1,5 +1,4 @@
 /* Import Dependencies */
-import Select from 'react-select';
 import KeycloakService from 'keycloak/Keycloak';
 import { Row, Col } from 'react-bootstrap';
 
@@ -18,6 +17,7 @@ import { faDiamond, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 /* Import Components */
 import BreadCrumbs from 'components/general/breadCrumbs/BreadCrumbs';
 import VersionSelect from '../../general/versionSelect/VersionSelect';
+import ActionsDropdown from 'components/general/actionsDropdown/ActionsDropdown';
 import Tooltip from 'components/general/tooltip/Tooltip';
 
 
@@ -43,7 +43,7 @@ const TitleBar = (props: Props) => {
     ];
 
     /* Function for executing Specimen Actions */
-    const SpecimenAction = (action: string) => {
+    const SpecimenActions = (action: string) => {
         switch (action) {
             case 'json':
                 window.open(`https://sandbox.dissco.tech/api/v1/specimens/${specimen.id.replace('https://hdl.handle.net/', '')}`);
@@ -127,30 +127,10 @@ const TitleBar = (props: Props) => {
                                     versions={specimenVersions}
                                 />
                             </Col>
-                            <Col>
-
-                            </Col>
+                            <Col />
                             <Col className="col-md-auto d-flex justify-content-end">
-                                <Select
-                                    value={{ value: 'Actions', label: 'Actions' }}
-                                    options={specimenActions}
-                                    className="text-white"
-                                    isSearchable={false}
-                                    styles={{
-                                        control: provided => ({
-                                            ...provided, backgroundColor: '#4d59a2', border: 'none',
-                                            borderRadius: '999px', fontWeight: '500', fontSize: '15px'
-                                        }),
-                                        menu: provided => ({
-                                            ...provided, zIndex: 100000, fontSize: '15px', width: 'max-content',
-                                            position: 'absolute', right: '0', color: '#333333'
-                                        }),
-                                        dropdownIndicator: provided => ({ ...provided, color: 'white', fontSize: '15px' }),
-                                        singleValue: provided => ({
-                                            ...provided, color: 'white'
-                                        })
-                                    }}
-                                    onChange={(option) => { option?.value && SpecimenAction(option.value) }}
+                                <ActionsDropdown actions={specimenActions}
+                                    Actions={(action: string) => SpecimenActions(action)}
                                 />
                             </Col>
                         </Row>

--- a/src/components/specimen/components/contentBlock/ContentBlock.tsx
+++ b/src/components/specimen/components/contentBlock/ContentBlock.tsx
@@ -6,7 +6,7 @@ import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector } from 'app/hooks';
-import { getSpecimen, getSpecimenDigitalMedia } from 'redux/specimen/SpecimenSlice';
+import { getSpecimenDigitalMedia } from 'redux/specimen/SpecimenSlice';
 
 /* Import Styles */
 import styles from 'components/specimen/specimen.module.scss';
@@ -28,7 +28,6 @@ const ContentBlock = (props: Props) => {
     const { ToggleModal } = props;
 
     /* Base variables */
-    const specimen = useAppSelector(getSpecimen);
     const digitalMedia = useAppSelector(getSpecimenDigitalMedia);
 
     /* Class Names for Tabs */

--- a/src/components/specimen/components/contentBlock/ContentBlock.tsx
+++ b/src/components/specimen/components/contentBlock/ContentBlock.tsx
@@ -49,11 +49,6 @@ const ContentBlock = (props: Props) => {
     return (
         <Row className="h-100">
             <Col className="h-100">
-                {/* <Row className="justify-content-end">
-                    <Col className="col-md-auto">
-                        
-                    </Col>
-                </Row> */}
                 <Row className="h-100">
                     <Col className="h-100">
                         <Tabs className="h-100">
@@ -64,16 +59,6 @@ const ContentBlock = (props: Props) => {
                                     <Tab className={classTab} selectedClassName={styles.active}>Digital Media</Tab>
                                 }
                                 <Tab className={classTab} selectedClassName={styles.active}>Provenance</Tab>
-
-                                <a href={`https://sandbox.dissco.tech/api/v1/specimens/${specimen.id.replace('https://hdl.handle.net/', '')}`}
-                                    target="_blank" rel="noreferrer" className="w-100"
-                                >
-                                    <button type="button"
-                                        className={`${styles.jsonButton} primaryButton`}
-                                    >
-                                        View JSON
-                                    </button>
-                                </a>
                             </TabList>
 
                             {/* Specimen Overview */}

--- a/src/components/specimen/components/contentBlock/ContentBlock.tsx
+++ b/src/components/specimen/components/contentBlock/ContentBlock.tsx
@@ -31,7 +31,7 @@ const ContentBlock = (props: Props) => {
     const specimen = useAppSelector(getSpecimen);
     const digitalMedia = useAppSelector(getSpecimenDigitalMedia);
 
-    /* Class Name for Tabs */
+    /* Class Names for Tabs */
     const classTabsList = classNames({
         [`${styles.tabsList}`]: true
     });

--- a/src/components/specimen/specimen.module.scss
+++ b/src/components/specimen/specimen.module.scss
@@ -181,12 +181,6 @@
     height: Calc(100% - 51px);
 }
 
-.jsonButton {
-    padding: 6px 2% 6px 2%;
-    font-size: 15px;
-    float: right;
-}
-
 /* Digital Specimen Block */
 
 .propertyTable {

--- a/src/components/specimen/specimen.module.scss
+++ b/src/components/specimen/specimen.module.scss
@@ -285,3 +285,31 @@
 .midsProperty {
     border: 1px solid var(--main-color);
 }
+
+/* Automated Annotations Modal */
+.automatedAnnotationsDialog {
+    height: 100%;
+}
+
+.automatedAnnotationsContent {
+    height: 60%;
+    margin-top: 20%;
+}
+
+.automatedAnnotationsBody {
+    min-height: 60%;
+}
+
+.automatedAnnotationsHeader {
+    font-size: 14px;
+    color: var(--greyDark);
+}
+
+.automatedAnnotationsDescription {
+    font-size: 14px;
+}
+
+.automatedAnnotationsSelectedBlock {
+    border: 1px solid var(--primary);
+    border-radius: 8px;
+}

--- a/src/redux/annotate/AnnotateSlice.ts
+++ b/src/redux/annotate/AnnotateSlice.ts
@@ -9,6 +9,7 @@ import { Annotation, AnnotateTarget, Specimen, DigitalMedia } from 'global/Types
 export interface AnnotateState {
     annotateTarget: AnnotateTarget;
     overviewAnnotations: Annotation[];
+    MASTarget: Specimen | DigitalMedia
 }
 
 const initialState: AnnotateState = {
@@ -19,7 +20,8 @@ const initialState: AnnotateState = {
         targetType: '',
         annotations: [] as Annotation[]
     },
-    overviewAnnotations: []
+    overviewAnnotations: [],
+    MASTarget: {} as Specimen | DigitalMedia
 };
 
 export const AnnotateSlice = createSlice({
@@ -31,15 +33,19 @@ export const AnnotateSlice = createSlice({
         },
         setOverviewAnnotations: (state, action: PayloadAction<Annotation[]>) => {
             state.overviewAnnotations = action.payload;
+        },
+        setMASTarget: (state, action: PayloadAction<Specimen | DigitalMedia>) => {
+            state.MASTarget = action.payload;
         }
     },
 })
 
 /* Action Creators */
-export const { setAnnotateTarget, setOverviewAnnotations } = AnnotateSlice.actions;
+export const { setAnnotateTarget, setOverviewAnnotations, setMASTarget } = AnnotateSlice.actions;
 
 /* Connect with Root State */
 export const getAnnotateTarget = (state: RootState) => state.annotate.annotateTarget;
 export const getOverviewAnnotations = (state: RootState) => state.annotate.overviewAnnotations;
+export const getMASTarget = (state: RootState) => state.annotate.MASTarget;
 
 export default AnnotateSlice.reducer;


### PR DESCRIPTION
PR adds the option to run Automated Annotation Services on Specimens and Digital Media from the actions dropdown. Also added actions dropdown with View JSON button to Digital Media page.

No clear status of the Automated Machine Annotation services can be given at the moment, since this data is not recorded.

Adds;
- Actions dropdown to Specimen and Digital Media pages
- View JSON button to Digital Media page
- Automated Annotation Services option to Specimen and Digital Media pages
- Generic Automated Annotation Services Modal for selecting the service and pressing schedule

Modifies:
- Transforms the View JSON button on the Specimen page to the actions dropdown