### PR TITLE
Add refresh button to Side Panel in order to refresh Annotations

### DIFF
--- a/src/api/specimen/GetSpecimenAnnotations.ts
+++ b/src/api/specimen/GetSpecimenAnnotations.ts
@@ -9,9 +9,9 @@ import { SpecimenAnnotations, Annotation, JSONResultArray } from 'global/Types';
 
 
 const GetSpecimenAnnotations = async (handle: string) => {
-    if (handle) {
-        let specimenAnnotations = {} as SpecimenAnnotations;
+    let specimenAnnotations = {} as SpecimenAnnotations;
 
+    if (handle) {
         const endPoint = `specimens/${handle}/annotations`;
 
         try {
@@ -42,9 +42,9 @@ const GetSpecimenAnnotations = async (handle: string) => {
         } catch (error) {
             console.warn(error);
         }
-
-        return specimenAnnotations;
     }
+
+    return specimenAnnotations;
 }
 
 export default GetSpecimenAnnotations;

--- a/src/components/annotate/AnnotationTools.tsx
+++ b/src/components/annotate/AnnotationTools.tsx
@@ -1,0 +1,54 @@
+/* Import Dependencies */
+import classNames from "classnames";
+
+/* Import Types */
+import { Annotation } from "global/Types";
+
+/* Import Components */
+import AutomatedAnnotationsModal from "components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal";
+import SidePanel from "./sidePanel/SidePanel";
+
+
+/* Props Typing */
+interface Props {
+    sidePanelToggle: boolean,
+    automatedAnnotationsToggle: boolean,
+    SetAutomatedAnnotationToggle: Function,
+    ShowWithAnnotations: Function,
+    UpdateAnnotationsSource: Function,
+    RefreshAnnotations: Function
+};
+
+
+const AnnotationTools = (props: Props) => {
+    const {
+        sidePanelToggle, automatedAnnotationsToggle, SetAutomatedAnnotationToggle,
+        ShowWithAnnotations, UpdateAnnotationsSource, RefreshAnnotations
+    } = props;
+
+    /* Class Names */
+    const classSidePanel = classNames({
+        'p-0': true,
+        'w-0': !sidePanelToggle,
+        'col-md-4': sidePanelToggle
+    });
+    
+    return (
+        <>
+            {/* Automated Annotations Modal */}
+            <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
+                HideAutomatedAnnotationsModal={() => SetAutomatedAnnotationToggle(false)}
+            />
+
+            {/* Annotations Side Panel */}
+            <div className={`${classSidePanel} transition`}>
+                <SidePanel ShowWithAllAnnotations={() => ShowWithAnnotations()}
+                    UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
+                    RefreshAnnotations={(targetProperty: string) => RefreshAnnotations(targetProperty)}
+                />
+            </div>
+        </>
+    );
+}
+
+export default AnnotationTools;

--- a/src/components/annotate/sidePanel/SidePanel.tsx
+++ b/src/components/annotate/sidePanel/SidePanel.tsx
@@ -34,12 +34,13 @@ import Tooltip from 'components/general/tooltip/Tooltip';
 /* Props Typing */
 interface Props {
     ShowWithAllAnnotations: Function,
-    UpdateAnnotationsSource?: Function
+    UpdateAnnotationsSource?: Function,
+    RefreshAnnotations?: Function
 };
 
 
 const SidePanel = (props: Props) => {
-    const { ShowWithAllAnnotations, UpdateAnnotationsSource } = props;
+    const { ShowWithAllAnnotations, UpdateAnnotationsSource, RefreshAnnotations } = props;
 
     /* Hooks */
     const dispatch = useAppDispatch();
@@ -147,6 +148,16 @@ const SidePanel = (props: Props) => {
                                 {sidePanelTitle}
                             </h4>
                         </Col>
+                        {RefreshAnnotations &&
+                            <Col className="col-md-auto">
+                                <button type="button"
+                                    className="primaryButton py-1 px-2"
+                                    onClick={() => RefreshAnnotations(annotateTarget.property)}
+                                >
+                                    Refresh
+                                </button>
+                            </Col>
+                        }
                         <Col className="col-md-auto">
                             <Tooltip text="All annotations are publicly available and subject to the CC-0 license" placement="left">
                                 <span>

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -173,14 +173,14 @@ const DigitalMedia = () => {
         let allAnnotations: Annotation[] = [];
 
         /* Append to the all annotations array, if property is the same, or all annotations are wanted */
-        Object.entries(annotations || digitalMediaAnnotations).forEach((annotationEntry) => {
+        Object.entries(annotations ?? digitalMediaAnnotations).forEach((annotationEntry) => {
             if (!targetProperty || targetProperty === annotationEntry[0]) {
                 allAnnotations = allAnnotations.concat(annotationEntry[1]);
             }
         });
 
         dispatch(setAnnotateTarget({
-            property: targetProperty || '',
+            property: targetProperty ?? '',
             target: digitalMedia,
             targetType: 'digital_media',
             annotations: allAnnotations

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -33,8 +33,7 @@ import VersionSelect from 'components/general/versionSelect/VersionSelect';
 import DigitalMediaFrame from './components/digitalMedia/DigitalMediaFrame';
 import DigitalMediaList from './components/digitalMedia/DigitalMediaList';
 import ActionsDropdown from 'components/general/actionsDropdown/ActionsDropdown';
-import SidePanel from 'components/annotate/sidePanel/SidePanel';
-import AutomatedAnnotationsModal from '../general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal';
+import AnnotationTools from 'components/annotate/AnnotationTools';
 import Footer from 'components/general/footer/Footer';
 
 /* Import API */
@@ -168,13 +167,13 @@ const DigitalMedia = () => {
         dispatch(setDigitalMediaAnnotations(copyDigitalMediaAnnotations));
     }
 
-     /* Function to open Side Panel with Annotations of Digital Media, default is all Annotations */
+    /* Function to open Side Panel with Annotations of Digital Media, default is all Annotations */
     const ShowWithAnnotations = (annotations?: DigitalMediaAnnotations, targetProperty?: string) => {
         /* Add up all property annotations into one annotations array */
         let allAnnotations: Annotation[] = [];
 
         /* Append to the all annotations array, if property is the same, or all annotations are wanted */
-        Object.entries(annotations? annotations : digitalMediaAnnotations).forEach((annotationEntry) => {
+        Object.entries(annotations ? annotations : digitalMediaAnnotations).forEach((annotationEntry) => {
             if (!targetProperty || targetProperty === annotationEntry[0]) {
                 allAnnotations = allAnnotations.concat(annotationEntry[1]);
             }
@@ -190,8 +189,8 @@ const DigitalMedia = () => {
         dispatch(setSidePanelToggle(true));
     }
 
-      /* Function for refreshing Annotations */
-      const RefreshAnnotations = (targetProperty?: string) => {
+    /* Function for refreshing Annotations */
+    const RefreshAnnotations = (targetProperty?: string) => {
         /* Refetch Digital Media Annotations */
         GetDigitalMediaAnnotations(digitalMedia.id.replace('https://hdl.handle.net/', '')).then((annotations) => {
             /* Show with refreshed Annotations */
@@ -214,12 +213,6 @@ const DigitalMedia = () => {
         'transition h-100': true,
         'col-md-12': !sidePanelToggle,
         'col-md-8': sidePanelToggle
-    });
-
-    const classSidePanel = classNames({
-        'p-0': true,
-        'w-0': !sidePanelToggle,
-        'col-md-4': sidePanelToggle
     });
 
     return (
@@ -273,24 +266,20 @@ const DigitalMedia = () => {
                                     </div>
                                 </Col>
                             </Row>
-
-                            {/* Automated Annotations Modal */}
-                            <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
-                                HideAutomatedAnnotationsModal={() => setAutomatedAnnotationToggle(false)}
-                            />
                         </Container >
                     }
-
+                    
                     <Footer />
                 </Col>
 
-                {/* Annotations Side Panel */}
-                <div className={`${classSidePanel} transition`}>
-                    <SidePanel ShowWithAllAnnotations={() => ShowWithAnnotations()}
-                        UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
-                        RefreshAnnotations={(targetProperty: string) => RefreshAnnotations(targetProperty)}
-                    />
-                </div>
+                {/* Annotation Tools */}
+                <AnnotationTools sidePanelToggle={sidePanelToggle}
+                    automatedAnnotationsToggle={automatedAnnotationsToggle}
+                    SetAutomatedAnnotationToggle={(toggle: boolean) => setAutomatedAnnotationToggle(toggle)}
+                    ShowWithAnnotations={() => ShowWithAnnotations()}
+                    UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
+                    RefreshAnnotations={(targetProperty: string) => RefreshAnnotations(targetProperty)}
+                />
             </Row>
         </div>
     );

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -173,14 +173,14 @@ const DigitalMedia = () => {
         let allAnnotations: Annotation[] = [];
 
         /* Append to the all annotations array, if property is the same, or all annotations are wanted */
-        Object.entries(annotations ? annotations : digitalMediaAnnotations).forEach((annotationEntry) => {
+        Object.entries(annotations || digitalMediaAnnotations).forEach((annotationEntry) => {
             if (!targetProperty || targetProperty === annotationEntry[0]) {
                 allAnnotations = allAnnotations.concat(annotationEntry[1]);
             }
         });
 
         dispatch(setAnnotateTarget({
-            property: targetProperty ? targetProperty : '',
+            property: targetProperty || '',
             target: digitalMedia,
             targetType: 'digital_media',
             annotations: allAnnotations

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -145,14 +145,14 @@ const Specimen = () => {
         let allAnnotations: Annotation[] = [];
 
         /* Append to the all annotations array, if property is the same, or all annotations are wanted */
-        Object.entries(annotations || specimenAnnotations).forEach((annotationEntry) => {
+        Object.entries(annotations ?? specimenAnnotations).forEach((annotationEntry) => {
             if (!targetProperty || targetProperty === annotationEntry[0]) {
                 allAnnotations = allAnnotations.concat(annotationEntry[1]);
             }
         });
 
         dispatch(setAnnotateTarget({
-            property: targetProperty || '',
+            property: targetProperty ?? '',
             target: specimen,
             targetType: 'digital_specimen',
             annotations: allAnnotations

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -145,14 +145,14 @@ const Specimen = () => {
         let allAnnotations: Annotation[] = [];
 
         /* Append to the all annotations array, if property is the same, or all annotations are wanted */
-        Object.entries(annotations ? annotations : specimenAnnotations).forEach((annotationEntry) => {
+        Object.entries(annotations || specimenAnnotations).forEach((annotationEntry) => {
             if (!targetProperty || targetProperty === annotationEntry[0]) {
                 allAnnotations = allAnnotations.concat(annotationEntry[1]);
             }
         });
 
         dispatch(setAnnotateTarget({
-            property: targetProperty ? targetProperty : '',
+            property: targetProperty || '',
             target: specimen,
             targetType: 'digital_specimen',
             annotations: allAnnotations

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -27,8 +27,7 @@ import Header from 'components/general/header/Header';
 import TitleBar from './components/TitleBar';
 import IDCard from './components/IDCard/IDCard';
 import ContentBlock from './components/ContentBlock';
-import AutomatedAnnotationsModal from '../general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal';
-import SidePanel from 'components/annotate/sidePanel/SidePanel';
+import AnnotationTools from 'components/annotate/AnnotationTools';
 import Footer from 'components/general/footer/Footer';
 
 /* Import API */
@@ -186,13 +185,6 @@ const Specimen = () => {
         'h-100': screenSize === 'lg'
     });
 
-    /* Class Name for Side Panel */
-    const classSidePanel = classNames({
-        'p-0': true,
-        'w-0': !sidePanelToggle,
-        [`${styles.sidePanel}`]: sidePanelToggle
-    });
-
     return (
         <div className="d-flex flex-column min-vh-100 overflow-hidden">
             <Row>
@@ -222,24 +214,20 @@ const Specimen = () => {
                                     </div>
                                 </Col>
                             </Row>
-
-                            {/* Automated Annotations Modal */}
-                            <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
-                                HideAutomatedAnnotationsModal={() => setAutomatedAnnotationToggle(false)}
-                            />
                         </Container>
                     }
 
                     <Footer />
                 </Col>
 
-                {/* Annotations Side Panel */}
-                <div className={`${classSidePanel} transition`}>
-                    <SidePanel ShowWithAllAnnotations={() => ShowWithAnnotations()}
-                        UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
-                        RefreshAnnotations={(targetProperty: string) => RefreshAnnotations(targetProperty)}
-                    />
-                </div>
+                {/* Annotation Tools */}
+                <AnnotationTools sidePanelToggle={sidePanelToggle}
+                    automatedAnnotationsToggle={automatedAnnotationsToggle}
+                    SetAutomatedAnnotationToggle={(toggle: boolean) => setAutomatedAnnotationToggle(toggle)}
+                    ShowWithAnnotations={() => ShowWithAnnotations()}
+                    UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
+                    RefreshAnnotations={(targetProperty: string) => RefreshAnnotations(targetProperty)}
+                />
             </Row>
         </div>
     );

--- a/src/sources/hamonisedAttributes.json
+++ b/src/sources/hamonisedAttributes.json
@@ -191,5 +191,11 @@
     },
     "mediaUrl": {
         "displayName": "Media URL"
+    },
+    "ac:accessURI": {
+        "displayName": "Acces URL"
+    },
+    "dcterms:format": {
+        "displayName": "Format"
     }
 }


### PR DESCRIPTION
Commit adds a refresh button to the Side Panel that can be used to refresh the annotations within it. This method is dependent upon the parent component passing it on, otherwise the button will not be displayed. The Specimen of Digital Media component will trigger a refresh call to the API and provide the annotations to the side panel, as well as update the source material.

Adds:
- Refresh functionality to the Side Panel
- Refresh functions for Specimen and Digital Media Annotations

Modifies:
- ShowWithAllAnnotations function to become a ShowWithAnnotations function that takes two parameters: optional annotations (default is all annotations), and a target property to keep track of).