### PR TITLE
OnClick -> Onchange bug

### DIFF
--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
@@ -112,6 +112,7 @@ const AutomatedAnnotationsForm = (props: Props) => {
                                                             <p className="formFieldTitle"> Choose MAS to schedule </p>
                                                             <Field name="MASList" as="select"
                                                                 className="formField w-75 mt-1"
+                                                                onChange={(event: Dict) => push(event.target.value)}
                                                             >
                                                                 {availableMASList.length > 0 ?
                                                                     <>
@@ -122,11 +123,7 @@ const AutomatedAnnotationsForm = (props: Props) => {
                                                                         {availableMASList.map((MASOption) => {
                                                                             if (!(values.selectedMAS.includes(MASOption.id))) {
                                                                                 return (
-                                                                                    <option key={MASOption.id} value={MASOption.id}
-                                                                                        onClick={() => {
-                                                                                            push(MASOption.id);
-                                                                                        }}
-                                                                                    >
+                                                                                    <option key={MASOption.id} value={MASOption.id}>
                                                                                         {MASOption.attributes.mas.name}
                                                                                     </option>
                                                                                 );


### PR DESCRIPTION
Commit resolves bug in certain browsers like Chrome that do not support onClick events on option elements, instead use onChange events on the parent select.