### PR TITLE
Add image, video, audio and file media types to Specimen Digital Media

### DIFF
--- a/src/components/general/audioPlayer/AudioPlayer.tsx
+++ b/src/components/general/audioPlayer/AudioPlayer.tsx
@@ -1,0 +1,113 @@
+/* Import Dependencies */
+import { useEffect, useState, useRef, useCallback } from "react";
+import moment from "moment";
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Styles */
+import styles from './audioPlayer.module.scss';
+
+/* Import Icons */
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlay, faPause, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+
+
+/* Props Typing */
+interface Props {
+    source: string
+};
+
+
+const AudioPlayer = (props: Props) => {
+    const { source } = props;
+
+    /* Hooks */
+    const audioRef = useRef<HTMLAudioElement>(null);
+    const rangeRef = useRef<HTMLInputElement>(null);
+    let playAnimationRef = useRef<number>(null);
+
+    /* Base variables */
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [duration, setDuration] = useState<number | string>(0);
+
+    /* Function for repeating the frame animation, allowing the progress bar to progress */
+    const Repeat = useCallback(() => {
+        if (audioRef.current && rangeRef.current) {
+            const audioPlayer = audioRef.current as HTMLAudioElement;
+            const audioRange = rangeRef.current as HTMLInputElement;
+
+            audioRange.value = String(audioPlayer.currentTime);
+            audioRange.style.setProperty(
+                '--range-progress',
+                `${(Number(audioRange.value) / Number(duration)) * 100}%`
+            )
+
+            playAnimationRef = { ...playAnimationRef, current: requestAnimationFrame(Repeat) };
+        }
+    }, []);
+
+    /* Function for playing and pausing audio */
+    useEffect(() => {
+        if (audioRef.current) {
+            const audioPlayer = audioRef.current as HTMLAudioElement;
+
+            if (isPlaying) {
+                audioPlayer.play();
+            } else {
+                audioPlayer.pause();
+            }
+
+            playAnimationRef = { ...playAnimationRef, current: requestAnimationFrame(Repeat) };
+        }
+    }, [isPlaying, audioRef, Repeat]);
+
+    /* Function for OnChange of Audio progress: update progress bar */
+    const HandleRangeChange = () => {
+        const audioPlayer = audioRef.current as HTMLAudioElement;
+        const audioRange = rangeRef.current as HTMLInputElement;
+
+        audioPlayer.currentTime = Number(audioRange.value);
+    }
+
+    /* Function for tracking the audio duration and total time */
+    const OnLoadedMetadata = () => {
+        const audioPlayer = audioRef.current as HTMLAudioElement;
+        const audioRange = rangeRef.current as HTMLInputElement;
+
+        setDuration(moment.utc(audioPlayer.duration * 1000).format('m:ss'));
+        audioRange.max = String(Math.round(audioPlayer.duration));
+    }
+
+    return (
+        <div className={`${styles.audioPlayer} px-3 py-2`}>
+            <audio src={source} ref={audioRef}
+                onLoadedMetadataCapture={() => OnLoadedMetadata()}
+                onEnded={() => { setIsPlaying(false) }}
+            />
+
+            <Row className="align-items-center">
+                <Col className="col-md-auto pe-0 ">
+                    <FontAwesomeIcon icon={!isPlaying ? faPlay : faPause}
+                        className={`${styles.audioPlayerIcon} c-pointer`}
+                        onClick={() => setIsPlaying(!isPlaying)}
+                    />
+                </Col>
+                <Col className="d-flex align-items-center">
+                    <input type="range" ref={rangeRef}
+                        className={`${styles.audioRange} w-100`}
+                        onChange={() => HandleRangeChange()}
+                    />
+                </Col>
+                <Col className="col-md-auto ps-0">
+                    <span className={styles.audioPlayerTotalTime}> {duration} </span>
+                </Col>
+                <Col className="col-md-auto ps-0">
+                    <FontAwesomeIcon icon={faInfoCircle}
+                        className={styles.audioPlayerIcon}
+                    />
+                </Col>
+            </Row>
+        </div>
+    );
+}
+
+export default AudioPlayer;

--- a/src/components/general/audioPlayer/AudioPlayer.tsx
+++ b/src/components/general/audioPlayer/AudioPlayer.tsx
@@ -32,8 +32,8 @@ const AudioPlayer = (props: Props) => {
     /* Function for repeating the frame animation, allowing the progress bar to progress */
     const Repeat = useCallback(() => {
         if (audioRef.current && rangeRef.current) {
-            const audioPlayer = audioRef.current as HTMLAudioElement;
-            const audioRange = rangeRef.current as HTMLInputElement;
+            const audioPlayer = audioRef.current;
+            const audioRange = rangeRef.current;
 
             audioRange.value = String(audioPlayer.currentTime);
             audioRange.style.setProperty(
@@ -48,7 +48,7 @@ const AudioPlayer = (props: Props) => {
     /* Function for playing and pausing audio */
     useEffect(() => {
         if (audioRef.current) {
-            const audioPlayer = audioRef.current as HTMLAudioElement;
+            const audioPlayer = audioRef.current;
 
             if (isPlaying) {
                 audioPlayer.play();

--- a/src/components/general/audioPlayer/audioPlayer.module.scss
+++ b/src/components/general/audioPlayer/audioPlayer.module.scss
@@ -1,0 +1,52 @@
+/* Custom styles for Audio Player */
+.audioPlayer {
+    background-color: #E6E2F1;
+    border-radius: 999px;
+}
+
+.audioPlayerIcon {
+    color: var(--primary);
+}
+
+.audioPlayerTotalTime {
+    font-size: 14px;
+}
+
+/* Audio Range */
+.audioRange {
+    background-color: #E6E2F1;
+}
+
+input[type=range] {
+    --range-progress: 0;
+}
+
+input[type=range]::before {
+    width: var(--range-progress);
+}
+
+input[type=range]::-webkit-slider-runnable-track {
+    height: 5px;
+    background: #BFBFDE;
+    border: none;
+    border-radius: 3px;
+}
+
+input[type=range]::-moz-range-track {
+    background: #BFBFDE;
+}
+
+input[type=range]::-webkit-slider-thumb {
+    width: 10px !important;
+    height: 10px !important;
+    background-color: var(--primary) !important;
+    border-color: var(--primary) !important;
+    margin-top: -5px;
+}
+
+input[type=range]::-moz-range-thumb {
+    width: 10px;
+    height: 10px;
+    background-color: var(--primary);
+    border-color: var(--primary);
+}

--- a/src/components/general/header/Header.tsx
+++ b/src/components/general/header/Header.tsx
@@ -50,7 +50,9 @@ const Header = () => {
                     {/* Title */}
                     <Row className="h-100 w-100 align-items-end">
                         <Col className="col-md-auto p-0 d-flex align-items-center">
-                            <h1 className={`${styles.title} fw-bold`}>DiSSCover</h1>
+                            <Link to="/">
+                                <h1 className={`${styles.title} fw-bold`}>DiSSCover</h1>
+                            </Link>
                         </Col>
                         {/* Navigation */}
                         <Col className="pb-3 d-flex justify-content-center">

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -181,6 +181,12 @@ const Specimen = () => {
         'col-md-12 px-5': sidePanelToggle
     });
 
+    const classHeadCol = classNames({
+        'transition h-100': true,
+        'col-md-12': !sidePanelToggle,
+        'col-md-8': sidePanelToggle
+    });
+
     const classIdCard = classNames({
         'h-100': screenSize === 'lg'
     });
@@ -188,7 +194,7 @@ const Specimen = () => {
     return (
         <div className="d-flex flex-column min-vh-100 overflow-hidden">
             <Row>
-                <Col>
+                <Col className={classHeadCol}>
                     <Header />
 
                     {(specimen.id && specimen.id.replace('https://hdl.handle.net/', '') === `${params['prefix']}/${params['suffix']}`) &&

--- a/src/components/specimen/components/IDCard/IDCard.tsx
+++ b/src/components/specimen/components/IDCard/IDCard.tsx
@@ -51,7 +51,7 @@ const IDCard = () => {
             <Col className="h-100">
                 <div className="h-100 d-flex flex-column">
                     {specimenDigitalMedia.length > 0 &&
-                        <Row className={styles.IDCardBanner}>
+                        <Row className={`${styles.IDCardBanner} overflow-hidden`}>
                             <Col className="h-100">
                                 <div className={`${styles.IDCardBannerBackground} h-100 d-flex justify-content-center`}>
                                     <img src={specimenDigitalMedia[0].digitalMediaObject.mediaUrl} alt="banner"

--- a/src/components/specimen/components/contentBlocks/DigitalMedia.tsx
+++ b/src/components/specimen/components/contentBlocks/DigitalMedia.tsx
@@ -21,63 +21,8 @@ const DigitalMedia = () => {
     const specimenDigitalMedia = useAppSelector(getSpecimenDigitalMedia);
     let sortedDigitalMedia: { [mediaType: string]: React.ReactElement[] } = {};
 
-    let created = new Date();
-
-    let test = [...specimenDigitalMedia];
-
-    test.push({
-        annotations: [],
-        created: new Date(),
-        digitalMediaObject: {
-            id: '100',
-            data: {},
-            created: new Date(),
-            digitalSpecimenId: '200',
-            format: 'video',
-            mediaUrl: '',
-            originalData: {},
-            sourceSystemId: '300',
-            type: 'video',
-            version: 2
-        }
-    });
-
-    test.push({
-        annotations: [],
-        created: new Date(),
-        digitalMediaObject: {
-            id: '100',
-            data: {},
-            created: new Date(),
-            digitalSpecimenId: '200',
-            format: 'video',
-            mediaUrl: '',
-            originalData: {},
-            sourceSystemId: '300',
-            type: 'audio',
-            version: 2
-        }
-    });
-
-    test.push({
-        annotations: [],
-        created: new Date(),
-        digitalMediaObject: {
-            id: '100',
-            data: {},
-            created: new Date(),
-            digitalSpecimenId: '200',
-            format: 'video',
-            mediaUrl: 'File.pdf',
-            originalData: {},
-            sourceSystemId: '300',
-            type: 'file',
-            version: 2
-        }
-    });
-
     /* Sort Digital Media based upon type/format */
-    test.forEach((item) => {
+    specimenDigitalMedia.forEach((item) => {
         const digitalMediaItem = item.digitalMediaObject;
 
         switch (digitalMediaItem.type) {

--- a/src/components/specimen/components/contentBlocks/DigitalMedia.tsx
+++ b/src/components/specimen/components/contentBlocks/DigitalMedia.tsx
@@ -1,6 +1,5 @@
 /* Import Dependencies */
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Capitalize } from 'global/Utilities';
 import { Row, Col, Card } from 'react-bootstrap';
 
 /* Import Store */
@@ -10,60 +9,134 @@ import { getSpecimenDigitalMedia } from 'redux/specimen/SpecimenSlice';
 /* Import Styles */
 import styles from 'components/specimen/specimen.module.scss';
 
-/* Import Icons */
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+/* Components */
+import Image from './digitalMediaBlock/Image';
+import Video from './digitalMediaBlock/Video';
+import Audio from './digitalMediaBlock/Audio';
+import File from './digitalMediaBlock/File';
 
 
 const DigitalMedia = () => {
-    /* Hooks */
-    const navigate = useNavigate();
-
     /* Base variables */
     const specimenDigitalMedia = useAppSelector(getSpecimenDigitalMedia);
-    const [imageHover, setImageHover] = useState<string>('');
+    let sortedDigitalMedia: { [mediaType: string]: React.ReactElement[] } = {};
+
+    let created = new Date();
+
+    let test = [...specimenDigitalMedia];
+
+    test.push({
+        annotations: [],
+        created: new Date(),
+        digitalMediaObject: {
+            id: '100',
+            data: {},
+            created: new Date(),
+            digitalSpecimenId: '200',
+            format: 'video',
+            mediaUrl: '',
+            originalData: {},
+            sourceSystemId: '300',
+            type: 'video',
+            version: 2
+        }
+    });
+
+    test.push({
+        annotations: [],
+        created: new Date(),
+        digitalMediaObject: {
+            id: '100',
+            data: {},
+            created: new Date(),
+            digitalSpecimenId: '200',
+            format: 'video',
+            mediaUrl: '',
+            originalData: {},
+            sourceSystemId: '300',
+            type: 'audio',
+            version: 2
+        }
+    });
+
+    test.push({
+        annotations: [],
+        created: new Date(),
+        digitalMediaObject: {
+            id: '100',
+            data: {},
+            created: new Date(),
+            digitalSpecimenId: '200',
+            format: 'video',
+            mediaUrl: 'File.pdf',
+            originalData: {},
+            sourceSystemId: '300',
+            type: 'file',
+            version: 2
+        }
+    });
+
+    /* Sort Digital Media based upon type/format */
+    test.forEach((item) => {
+        const digitalMediaItem = item.digitalMediaObject;
+
+        switch (digitalMediaItem.type) {
+            case '2DImageObject':
+                (sortedDigitalMedia.images || (sortedDigitalMedia.images = [])).push(
+                    <Image digitalMedia={digitalMediaItem} />
+                );
+
+                return;
+            case 'video':
+                (sortedDigitalMedia.videos || (sortedDigitalMedia.videos = [])).push(
+                    <Video digitalMedia={digitalMediaItem} />
+                );
+
+                return;
+            case 'audio':
+                (sortedDigitalMedia.audio || (sortedDigitalMedia.audio = [])).push(
+                    <Audio digitalMedia={digitalMediaItem} />
+                );
+
+                return;
+            default:
+                (sortedDigitalMedia['other Media'] || (sortedDigitalMedia['other Media'] = [])).push(
+                    <File digitalMedia={digitalMediaItem} />
+                );
+        }
+    });
 
     return (
-        <Row className="h-100">
+        <Row className="h-100 overflow-scroll">
             <Col className="h-100">
-                <Card className="h-100">
-                    <Card.Body className="h-100">
-                        <Row className={`${styles.digitalMediaImagesBlock} mt-2`}>
-                            <Col className="h-100">
-                                <p className={`${styles.digitalMediaTitle} fw-bold`}> Images: </p>
+                {Object.keys(sortedDigitalMedia).map((mediaType) => {
+                    const mediaComponents = sortedDigitalMedia[mediaType];
 
-                                <div className={`${styles.digitalMediaImagesSlider} px-3 py-2 mt-1`}>
-                                    {specimenDigitalMedia.map((specimenDigitalMediaItem) => {
-                                        const digitalMedia = specimenDigitalMediaItem.digitalMediaObject;
+                    return (
+                        <Card key={mediaType} className="px-4 py-3 mb-3">
+                            {/* Digital Media type title */}
+                            <Row>
+                                <Col>
+                                    <p className={`${styles.digitalMediaTitle} c-accent fw-lightBold`}>
+                                        {Capitalize(mediaType)}
+                                    </p>
+                                </Col>
+                            </Row>
+                            {/* Digital Media Components */}
+                            <Row className="mt-2">
+                                {mediaComponents.map((mediaComponent, index) => {
+                                    const key = `${mediaType} ${index}`;
 
-                                        return (
-                                            <div key={digitalMedia.id}
-                                                className={`${styles.digitalMediaImageDiv} h-100 me-3 d-inline-block position-relative`}
-                                            >
-                                                <img src={digitalMedia.mediaUrl}
-                                                    alt={digitalMedia.mediaUrl}
-                                                    className={`${styles.digitalMediaImage} h-100`}
-                                                    onMouseEnter={() => setImageHover(digitalMedia.id)}
-                                                    onMouseLeave={() => setImageHover('')}
-                                                />
-
-                                                <div className={`${styles.digitalMediaImageHover} 
-                                                    ${(digitalMedia.id === imageHover && styles.active)} 
-                                                    position-absolute bottom-0 w-100 h-100 py-1 px-2 bg-white d-flex justify-content-center align-items-center`}
-                                                    onMouseEnter={() => setImageHover(digitalMedia.id)}
-                                                    onMouseLeave={() => setImageHover('')}
-                                                    onClick={() => navigate(`/dm/${digitalMedia.id.replace('https://hdl.handle.net/', '')}`)}
-                                                >
-                                                    Go to Image <FontAwesomeIcon icon={faChevronRight} className="ms-1 fw-lightBold" />
-                                                </div>
-                                            </div>
-                                        );
-                                    })}
-                                </div>
-                            </Col>
-                        </Row>
-                    </Card.Body>
-                </Card>
+                                    return (
+                                        <Col key={key} lg={{span: 3}}>
+                                            {mediaComponent}
+                                        </Col>
+                                    );
+                                })}
+                            </Row>
+                        </Card>
+                    );
+                })}
             </Col>
         </Row>
     );

--- a/src/components/specimen/components/contentBlocks/digitalMediaBlock/Audio.tsx
+++ b/src/components/specimen/components/contentBlocks/digitalMediaBlock/Audio.tsx
@@ -1,11 +1,5 @@
-/* Import Dependencies */
-import { Row, Col } from 'react-bootstrap';
-
 /* Import Types */
 import { DigitalMedia } from "global/Types";
-
-/* Import Styling */
-import styles from 'components/specimen/specimen.module.scss';
 
 /* Import Components */
 import AudioPlayer from 'components/general/audioPlayer/AudioPlayer';
@@ -21,7 +15,7 @@ const Audio = (props: Props) => {
     const { digitalMedia } = props;
 
     return (
-        <AudioPlayer source="http://codeskulptor-demos.commondatastorage.googleapis.com/descent/background%20music.mp3" />
+        <AudioPlayer source={digitalMedia.mediaUrl} />
     );
 }
 

--- a/src/components/specimen/components/contentBlocks/digitalMediaBlock/Audio.tsx
+++ b/src/components/specimen/components/contentBlocks/digitalMediaBlock/Audio.tsx
@@ -1,0 +1,28 @@
+/* Import Dependencies */
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Types */
+import { DigitalMedia } from "global/Types";
+
+/* Import Styling */
+import styles from 'components/specimen/specimen.module.scss';
+
+/* Import Components */
+import AudioPlayer from 'components/general/audioPlayer/AudioPlayer';
+
+
+/* Props Typing */
+interface Props {
+    digitalMedia: DigitalMedia
+};
+
+
+const Audio = (props: Props) => {
+    const { digitalMedia } = props;
+
+    return (
+        <AudioPlayer source="http://codeskulptor-demos.commondatastorage.googleapis.com/descent/background%20music.mp3" />
+    );
+}
+
+export default Audio;

--- a/src/components/specimen/components/contentBlocks/digitalMediaBlock/File.tsx
+++ b/src/components/specimen/components/contentBlocks/digitalMediaBlock/File.tsx
@@ -1,0 +1,40 @@
+/* Import Dependencies */
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Types */
+import { DigitalMedia } from 'global/Types';
+
+/* Import Styles */
+import styles from 'components/specimen/specimen.module.scss';
+
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFile } from '@fortawesome/free-solid-svg-icons';
+
+
+/* Props Typing */
+interface Props {
+    digitalMedia: DigitalMedia
+};
+
+
+const File = (props: Props) => {
+    const { digitalMedia } = props;
+
+    return (
+        <div className={`${styles.fileBlock} px-3 py-2 rounded`}>
+            <Row>
+                <Col className="col-md-auto pe-0 d-flex align-items-center">
+                    <FontAwesomeIcon icon={faFile}
+                        className={`${styles.fileIcon} c-secondary`}
+                    />
+                </Col>
+                <Col>
+                    <p className={styles.fileTitle}> {digitalMedia.mediaUrl} </p>
+                </Col>
+            </Row>
+        </div>
+    );
+}
+
+export default File;

--- a/src/components/specimen/components/contentBlocks/digitalMediaBlock/Image.tsx
+++ b/src/components/specimen/components/contentBlocks/digitalMediaBlock/Image.tsx
@@ -1,0 +1,38 @@
+/* Import Dependencies */
+import { Link } from 'react-router-dom';
+
+/* Import Types */
+import { DigitalMedia } from "global/Types";
+
+/* Import Styling */
+import styles from 'components/specimen/specimen.module.scss';
+
+
+/* Props Typing */
+interface Props {
+    digitalMedia: DigitalMedia
+};
+
+
+const Image = (props: Props) => {
+    const { digitalMedia } = props;
+
+    return (
+        <Link to={`/dm/${digitalMedia.id.replace('https://hdl.handle.net/', '')}`}>
+            <div className="position-relative">
+                <img src={digitalMedia.mediaUrl}
+                    alt={digitalMedia.id}
+                    className="w-100 rounded"
+                />
+
+                <div className={`${styles.imageHover} position-absolute transition 
+                        h-100 w-100 top-0 d-flex justify-content-center align-items-center c-pointer px-3`
+                }>
+                    <p className="fw-bold"> {digitalMedia.id.replace('https://hdl.handle.net/', '')} </p>
+                </div>
+            </div>
+        </Link>
+    );
+}
+
+export default Image;

--- a/src/components/specimen/components/contentBlocks/digitalMediaBlock/Video.tsx
+++ b/src/components/specimen/components/contentBlocks/digitalMediaBlock/Video.tsx
@@ -1,0 +1,39 @@
+/* Import Types */
+import { DigitalMedia } from "global/Types";
+
+/* Import Styling */
+import styles from 'components/specimen/specimen.module.scss';
+
+
+/* Props Typing */
+interface Props {
+    digitalMedia: DigitalMedia
+};
+
+
+const Video = (props: Props) => {
+    const { digitalMedia } = props;
+
+    /* Temporary */
+    let mediaUrl = "https://www.youtube.com/embed/4PY0uilPMfk";
+
+    if (mediaUrl.includes('youtube')) {
+        return (
+            <div className={`${styles.videoHover} w-100 h-100 position-relative transition`}>
+                <iframe className={`w-100 h-100`} src="https://www.youtube.com/embed/4PY0uilPMfk" />
+            </div>
+        );
+    } else {
+        return (
+            <div className={`${styles.videoHover} w-100 h-100 position-relative transition`}>
+                <video className="w-100 rounded">
+                    <source src={mediaUrl} type="video/mp4" />
+                    <source src={mediaUrl} type="video/ogg" />
+                    Your browser does not support direct video
+                </video>
+            </div>
+        );
+    }
+}
+
+export default Video;

--- a/src/components/specimen/components/contentBlocks/digitalMediaBlock/Video.tsx
+++ b/src/components/specimen/components/contentBlocks/digitalMediaBlock/Video.tsx
@@ -14,21 +14,18 @@ interface Props {
 const Video = (props: Props) => {
     const { digitalMedia } = props;
 
-    /* Temporary */
-    let mediaUrl = "https://www.youtube.com/embed/4PY0uilPMfk";
-
-    if (mediaUrl.includes('youtube')) {
+    if (digitalMedia.mediaUrl.includes('youtube')) {
         return (
             <div className={`${styles.videoHover} w-100 h-100 position-relative transition`}>
-                <iframe className={`w-100 h-100`} src="https://www.youtube.com/embed/4PY0uilPMfk" />
+                <iframe className={`w-100 h-100`} src={digitalMedia.mediaUrl} />
             </div>
         );
     } else {
         return (
             <div className={`${styles.videoHover} w-100 h-100 position-relative transition`}>
                 <video className="w-100 rounded">
-                    <source src={mediaUrl} type="video/mp4" />
-                    <source src={mediaUrl} type="video/ogg" />
+                    <source src={digitalMedia.mediaUrl} type="video/mp4" />
+                    <source src={digitalMedia.mediaUrl} type="video/ogg" />
                     Your browser does not support direct video
                 </video>
             </div>

--- a/src/components/specimen/specimen.module.scss
+++ b/src/components/specimen/specimen.module.scss
@@ -262,12 +262,39 @@
 }
 
 /* Digital Media Block */
-.digitalMediaImagesBlock {
-    height: 35%;
+.digitalMediaTitle {
+    font-size: 18px;
 }
 
-.digitalMediaTitle {
-    font-size: 15px;
+.imageHover {
+    opacity: 0;
+}
+
+.imageHover:hover {
+    opacity: 1;
+    background-color: rgb(51, 51, 51, 0.25);
+}
+
+.videoHover {
+    z-index: 2;
+}
+
+.videoHover:hover {
+    width: 150% !important;
+    height: 130% !important;
+    transition-delay: 2s;
+}
+
+.fileBlock {
+    border: 1px solid var(--secondary);
+}
+
+.fileIcon {
+    font-size: 20px;
+}
+
+.fileTitle {
+    font-size: 13px;
 }
 
 .digitalMediaImagesSlider {


### PR DESCRIPTION
PR adds templates for images, videos, audio and other media in the shape of files to the Digital Media tab of the Specimen page. Images have been reworked to align vertically (not horizontal in a slider anymore), and include a link to the digital media page. Videos are included and can either can loaded from an external source with the video element, or using an iframe for youtube videos. A custom audio player has been implemented for playing audio. This audio player can be styled freely and should remain the same across different browsers. Lastly, other media is currently housed under the 'other media' category, simply being displayed using a file icon and the name of the media object.

Adds:
- Image type template Specimen Page
- Video type template Specimen Page
- Audio type template Specimen Page
- File type template Specimen Page
- Audio player component