### PR TITLE
Download specimen

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,5 @@
     "@types/openseadragon": "^3.0.6",
     "@types/react-datepicker": "^4.8.0",
     "@types/validator": "^13.7.17"
-  },
-  "proxy": "https://sandbox.dissco.tech"
+  }
 }

--- a/src/components/annotate/sidePanel/AnnotationForm.tsx
+++ b/src/components/annotate/sidePanel/AnnotationForm.tsx
@@ -136,12 +136,12 @@ const AnnotationForm = (props: Props) => {
                             {/* Motivation */}
                             <Row className="mt-3">
                                 <Col>
-                                    <p className="formFieldTitle pb-1"> Motivation type </p>
+                                    <p className="formFieldTitle pb-1"> Annotation type </p>
                                     <Field name="motivation" as="select"
                                         className="formField w-100" disabled={!isEmpty(editAnnotation)}
                                     >
                                         <option value="" disabled={true}>
-                                            Select motivation
+                                            Select annotation type
                                         </option>
 
                                         {Object.keys(annotationMotivations).map((motivation) => {

--- a/src/components/annotate/sidePanel/AnnotationsOverview.tsx
+++ b/src/components/annotate/sidePanel/AnnotationsOverview.tsx
@@ -18,9 +18,14 @@ import annotationMotivationsSource from 'sources/annotationMotivations.json';
 /* Import Styles */
 import styles from 'components/annotate/annotate.module.scss';
 
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+
 /* Import Components */
 import Annotation from './Annotation';
 import ActionsDropdown from 'components/general/actionsDropdown/ActionsDropdown';
+import Tooltip from 'components/general/tooltip/Tooltip';
 
 
 /* Props Typing */
@@ -98,7 +103,13 @@ const AnnotationsOverview = (props: Props) => {
                     {/* Filters and sorting */}
                     <Row className="sidePanelFilters mt-4">
                         <Col>
-                            <p className="fw-lightBold pb-2"> Motivation type </p>
+                            <p className="fw-lightBold pb-2"> Annotation type
+                                <Tooltip text="Reason for creating an annotation" placement="top">
+                                    <span className="ms-2">
+                                        <FontAwesomeIcon icon={faInfoCircle} />
+                                    </span>
+                                </Tooltip>
+                            </p>
 
                             <ActionsDropdown value={motivationFilter}
                                 actions={motivationActions}

--- a/src/components/general/header/components/IntroTopics.tsx
+++ b/src/components/general/header/components/IntroTopics.tsx
@@ -13,10 +13,6 @@ import { Dict } from 'global/Types';
 /* Import Styles */
 import styles from '../header.module.scss';
 
-/* Import Icons */
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCompass } from '@fortawesome/free-solid-svg-icons';
-
 
 /* Props Typing */
 interface Props {

--- a/src/components/general/header/components/IntroTopics.tsx
+++ b/src/components/general/header/components/IntroTopics.tsx
@@ -20,7 +20,7 @@ import { faCompass } from '@fortawesome/free-solid-svg-icons';
 
 /* Props Typing */
 interface Props {
-    introTopics: {intro: string, title: string}[]
+    introTopics: { intro: string, title: string }[]
 };
 
 
@@ -65,10 +65,11 @@ const IntroTopics = (props: Props) => {
 
     return (
         <div className="position-relative">
-            <FontAwesomeIcon icon={faCompass}
-                className="c-pointer"
+            <button type="button" className="primaryButton px-2 py-1"
                 onClick={() => introTopics.length > 1 ? setDropdown(true) : dispatch(setIntroTopic(introTopics[0].intro))}
-            />
+            >
+                Take a tour
+            </button>
 
             {/* Intro Topic options, if there are multiple options */}
             {introTopics.length > 1 &&

--- a/src/components/home/components/specimenTypes/SpecimenTypeFilters.tsx
+++ b/src/components/home/components/specimenTypes/SpecimenTypeFilters.tsx
@@ -39,6 +39,7 @@ const SpecimenTypeFilters = () => {
             Palaeontology: false,
             Other: false,
             Environment: false,
+            Geology: false,
             EarthSystem: false,
             Astrogeology: false
         },
@@ -187,11 +188,11 @@ const SpecimenTypeFilters = () => {
                                             />
                                         </Col>
                                         <Col md={{ span: 4 }} className="px-2">
-                                            <FilterBlock type="EarthSystem"
-                                                title="Earth System"
+                                            <FilterBlock type="Geology"
+                                                title="Earth Geology"
                                                 subTitle="Geology"
-                                                discipline={disciplines['Earth System']}
-                                                ToggleFilterType={() => setFieldValue('disciplines.EarthSystem', !values.disciplines.EarthSystem)}
+                                                discipline={disciplines['Geology']}
+                                                ToggleFilterType={() => setFieldValue('disciplines.Geology', !values.disciplines.Geology)}
                                             />
                                         </Col>
                                         <Col md={{ span: 4 }} className="ps-2">

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -202,9 +202,9 @@ const Specimen = () => {
             <Row>
                 <Col className={classHeadCol}>
                     <Header introTopics={[
-                        {intro: 'specimen', title: 'About This Page'},
-                        {intro: 'annotate', title: 'Using Annotations'},
-                        {intro: 'MAS', title: 'Machine Annotation Services'}
+                        { intro: 'specimen', title: 'About This Page' },
+                        { intro: 'annotate', title: 'Using Annotations' },
+                        { intro: 'MAS', title: 'Machine Annotation Services' }
                     ]} />
 
                     <SpecimenSteps SetSelectedTab={(tabIndex: number) => setSelectedTab(tabIndex)} />
@@ -231,7 +231,7 @@ const Specimen = () => {
                                                 <IDCard />
                                             </Col>
                                             <Col lg={{ span: 9 }} className="contentBlock ps-4 h-100 mt-4 m-lg-0">
-                                                <ContentBlock selectedTab={selectedTab} 
+                                                <ContentBlock selectedTab={selectedTab}
                                                     SetSelectedTab={(tabIndex: number) => setSelectedTab(tabIndex)}
                                                 />
                                             </Col>

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -56,7 +56,7 @@ const TitleBar = (props: Props) => {
         /* Create and click on link to download file */
         const link = document.createElement("a");
         link.href = URL.createObjectURL(jsonFile);
-        link.download = `${specimen.specimenName}.json`;
+        link.download = `${specimen.id.replace('https://hdl.handle.net/', '')}_${specimen.version}.json`;
 
         link.click();
     }

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -41,8 +41,25 @@ const TitleBar = (props: Props) => {
     const specimenActions = [
         { value: 'json', label: 'View JSON' },
         { value: 'sidePanel', label: 'View all Annotations' },
-        { value: 'automatedAnnotations', label: 'Trigger Automated Annotations', isDisabled: !KeycloakService.IsLoggedIn() }
+        { value: 'automatedAnnotations', label: 'Trigger Automated Annotations', isDisabled: !KeycloakService.IsLoggedIn() },
+        { value: 'download', label: 'Download as JSON' }
     ];
+
+    /* Function for downloading a Specimen as JSON */
+    const DownloadSpecimen = () => {
+        /* Parse Specimen object to JSON */
+        const jsonSpecimen = JSON.stringify(specimen);
+
+        /* Create JSON file */
+        const jsonFile = new Blob([jsonSpecimen], { type: "text/plain" });
+
+        /* Create and click on link to download file */
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(jsonFile);
+        link.download = `${specimen.specimenName}.json`;
+
+        link.click();
+    }
 
     /* Function for executing Specimen Actions */
     const SpecimenActions = (action: string) => {
@@ -61,6 +78,11 @@ const TitleBar = (props: Props) => {
 
                 /* Open MAS Modal */
                 ToggleAutomatedAnnotations();
+
+                return;
+            case 'download':
+                /* Download Specimen as JSON */
+                DownloadSpecimen();
 
                 return;
             default:

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -51,7 +51,7 @@ const TitleBar = (props: Props) => {
         const jsonSpecimen = JSON.stringify(specimen);
 
         /* Create JSON file */
-        const jsonFile = new Blob([jsonSpecimen], { type: "text/plain" });
+        const jsonFile = new Blob([jsonSpecimen], { type: "application/json" });
 
         /* Create and click on link to download file */
         const link = document.createElement("a");

--- a/src/components/specimen/steps/AnnotateSteps.tsx
+++ b/src/components/specimen/steps/AnnotateSteps.tsx
@@ -223,7 +223,7 @@ const AnnotateSteps = (props: Props) => {
 
                             resolve();
                         } else if (nextIndex === 14) {
-                            /* On step 15: Set edit annotation with motivation type */
+                            /* On step 15: Set edit annotation with annotation type */
                             dispatch(setEditAnnotation(dummyAnnotation));
                             dispatch(setAnnotationFormToggle(true));
 

--- a/src/sources/introText/specimen.json
+++ b/src/sources/introText/specimen.json
@@ -16,7 +16,7 @@
         "First off, where do these annotations hide? Well they are kept in a separate side panel which is disabled on default. There are multiple ways to trigger the annotation side panel. The most generic method is to select ‘view all annotations’ from the actions dropdown.",
         "Select ‘view all annotation’ from the actions dropdown.",
         "This is the annotations side panel. As you can see, annotations might pop up already depending on whether the specimen you are looking at has annotations or not. This side panel contains all functionality related to annotations and can show up in more places than just the specimen page.",
-        "You can filter on motivation type and also order displayed annotations, for example by creation date. Motivation types describe the purpose of annotations. Current motivations include: commenting, linking, adding, correcting and quality flagging.",
+        "You can filter on annotation type and also order displayed annotations, for example by creation date. Annotation types describe the purpose of annotations. Current motivations include: commenting, linking, adding, correcting and quality flagging.",
         "To hide the side panel, click on this arrow pointing to the left at the top left corner.",
         "As mentioned, there are multiple methods for triggering the annotations side panel. Another method for triggering the side panel, for a specific property of a specimen, is by selecting that property from the view. This is a useful method for when you only want to see annotations made for that property, or if you want to create an annotation on that property.",
         "Let’s trigger the annotations side panel for the scientific name only. We can achieve this by clicking on the scientific name property in the ID card.",
@@ -26,7 +26,7 @@
         "To add new annotations, you need to be logged into your DiSSCo account. A button will appear at the bottom of the side panel saying ‘add annotation’. Click on this button to display the annotation form.",
         "Using this form, you can add annotations.",
         "First you can choose a specimen property or add an annotation on the whole specimen. The difference is that a property specific annotation will show up in the side panel when an user selects the property from the view, while annotations on the whole specimen only show up in the total overview.",
-        "Next, select one of the available motivation types. Selecting one will trigger the remaining fields of the form. These fields are directly influenced by the motivation type as not all are required with every type.",
+        "Next, select one of the available annotation types. Selecting one will trigger the remaining fields of the form. These fields are directly influenced by the annotation type as not all are required with every type.",
         "After filling in these fields with your values, save the annotation by clicking on the ‘save’ button. This will save your annotation and redirect you back to the overview, highlighting the new annotation.",
         "To edit one of your existing annotations, click on the pencil icon.",
         "To delete one of your existing annotations, click on the trash can icon."


### PR DESCRIPTION
PR adds download option for Specimen and changes several small things for improving the user experience. It changes the Earth System topic discipline to geology. Adds a 'take a tour' button to the header to initiate a tour rather than the compass icon. Changes the downloaded specimen file name to be the PID with the version attached. Lastly, changes annotation motivation to annotation type because the term motivation would be too vague.