### PR TITLE
Resolve annotation bugs

### DIFF
--- a/src/api/user/GetUser.ts
+++ b/src/api/user/GetUser.ts
@@ -9,9 +9,9 @@ import { JSONResult, User } from 'global/Types';
 
 
 const GetUser = async (userId?: string, token?: string) => {
-    if (userId && token) {
-        let user = {} as User;
+    let user = {} as User;
 
+    if (userId && token) {
         const endPoint = `users/${userId}`;
 
         try {
@@ -32,9 +32,9 @@ const GetUser = async (userId?: string, token?: string) => {
         } catch (error) {
             console.warn(error);
         }
-
-        return user;
     }
+
+    return user;
 }
 
 export default GetUser;

--- a/src/components/annotate/sidePanel/SidePanel.tsx
+++ b/src/components/annotate/sidePanel/SidePanel.tsx
@@ -31,7 +31,15 @@ import AnnotationForm from './AnnotationForm';
 import Tooltip from 'components/general/tooltip/Tooltip';
 
 
-const SidePanel = () => {
+/* Props Typing */
+interface Props {
+    UpdateAnnotationsSource?: Function
+};
+
+
+const SidePanel = (props: Props) => {
+    const { UpdateAnnotationsSource } = props;
+
     /* Hooks */
     const dispatch = useAppDispatch();
 
@@ -55,7 +63,12 @@ const SidePanel = () => {
         sidePanelTitle = 'All annotations';
     }
 
-    /* OnLoad: Reset edit annotation */
+    /* OnLoad: Make sure toggle is reset */
+    useEffect(() => {
+        dispatch(setSidePanelToggle(false));
+    }, []);
+
+    /* OnToggle of Side Panel: Reset edit annotation */
     useEffect(() => {
         dispatch(setEditAnnotation({} as Annotation));
     }, [toggle]);
@@ -79,6 +92,11 @@ const SidePanel = () => {
         copyAnnotateTarget.annotations = copyAnnotations;
 
         dispatch(setAnnotateTarget(copyAnnotateTarget));
+
+        /* If provided, update source annotations */
+        if (UpdateAnnotationsSource) {
+            UpdateAnnotationsSource(annotation, remove);
+        }
 
         /* If enabled, disable edit annotation */
         if (!isEmpty(editAnnotation)) {

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -16,6 +16,9 @@ import {
 } from 'redux/annotate/AnnotateSlice';
 import { setErrorMessage } from 'redux/general/GeneralSlice';
 
+/* Import Types */
+import { Annotation } from 'global/Types';
+
 /* Import Styles */
 import styles from './specimen.module.scss';
 
@@ -104,6 +107,40 @@ const Specimen = () => {
         }
     }, [specimen, params]);
 
+    /* Function for updating the Specimen Annotations source */
+    const UpdateAnnotationsSource = (annotation: Annotation, remove: boolean = false) => {
+        const copySpecimenAnnotations = { ...specimenAnnotations };
+
+        /* Check if target is a property */
+        if (annotation.target.indvProp) {
+            /* Check if array for target property exists */
+            if (annotation.target.indvProp in specimenAnnotations) {
+                /* Push or patch to existing array */
+                const copySpecimenTargetAnnotations = [...specimenAnnotations[annotation.target.indvProp]];
+                const index = copySpecimenTargetAnnotations.findIndex(
+                    (annotationRecord) => annotationRecord.id === annotation.id
+                );
+
+                if (index >= 0) {
+                    if (remove) {
+                        copySpecimenTargetAnnotations.splice(index, 1);
+                    } else {
+                        copySpecimenTargetAnnotations[index] = annotation;
+                    }
+                } else {
+                    copySpecimenTargetAnnotations.push(annotation);
+                }
+
+                copySpecimenAnnotations[annotation.target.indvProp] = copySpecimenTargetAnnotations;
+            } else {
+                /* Create into new array */
+                copySpecimenAnnotations[annotation.target.indvProp] = [annotation];
+            }
+        }
+
+        dispatch(setSpecimenAnnotations(copySpecimenAnnotations));
+    }
+
     /* Function for toggling the Annotate Modal */
     const ToggleSidePanel = (property?: string, motivation?: string) => {
         if (property) {
@@ -174,7 +211,7 @@ const Specimen = () => {
 
                 {/* Annotations Side Panel */}
                 <div className={`${classSidePanel} transition`}>
-                    <SidePanel />
+                    <SidePanel UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)} />
                 </div>
             </Row>
         </div>


### PR DESCRIPTION
PR resolves bugs with the annotation side panel.

- Annotations from MAS crash the front-end
- Annotations that where created, patched or deleted dissappeared, now they behave correctly by an additional update function for the specimen annotations
- Annotation creator is now the full name of the person if present, otherwise the id is still shown
- Side panel and thus annotate target are hiden on default, preventing annotations from one specimen to show up at another specimen

Added:
- ID and version to annotations