### PR TITLE
Add Generic Annotation to Specimen

### DIFF
--- a/src/components/annotate/sidePanel/Annotation.tsx
+++ b/src/components/annotate/sidePanel/Annotation.tsx
@@ -49,7 +49,6 @@ const Annotation = (props: Props) => {
     const user = useAppSelector(getUser);
 
     /* Base variables */
-    const annotateTarget = useAppSelector(getAnnotateTarget);
     const highlightAnnotationId = useAppSelector(getHighlightAnnotationId);
     const [userTag, setUserTag] = useState<string>('');
     const annotationMotivations = { ...AnnotationMotivations };

--- a/src/components/annotate/sidePanel/Annotation.tsx
+++ b/src/components/annotate/sidePanel/Annotation.tsx
@@ -9,8 +9,7 @@ import { Row, Col } from 'react-bootstrap';
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
 import {
-    getAnnotateTarget, setEditAnnotation,
-    getHighlightAnnotationId, setHighlightAnnotationId
+    setEditAnnotation, getHighlightAnnotationId, setHighlightAnnotationId
 } from 'redux/annotate/AnnotateSlice';
 import { getUser } from 'redux/user/UserSlice';
 

--- a/src/components/annotate/sidePanel/Annotation.tsx
+++ b/src/components/annotate/sidePanel/Annotation.tsx
@@ -137,7 +137,7 @@ const Annotation = (props: Props) => {
                         </Col>
                     </Row>
                     {/* Annotation content */}
-                    {!annotateTarget.property &&
+                    {annotation.target.indvProp &&
                         <Row className="mt-2">
                             <Col className="col-md-auto pe-0">
                                 <div className={`${styles.sidePanelTopStripe} h-100`} />

--- a/src/components/annotate/sidePanel/AnnotationForm.tsx
+++ b/src/components/annotate/sidePanel/AnnotationForm.tsx
@@ -118,8 +118,8 @@ const AnnotationForm = (props: Props) => {
                                         <Field name="targetProperty" as="select"
                                             className="formField w-100 mt-1"
                                         >
-                                            <option value="" disabled={true}>
-                                                Select target property
+                                            <option value="">
+                                                Specimen in general
                                             </option>
 
                                             {Object.keys(annotateTarget.target.data).map((property) => {

--- a/src/components/annotate/sidePanel/AnnotationsOverview.tsx
+++ b/src/components/annotate/sidePanel/AnnotationsOverview.tsx
@@ -131,7 +131,7 @@ const AnnotationsOverview = (props: Props) => {
                     {/* Annotations section */}
                     <Row className="flex-grow-1 pt-4 overflow-scroll">
                         <Col>
-                            {!isEmpty(annotateTarget.annotations) ?
+                            {!isEmpty(annotateTarget.annotations) && !isEmpty(annotations) ?
                                 <>
                                     {annotations.map((annotation) => {
                                         return (
@@ -151,18 +151,19 @@ const AnnotationsOverview = (props: Props) => {
                         </Col>
                     </Row>
                     {/* If logged in, show add Annotation button */}
-                    {KeycloakService.IsLoggedIn() &&
-                        <Row className={`${styles.annotationForm} pb-2 pt-3 justify-content-end`}>
-                            <Col className="col-md-auto">
+                    <Row className={`${styles.annotationForm} pb-2 pt-3 justify-content-end`}>
+                        <Col className="col-md-auto">
+                            {KeycloakService.IsLoggedIn() ?
                                 <button type="button"
                                     className="accentButton px-3 py-1 float-right"
                                     onClick={() => ToggleAnnotationForm()}
                                 >
                                     Add annotation
                                 </button>
-                            </Col>
-                        </Row>
-                    }
+                                : <p className="fst-italic"> Login to make annotations </p>
+                            }
+                        </Col>
+                    </Row>
                 </div>
             </Col>
         </Row>

--- a/src/components/annotate/sidePanel/SidePanel.tsx
+++ b/src/components/annotate/sidePanel/SidePanel.tsx
@@ -158,7 +158,7 @@ const SidePanel = (props: Props) => {
                         </Col>
                     </Row>
                     {/* Annotation current value, if property is chosen */}
-                    {(annotateTarget.property || (editAnnotation.target && editAnnotation.target?.indvProp)) &&
+                    {(annotateTarget.property || (editAnnotation?.target?.indvProp)) &&
                         <Row className="mt-5">
                             <Col className="col-md-auto pe-0">
                                 <div className={`${styles.sidePanelTopStripe} h-100`} />

--- a/src/components/annotate/sidePanel/SidePanel.tsx
+++ b/src/components/annotate/sidePanel/SidePanel.tsx
@@ -88,7 +88,7 @@ const SidePanel = (props: Props) => {
         } else {
             copyAnnotations.push(annotation);
         }
-        
+
         copyAnnotateTarget.annotations = copyAnnotations;
 
         dispatch(setAnnotateTarget(copyAnnotateTarget));
@@ -105,6 +105,22 @@ const SidePanel = (props: Props) => {
 
         /* Return to Annotations overview */
         setAnnotationFormToggle(false);
+    }
+
+    /* Function for when clicking on the Back Button */
+    const BackAction = () => {
+        if (annotationFormToggle || !isEmpty(editAnnotation)) {
+            setAnnotationFormToggle(false);
+            dispatch(setEditAnnotation({} as Annotation));
+        } else if (annotateTarget.property) {
+            dispatch(setAnnotateTarget({
+                ...annotateTarget,
+                property: ''
+            }));
+        } else {
+            dispatch(setSidePanelToggle(false));
+            setAnnotationFormToggle(false);
+        }
     }
 
     /* ClassName for Side Panel */
@@ -125,10 +141,7 @@ const SidePanel = (props: Props) => {
                         <Col className="col-md-auto">
                             <FontAwesomeIcon icon={faChevronLeft}
                                 className={`${styles.sidePanelTopIcon} c-pointer c-primary`}
-                                onClick={() => {
-                                    dispatch(setSidePanelToggle(false));
-                                    setAnnotationFormToggle(false);
-                                }}
+                                onClick={() => BackAction()}
                             />
                         </Col>
                         <Col>
@@ -147,7 +160,7 @@ const SidePanel = (props: Props) => {
                         </Col>
                     </Row>
                     {/* Annotation current value, if property is chosen */}
-                    {annotateTarget.property &&
+                    {(annotateTarget.property || (editAnnotation.target && editAnnotation.target?.indvProp)) &&
                         <Row className="mt-5">
                             <Col className="col-md-auto pe-0">
                                 <div className={`${styles.sidePanelTopStripe} h-100`} />
@@ -155,10 +168,10 @@ const SidePanel = (props: Props) => {
                             <Col>
                                 <p>
                                     <span className="fw-bold">
-                                        {`${harmonisedAttributes[annotateTarget.property].displayName}: `}
+                                        {`${harmonisedAttributes[annotateTarget.property ? annotateTarget.property : editAnnotation.target.indvProp].displayName}: `}
                                     </span>
                                     <span className="fst-italic">
-                                        {`${annotateTarget.target.data[annotateTarget.property]}`}
+                                        {`${annotateTarget.target.data[annotateTarget.property ? annotateTarget.property : editAnnotation.target.indvProp]}`}
                                     </span>
                                 </p>
                             </Col>

--- a/src/components/annotate/sidePanel/SidePanel.tsx
+++ b/src/components/annotate/sidePanel/SidePanel.tsx
@@ -1,7 +1,7 @@
 /* Import Dependencies */
 import { useEffect, useState } from 'react';
 import classNames from 'classnames';
-import { isEmpty } from 'lodash';
+import { Function0, isEmpty } from 'lodash';
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
@@ -33,12 +33,13 @@ import Tooltip from 'components/general/tooltip/Tooltip';
 
 /* Props Typing */
 interface Props {
+    ShowWithAllAnnotations: Function,
     UpdateAnnotationsSource?: Function
 };
 
 
 const SidePanel = (props: Props) => {
-    const { UpdateAnnotationsSource } = props;
+    const { ShowWithAllAnnotations, UpdateAnnotationsSource } = props;
 
     /* Hooks */
     const dispatch = useAppDispatch();
@@ -113,10 +114,7 @@ const SidePanel = (props: Props) => {
             setAnnotationFormToggle(false);
             dispatch(setEditAnnotation({} as Annotation));
         } else if (annotateTarget.property) {
-            dispatch(setAnnotateTarget({
-                ...annotateTarget,
-                property: ''
-            }));
+            ShowWithAllAnnotations();
         } else {
             dispatch(setSidePanelToggle(false));
             setAnnotationFormToggle(false);

--- a/src/components/annotate/sidePanel/SidePanel.tsx
+++ b/src/components/annotate/sidePanel/SidePanel.tsx
@@ -1,7 +1,7 @@
 /* Import Dependencies */
 import { useEffect, useState } from 'react';
 import classNames from 'classnames';
-import { Function0, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -111,31 +111,28 @@ const Specimen = () => {
     const UpdateAnnotationsSource = (annotation: Annotation, remove: boolean = false) => {
         const copySpecimenAnnotations = { ...specimenAnnotations };
 
-        /* Check if target is a property */
-        if (annotation.target.indvProp) {
-            /* Check if array for target property exists */
-            if (annotation.target.indvProp in specimenAnnotations) {
-                /* Push or patch to existing array */
-                const copySpecimenTargetAnnotations = [...specimenAnnotations[annotation.target.indvProp]];
-                const index = copySpecimenTargetAnnotations.findIndex(
-                    (annotationRecord) => annotationRecord.id === annotation.id
-                );
+        /* Check if array for target property exists */
+        if (annotation.target.indvProp in specimenAnnotations) {
+            /* Push or patch to existing array */
+            const copySpecimenTargetAnnotations = [...specimenAnnotations[annotation.target.indvProp]];
+            const index = copySpecimenTargetAnnotations.findIndex(
+                (annotationRecord) => annotationRecord.id === annotation.id
+            );
 
-                if (index >= 0) {
-                    if (remove) {
-                        copySpecimenTargetAnnotations.splice(index, 1);
-                    } else {
-                        copySpecimenTargetAnnotations[index] = annotation;
-                    }
+            if (index >= 0) {
+                if (remove) {
+                    copySpecimenTargetAnnotations.splice(index, 1);
                 } else {
-                    copySpecimenTargetAnnotations.push(annotation);
+                    copySpecimenTargetAnnotations[index] = annotation;
                 }
-
-                copySpecimenAnnotations[annotation.target.indvProp] = copySpecimenTargetAnnotations;
             } else {
-                /* Create into new array */
-                copySpecimenAnnotations[annotation.target.indvProp] = [annotation];
+                copySpecimenTargetAnnotations.push(annotation);
             }
+
+            copySpecimenAnnotations[annotation.target.indvProp] = copySpecimenTargetAnnotations;
+        } else {
+            /* Create into new array */
+            copySpecimenAnnotations[annotation.target.indvProp] = [annotation];
         }
 
         dispatch(setSpecimenAnnotations(copySpecimenAnnotations));

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -153,6 +153,25 @@ const Specimen = () => {
         dispatch(setSidePanelToggle(true));
     }
 
+    /* Function to open Side Panel with all Annotations of Specimen */
+    const ShowWithAllAnnotations = () => {
+        /* Add up all property annotations into one annotations array */
+        let allAnnotations: Annotation[] = [];
+
+        Object.values(specimenAnnotations).forEach((annotationsArray) => {
+            allAnnotations = allAnnotations.concat(annotationsArray);
+        });
+
+        dispatch(setAnnotateTarget({
+            property: '',
+            target: specimen,
+            targetType: 'digital_specimen',
+            annotations: allAnnotations
+        }));
+
+        dispatch(setSidePanelToggle(true));
+    }
+
     /* ClassName for Specimen Content */
     const classSpecimenContent = classNames({
         'col-md-10 offset-md-1': !sidePanelToggle,
@@ -179,7 +198,7 @@ const Specimen = () => {
                                     <div className="h-100 d-flex flex-column">
                                         <Row className={styles.titleBar}>
                                             <Col>
-                                                <TitleBar
+                                                <TitleBar ShowWithAllAnnotations={() => ShowWithAllAnnotations()}
                                                     ToggleAutomatedAnnotations={() => setAutomatedAnnotationToggle(!automatedAnnotationsToggle)}
                                                 />
                                             </Col>
@@ -208,7 +227,9 @@ const Specimen = () => {
 
                 {/* Annotations Side Panel */}
                 <div className={`${classSidePanel} transition`}>
-                    <SidePanel UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)} />
+                    <SidePanel ShowWithAllAnnotations={() => ShowWithAllAnnotations()}
+                        UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
+                    />
                 </div>
             </Row>
         </div>

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -4,11 +4,8 @@ import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
-import { getSpecimen, getSpecimenAnnotations, getSpecimenVersions } from 'redux/specimen/SpecimenSlice';
-import { setAnnotateTarget, setSidePanelToggle, setMASTarget } from 'redux/annotate/AnnotateSlice';
-
-/* Import Types */
-import { Annotation } from 'global/Types';
+import { getSpecimen, getSpecimenVersions } from 'redux/specimen/SpecimenSlice';
+import { setMASTarget } from 'redux/annotate/AnnotateSlice';
 
 /* Import Styles */
 import styles from 'components/specimen/specimen.module.scss';
@@ -40,7 +37,6 @@ const TitleBar = (props: Props) => {
     /* Base variables */
     const specimen = useAppSelector(getSpecimen);
     const specimenVersions = useAppSelector(getSpecimenVersions);
-    const specimenAnnotations = useAppSelector(getSpecimenAnnotations);
 
     const specimenActions = [
         { value: 'json', label: 'View JSON' },

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -26,12 +26,13 @@ import Tooltip from 'components/general/tooltip/Tooltip';
 
 /* Props Typing */
 interface Props {
+    ShowWithAllAnnotations: Function,
     ToggleAutomatedAnnotations: Function
 };
 
 
 const TitleBar = (props: Props) => {
-    const { ToggleAutomatedAnnotations } = props;
+    const { ShowWithAllAnnotations, ToggleAutomatedAnnotations } = props;
 
     /* Hooks */
     const dispatch = useAppDispatch();
@@ -40,25 +41,6 @@ const TitleBar = (props: Props) => {
     const specimen = useAppSelector(getSpecimen);
     const specimenVersions = useAppSelector(getSpecimenVersions);
     const specimenAnnotations = useAppSelector(getSpecimenAnnotations);
-
-    /* Function to open Side Panel with all Annotations of Specimen */
-    const ShowWithAllAnnotations = () => {
-        /* Add up all property annotations into one annotations array */
-        let allAnnotations: Annotation[] = [];
-
-        Object.values(specimenAnnotations).forEach((annotationsArray) => {
-            allAnnotations = allAnnotations.concat(annotationsArray);
-        });
-
-        dispatch(setAnnotateTarget({
-            property: '',
-            target: specimen,
-            targetType: 'digital_specimen',
-            annotations: allAnnotations
-        }));
-
-        dispatch(setSidePanelToggle(true));
-    }
 
     const specimenActions = [
         { value: 'json', label: 'View JSON' },


### PR DESCRIPTION
Commit adds the possibility to add a generic annotation to a specimen. It also better indicates the difference between property bound annotations and the generic ones. The back button (chevron) on the top of the side panel now acts different, going back to the overview first when editing or viewing an individual property.

Adds:
- Add generic annotations
- Back button functionality for the top chevron in the side panel