### PR TITLE
Add Annotation Side Panel to Digital Media

### DIFF
--- a/src/api/digitalMedia/GetDigitalMediaAnnotations.ts
+++ b/src/api/digitalMedia/GetDigitalMediaAnnotations.ts
@@ -9,9 +9,9 @@ import { DigitalMediaAnnotations, Annotation, JSONResultArray } from 'global/Typ
 
 
 const GetDigitalMediaAnnotations = async (handle: string) => {
-    if (handle) {
-        let digitalMediaAnnotations = { observation: [] } as DigitalMediaAnnotations;
+    let digitalMediaAnnotations = { observation: [] } as DigitalMediaAnnotations;
 
+    if (handle) {
         const endPoint = `specimens/${handle}/annotations`;
 
         try {
@@ -33,14 +33,13 @@ const GetDigitalMediaAnnotations = async (handle: string) => {
 
             /* Refactor Annotations object */
             annotations.forEach((annotation) => {
-                /* Check if property is present */
-                if (annotation.target.indvProp) {
-                    if (digitalMediaAnnotations[annotation.target.indvProp]) {
-                        digitalMediaAnnotations[annotation.target.indvProp].push(annotation);
-                    } else {
-                        digitalMediaAnnotations[annotation.target.indvProp] = [annotation];
-                    }
-                } else if (annotation.body.values) {
+                if (digitalMediaAnnotations[annotation.target.indvProp]) {
+                    digitalMediaAnnotations[annotation.target.indvProp].push(annotation);
+                } else {
+                    digitalMediaAnnotations[annotation.target.indvProp] = [annotation];
+                }
+
+                if (annotation.body.values) {
                     annotation.body.values.forEach((observationAnnotation: object) => {
                         digitalMediaAnnotations.observation.push({ ...observationAnnotation, creator: annotation.creator });
                     });
@@ -49,9 +48,9 @@ const GetDigitalMediaAnnotations = async (handle: string) => {
         } catch (error) {
             console.warn(error);
         }
-
-        return digitalMediaAnnotations;
     }
+
+    return digitalMediaAnnotations;
 }
 
 export default GetDigitalMediaAnnotations;

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -3,16 +3,24 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 import KeycloakService from 'keycloak/Keycloak';
+import classNames from 'classnames';
 import { Container, Row, Col } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
 import {
     getDigitalMedia, setDigitalMedia,
-    getDigitalMediaVersions, setDigitalMediaVersions
+    getDigitalMediaVersions, setDigitalMediaVersions,
+    getDigitalMediaAnnotations, setDigitalMediaAnnotations
 } from 'redux/digitalMedia/DigitalMediaSlice';
-import { setMASTarget } from 'redux/annotate/AnnotateSlice';
+import {
+    setMASTarget, setAnnotateTarget,
+    getSidePanelToggle, setSidePanelToggle
+} from 'redux/annotate/AnnotateSlice';
 import { setErrorMessage } from 'redux/general/GeneralSlice';
+
+/* Import Types */
+import { Annotation } from 'global/Types';
 
 /* Import Styles */
 import styles from './digitalMedia.module.scss';
@@ -25,11 +33,13 @@ import VersionSelect from 'components/general/versionSelect/VersionSelect';
 import DigitalMediaFrame from './components/digitalMedia/DigitalMediaFrame';
 import DigitalMediaList from './components/digitalMedia/DigitalMediaList';
 import ActionsDropdown from 'components/general/actionsDropdown/ActionsDropdown';
+import SidePanel from 'components/annotate/sidePanel/SidePanel';
 import AutomatedAnnotationsModal from '../general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal';
 import Footer from 'components/general/footer/Footer';
 
 /* Import API */
 import GetDigitalMedia from 'api/digitalMedia/GetDigitalMedia';
+import GetDigitalMediaAnnotations from 'api/digitalMedia/GetDigitalMediaAnnotations';
 import GetDigitalMediaVersions from 'api/digitalMedia/GetDigitalMediaVersions';
 
 
@@ -42,10 +52,13 @@ const DigitalMedia = () => {
     /* Base variables */
     const digitalMedia = useAppSelector(getDigitalMedia);
     const digitalMediaVersions = useAppSelector(getDigitalMediaVersions);
+    const digitalMediaAnnotations = useAppSelector(getDigitalMediaAnnotations);
+    const sidePanelToggle = useAppSelector(getSidePanelToggle);
     const [automatedAnnotationsToggle, setAutomatedAnnotationToggle] = useState(false);
 
     const digitalMediaActions = [
         { value: 'json', label: 'View JSON' },
+        { value: 'sidePanel', label: 'View all Annotations' },
         { value: 'automatedAnnotations', label: 'Trigger Automated Annotations', isDisabled: !KeycloakService.IsLoggedIn() }
     ];
 
@@ -64,6 +77,15 @@ const DigitalMedia = () => {
 
             GetDigitalMedia(`${params.prefix}/${params.suffix}${version}`).then((digitalMedia) => {
                 dispatch(setDigitalMedia(digitalMedia));
+
+                /* Get Digital Media annotations */
+                GetDigitalMediaAnnotations(digitalMedia.id.replace('https://hdl.handle.net/', '')).then((annotations) => {
+                    console.log(annotations);
+
+                    dispatch(setDigitalMediaAnnotations(annotations));
+                }).catch(error => {
+                    console.warn(error);
+                });
 
                 /* Get Digital Media versions */
                 GetDigitalMediaVersions(digitalMedia.id.replace('https://hdl.handle.net/', '')).then((versions) => {
@@ -100,6 +122,10 @@ const DigitalMedia = () => {
                 window.open(`https://sandbox.dissco.tech/api/v1/digitalmedia/${digitalMedia.id.replace('https://hdl.handle.net/', '')}`);
 
                 return;
+            case 'sidePanel':
+                ShowWithAllAnnotations();
+
+                return;
             case 'automatedAnnotations':
                 /* Set MAS Target */
                 dispatch(setMASTarget(digitalMedia));
@@ -113,65 +139,144 @@ const DigitalMedia = () => {
         }
     }
 
-    return (
-        <div className="d-flex flex-column min-vh-100 overflow-hidden">
-            <Header />
+    /* Function for updating the Digital Media Annotations source */
+    const UpdateAnnotationsSource = (annotation: Annotation, remove: boolean = false) => {
+        const copyDigitalMediaAnnotations = { ...digitalMediaAnnotations };
 
-            {Object.keys(digitalMedia).length > 0 &&
-                <Container fluid className={`${styles.content} pt-5`}>
-                    <Row className="h-100">
-                        <Col md={{ span: 10, offset: 1 }} className="h-100">
-                            <div className="h-100 d-flex flex-column">
-                                <Row className={styles.titleBar}>
-                                    <Col>
-                                        <TitleBar />
-                                    </Col>
-                                </Row>
-                                <Row className={`${styles.specimenContent} py-4 flex-grow-1 overflow-hidden`}>
-                                    <Col md={{ span: 3 }} className="h-100">
-                                        <IDCard ToggleModal={() => console.log('Toggle Modal')} />
-                                    </Col>
-                                    <Col md={{ span: 9 }} className="h-100">
-                                        <div className="h-100 d-flex flex-column">
-                                            <Row>
-                                                <Col className="col-md-auto">
-                                                    <VersionSelect target={digitalMedia}
-                                                        versions={digitalMediaVersions}
-                                                    />
-                                                </Col>
-                                                <Col />
-                                                <Col className="col-md-auto">
-                                                    <ActionsDropdown actions={digitalMediaActions}
-                                                        Actions={(action: string) => DigitalMediaActions(action)}
-                                                    />
-                                                </Col>
-                                            </Row>
-                                            <Row className="flex-grow-1 overflow-hidden mt-3">
-                                                <Col className="h-100 pb-2">
-                                                    <DigitalMediaFrame />
-                                                </Col>
-                                            </Row>
-                                            <Row className={styles.digitalMediaListBlock}>
-                                                <Col className="h-100">
-                                                    <DigitalMediaList />
-                                                </Col>
-                                            </Row>
-                                        </div>
-                                    </Col>
-                                </Row>
-                            </div>
-                        </Col>
-                    </Row>
+        /* Check if array for target property exists */
+        if (annotation.target.indvProp in digitalMediaAnnotations) {
+            /* Push or patch to existing array */
+            const copyDigitalMediaTargetAnnotations = [...digitalMediaAnnotations[annotation.target.indvProp]];
+            const index = copyDigitalMediaTargetAnnotations.findIndex(
+                (annotationRecord) => annotationRecord.id === annotation.id
+            );
 
-                    {/* Automated Annotations Modal */}
-                    <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
-                        HideAutomatedAnnotationsModal={() => setAutomatedAnnotationToggle(false)}
-                    />
-                </Container >
+            if (index >= 0) {
+                if (remove) {
+                    copyDigitalMediaTargetAnnotations.splice(index, 1);
+                } else {
+                    copyDigitalMediaTargetAnnotations[index] = annotation;
+                }
+            } else {
+                copyDigitalMediaTargetAnnotations.push(annotation);
             }
 
-            <Footer />
-        </div >
+            copyDigitalMediaAnnotations[annotation.target.indvProp] = copyDigitalMediaTargetAnnotations;
+        } else {
+            /* Create into new array */
+            copyDigitalMediaAnnotations[annotation.target.indvProp] = [annotation];
+        }
+
+        dispatch(setDigitalMediaAnnotations(copyDigitalMediaAnnotations));
+    }
+
+    /* Function to open Side Panel with all Annotations of Digital Media */
+    const ShowWithAllAnnotations = () => {
+        /* Add up all property annotations into one annotations array */
+        let allAnnotations: Annotation[] = [];
+
+        Object.values(digitalMediaAnnotations).forEach((annotationsArray) => {
+            allAnnotations = allAnnotations.concat(annotationsArray);
+        });
+
+        dispatch(setAnnotateTarget({
+            property: '',
+            target: digitalMedia,
+            targetType: 'digital_media',
+            annotations: allAnnotations
+        }));
+
+        dispatch(setSidePanelToggle(true));
+    }
+
+    /* Class Names */
+    const classDigitalMediaContent = classNames({
+        'col-md-10 offset-md-1': !sidePanelToggle,
+        'col-md-12 px-5': sidePanelToggle
+    });
+
+    const classHeadCol = classNames({
+        'transition h-100': true,
+        'col-md-12': !sidePanelToggle,
+        'col-md-8': sidePanelToggle
+    });
+
+    const classSidePanel = classNames({
+        'p-0': true,
+        'w-0': !sidePanelToggle,
+        'col-md-4': sidePanelToggle
+    });
+
+    return (
+        <div className="d-flex flex-column min-vh-100 overflow-hidden">
+            <Row>
+                <Col className={classHeadCol}>
+                    <Header />
+
+                    {Object.keys(digitalMedia).length > 0 &&
+                        <Container fluid className={`${styles.content} pt-5`}>
+                            <Row className="h-100">
+                                <Col className={`${classDigitalMediaContent} h-100 transition`}>
+                                    <div className="h-100 d-flex flex-column">
+                                        <Row className={styles.titleBar}>
+                                            <Col>
+                                                <TitleBar />
+                                            </Col>
+                                        </Row>
+                                        <Row className="py-4 flex-grow-1 overflow-scroll overflow-lg-hidden">
+                                            <Col lg={{ span: 3 }} className="h-100">
+                                                <IDCard />
+                                            </Col>
+                                            <Col lg={{ span: 9 }} className="ps-4 h-100 mt-4 m-lg-0">
+                                                <div className="h-100 d-flex flex-column">
+                                                    <Row>
+                                                        <Col className="col-md-auto">
+                                                            <VersionSelect target={digitalMedia}
+                                                                versions={digitalMediaVersions}
+                                                            />
+                                                        </Col>
+                                                        <Col />
+                                                        <Col className="col-md-auto">
+                                                            <ActionsDropdown actions={digitalMediaActions}
+                                                                Actions={(action: string) => DigitalMediaActions(action)}
+                                                            />
+                                                        </Col>
+                                                    </Row>
+                                                    <Row className="flex-grow-1 overflow-hidden mt-3">
+                                                        <Col className="h-100 pb-2">
+                                                            <DigitalMediaFrame />
+                                                        </Col>
+                                                    </Row>
+                                                    <Row className={styles.digitalMediaListBlock}>
+                                                        <Col className="h-100">
+                                                            <DigitalMediaList />
+                                                        </Col>
+                                                    </Row>
+                                                </div>
+                                            </Col>
+                                        </Row>
+                                    </div>
+                                </Col>
+                            </Row>
+
+                            {/* Automated Annotations Modal */}
+                            <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
+                                HideAutomatedAnnotationsModal={() => setAutomatedAnnotationToggle(false)}
+                            />
+                        </Container >
+                    }
+
+                    <Footer />
+                </Col>
+
+                {/* Annotations Side Panel */}
+                <div className={`${classSidePanel} transition`}>
+                    <SidePanel ShowWithAllAnnotations={() => ShowWithAllAnnotations()}
+                        UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
+                    />
+                </div>
+            </Row>
+        </div>
     );
 }
 

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -259,7 +259,7 @@ const DigitalMedia = () => {
                                 </Col>
                             </Row>
 
-                            {/* Automated Annotations Modal for Digital Media */}
+                            {/* Automated Annotations Modal */}
                             <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
                                 HideAutomatedAnnotationsModal={() => setAutomatedAnnotationToggle(false)}
                             />
@@ -269,7 +269,7 @@ const DigitalMedia = () => {
                     <Footer />
                 </Col>
 
-                {/* Annotations Side Panel for Digital Media */}
+                {/* Annotations Side Panel */}
                 <div className={`${classSidePanel} transition`}>
                     <SidePanel ShowWithAllAnnotations={() => ShowWithAllAnnotations()}
                         UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -259,7 +259,7 @@ const DigitalMedia = () => {
                                 </Col>
                             </Row>
 
-                            {/* Automated Annotations Modal */}
+                            {/* Automated Annotations Modal for Digital Media */}
                             <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
                                 HideAutomatedAnnotationsModal={() => setAutomatedAnnotationToggle(false)}
                             />
@@ -269,7 +269,7 @@ const DigitalMedia = () => {
                     <Footer />
                 </Col>
 
-                {/* Annotations Side Panel */}
+                {/* Annotations Side Panel for Digital Media */}
                 <div className={`${classSidePanel} transition`}>
                     <SidePanel ShowWithAllAnnotations={() => ShowWithAllAnnotations()}
                         UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}

--- a/src/components/digitalMedia/components/IDCard/IDCard.tsx
+++ b/src/components/digitalMedia/components/IDCard/IDCard.tsx
@@ -4,24 +4,36 @@ import KeycloakService from 'keycloak/Keycloak';
 import { Row, Col, Card } from 'react-bootstrap';
 
 /* Import Store */
-import { useAppSelector } from 'app/hooks';
-import { getDigitalMedia } from 'redux/digitalMedia/DigitalMediaSlice';
+import { useAppSelector, useAppDispatch } from 'app/hooks';
+import { getDigitalMedia, getDigitalMediaAnnotations } from 'redux/digitalMedia/DigitalMediaSlice';
+import { setAnnotateTarget, setSidePanelToggle } from 'redux/annotate/AnnotateSlice';
 
 /* Import Styles */
 import styles from 'components/digitalMedia/digitalMedia.module.scss';;
 
 
-/* Props Typing */
-interface Props {
-    ToggleModal: Function
-};
-
-
-const IDCard = (props: Props) => {
-    const { ToggleModal } = props;
+const IDCard = () => {
+    /* Hooks */
+    const dispatch = useAppDispatch();
 
     /* Base variables */
     const digitalMedia = useAppSelector(getDigitalMedia);
+    const digitalMediaAnnotations = useAppSelector(getDigitalMediaAnnotations);
+
+    /* Function for toggling the Annotate Modal */
+    const ToggleSidePanel = (property: string) => {
+        if (property) {
+            dispatch(setAnnotateTarget({
+                property,
+                motivation: '',
+                target: digitalMedia,
+                targetType: 'digital_media',
+                annotations: digitalMediaAnnotations[property] ? digitalMediaAnnotations[property] : []
+            }));
+        }
+
+        dispatch(setSidePanelToggle(true));
+    }
 
     /* ClassName for Specimen Property Hover */
     const classPropertyBlockHover = classNames({
@@ -50,64 +62,52 @@ const IDCard = (props: Props) => {
                                 <Row className={styles.IDCardProperties}>
                                     <Col className="col-md-auto h-100">
                                         <Row className={styles.IDCardPropertyBlock}>
-                                            <Col className={`${classPropertyBlockHover} rounded-c py-1`}
-                                                onClick={() => ToggleModal('digitalSpecimenID')}
-                                            >
+                                            <Col className={`${classPropertyBlockHover} rounded-c py-1`}>
                                                 <span className="fw-lightBold m-0 h-50" role="modalTrigger">Digital Specimen ID</span>
                                                 <br /> <span className={`${styles.IDCardValue} m-0 h-50`}> {digitalMedia.digitalSpecimenId} </span>
                                             </Col>
                                         </Row>
                                         <Row className={styles.IDCardPropertyBlock}>
                                             <Col className={`${classPropertyBlockHover} rounded-c py-1`}
-                                                onClick={() => ToggleModal('mediaUrl')}
+                                                onClick={() => ToggleSidePanel('mediaUrl')}
                                             >
                                                 <span className="fw-lightBold m-0 h-50">Media URL</span>
                                                 <br /> <span className={`${styles.IDCardValue} m-0 h-50`}> {digitalMedia.mediaUrl} </span>
                                             </Col>
                                         </Row>
                                         <Row className={styles.IDCardPropertyBlock}>
-                                            <Col className="m-0 py-1"
-                                                onClick={() => ToggleModal('dcterms:title')}
-                                            >
+                                            <Col className="m-0 py-1">
                                                 <span className="fw-lightBold m-0 h-50">Title</span>
                                                 <br /> <span className={`${styles.IDCardValue} m-0 h-50`}> {digitalMedia.data['dcterms:title']} </span>
                                             </Col>
                                         </Row>
                                         <Row className={styles.IDCardPropertyBlock}>
-                                            <Col className="m-0 py-1"
-                                                onClick={() => ToggleModal('format')}
-                                            >
+                                            <Col className="m-0 py-1">
                                                 <span className="fw-lightBold m-0 h-50">Format</span>
                                                 <br /> <span className={`${styles.IDCardValue} m-0 h-50`}> {digitalMedia.format} </span>
                                             </Col>
                                         </Row>
                                         <Row className={styles.IDCardPropertyBlock}>
-                                            <Col className={`${classPropertyBlockHover} rounded-c py-1`}
-                                                onClick={() => ToggleModal('type')}
-                                            >
+                                            <Col className={`${classPropertyBlockHover} rounded-c py-1`}>
                                                 <span className="fw-lightBold m-0 h-50">Type</span>
                                                 <br /> <span className={`${styles.IDCardValue} m-0 h-50`}> {digitalMedia.type} </span>
                                             </Col>
                                         </Row>
                                         <Row className={styles.IDCardPropertyBlock}>
-                                            <Col className={`${classPropertyBlockHover} rounded-c py-1 text-truncate`}
-                                                onClick={() => ToggleModal('dcterms:publisher')}
-                                            >
+                                            <Col className={`${classPropertyBlockHover} rounded-c py-1 text-truncate`}>
                                                 <span className="fw-lightBold m-0 h-50">Publisher</span>
                                                 <br /> <span className={`${styles.IDCardValue} m-0 h-50`}> {digitalMedia.data['dcterms:publisher']} </span>
                                             </Col>
                                         </Row>
                                         <Row className={styles.IDCardPropertyBlock}>
-                                            <Col className={`${classPropertyBlockHover} rounded-c py-1`}
-                                                onClick={() => ToggleModal('dcterms:rightsHolder')}
-                                            >
+                                            <Col className={`${classPropertyBlockHover} rounded-c py-1`}>
                                                 <span className="fw-lightBold m-0 h-50">Rightsholder</span>
                                                 <br /> <span className={`${styles.IDCardValue} m-0 h-50`}> {digitalMedia.data['rightsHolder']} </span>
                                             </Col>
                                         </Row>
                                         <Row className={styles.IDCardPropertyBlock}>
                                             <Col className={`${classPropertyBlockHover} rounded-c py-1`}
-                                                onClick={() => ToggleModal('dcterms:license')}
+                                                onClick={() => ToggleSidePanel('dcterms:license')}
                                             >
                                                 <span className="fw-lightBold m-0 h-50">License</span>
                                                 <br /> <span className={`${styles.IDCardValue} m-0 h-50`}> {digitalMedia.data['dcterms:license']} </span>

--- a/src/components/digitalMedia/digitalMedia.module.scss
+++ b/src/components/digitalMedia/digitalMedia.module.scss
@@ -4,6 +4,11 @@
     height: calc(100vh - 140px)
 }
 
+.sidePanel {
+    height: 100vh;
+    width: Calc(100% / 3);
+}
+
 
 /* Title Bar */
 .title {

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -158,7 +158,7 @@ const Specimen = () => {
         dispatch(setSidePanelToggle(true));
     }
 
-    /* ClassName for Specimen Content */
+    /* Class Name for Specimen Content */
     const classSpecimenContent = classNames({
         'col-md-10 offset-md-1': !sidePanelToggle,
         'col-md-12 px-5': sidePanelToggle
@@ -168,7 +168,7 @@ const Specimen = () => {
         'h-100': screenSize === 'lg'
     });
 
-    /* ClassName for Side Panel */
+    /* Class Name for Side Panel */
     const classSidePanel = classNames({
         'p-0': true,
         'w-0': !sidePanelToggle,

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -205,7 +205,7 @@ const Specimen = () => {
                                 </Col>
                             </Row>
 
-                            {/* Automated Annotations Modal for Specimen */}
+                            {/* Automated Annotations Modal */}
                             <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
                                 HideAutomatedAnnotationsModal={() => setAutomatedAnnotationToggle(false)}
                             />
@@ -215,7 +215,7 @@ const Specimen = () => {
                     <Footer />
                 </Col>
 
-                {/* Annotations Side Panel for Specimen */}
+                {/* Annotations Side Panel */}
                 <div className={`${classSidePanel} transition`}>
                     <SidePanel ShowWithAllAnnotations={() => ShowWithAllAnnotations()}
                         UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -205,7 +205,7 @@ const Specimen = () => {
                                 </Col>
                             </Row>
 
-                            {/* Automated Annotations Modal */}
+                            {/* Automated Annotations Modal for Specimen */}
                             <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
                                 HideAutomatedAnnotationsModal={() => setAutomatedAnnotationToggle(false)}
                             />
@@ -215,7 +215,7 @@ const Specimen = () => {
                     <Footer />
                 </Col>
 
-                {/* Annotations Side Panel */}
+                {/* Annotations Side Panel for Specimen */}
                 <div className={`${classSidePanel} transition`}>
                     <SidePanel ShowWithAllAnnotations={() => ShowWithAllAnnotations()}
                         UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}

--- a/src/sources/hamonisedAttributes.json
+++ b/src/sources/hamonisedAttributes.json
@@ -188,5 +188,14 @@
     },
     "ods:topicDiscipline": {
         "displayName": "Topic Discipline"
+    },
+    "mediaUrl": {
+        "displayName": "Media URL"
+    },
+    "ac:accessURI": {
+        "displayName": "Acces URL"
+    },
+    "dcterms:format": {
+        "displayName": "Format"
     }
 }

--- a/src/sources/hamonisedAttributes.json
+++ b/src/sources/hamonisedAttributes.json
@@ -191,11 +191,5 @@
     },
     "mediaUrl": {
         "displayName": "Media URL"
-    },
-    "ac:accessURI": {
-        "displayName": "Acces URL"
-    },
-    "dcterms:format": {
-        "displayName": "Format"
     }
 }


### PR DESCRIPTION
Commit adds Annotation Side Panel to Digital Media page. All annotation features are included: creating, editing and deleting annotations. Actually, this functionality is supplied by the side panel itself, and is not repeatably used. Only the update functions for the original Digital Media annotations are similar to the Specimen counterpart and could be generalised in the future.

Adds:
- Annotations Side Panel to Digital Media page

Modifies:
- Digital Media ID Card's properties to not trigger the side panel, these need refinement and decide on whether these are harmonised properties or not
- Aligning of the components on the Digital Media page to fit the side panel, and be relative to the Specimen Page