### PR TITLE
Scale Specimen ID Card and Text / change the Digital Specimen and Med…

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,7 +20,7 @@
 /* Global Styling */
 html {
   height: 100vh;
-  font-size: 16px;
+  font-size: 0.85vw;
 }
 
 body {
@@ -100,23 +100,23 @@ p {
 
 /* Font sizes, default is 16px */
 .fs-1 {
-  font-size: 40px !important;
+  font-size: 2.5rem !important;
 }
 
 .fs-2 {
-  font-size: 24px !important;
+  font-size: 1.5rem !important;
 }
 
 .fs-3 {
-  font-size: 18px !important;
+  font-size: 1.125rem !important;
 }
 
 .fs-4 {
-  font-size: 14px !important;
+  font-size: 0.875rem !important;
 }
 
 .fs-5 {
-  font-size: 12px !important;
+  font-size: 0.75rem !important;
 }
 
 /* Color */
@@ -284,6 +284,7 @@ p {
   border-radius: 999px;
   transition: 0.4s;
   font-weight: 500;
+  font-size: 1rem;
 }
 
 .primaryButton.active {
@@ -313,6 +314,7 @@ p {
   border-radius: 999px;
   transition: 0.4s;
   font-weight: 500;
+  font-size: 1rem;
 }
 
 .secondaryButton:hover {
@@ -326,6 +328,7 @@ p {
   border-radius: 999px;
   transition: 0.4s;
   font-weight: 500;
+  font-size: 1rem;
 }
 
 .accentButton:hover {
@@ -339,6 +342,7 @@ p {
   border-radius: 4px;
   transition: 0.4s;
   font-weight: 500;
+  font-size: 1rem;
 }
 
 .removeButton:hover {
@@ -437,6 +441,11 @@ li.page-item.active .page-link {
   -ms-user-select: none;
   -o-user-select: none;
   user-select: none;
+}
+
+/* React Tabs overwrite */
+.tab {
+  font-size: 0.875rem;
 }
 
 

--- a/src/App.css
+++ b/src/App.css
@@ -284,7 +284,6 @@ p {
   border-radius: 999px;
   transition: 0.4s;
   font-weight: 500;
-  font-size: 1rem;
 }
 
 .primaryButton.active {
@@ -314,7 +313,6 @@ p {
   border-radius: 999px;
   transition: 0.4s;
   font-weight: 500;
-  font-size: 1rem;
 }
 
 .secondaryButton:hover {
@@ -328,7 +326,6 @@ p {
   border-radius: 999px;
   transition: 0.4s;
   font-weight: 500;
-  font-size: 1rem;
 }
 
 .accentButton:hover {
@@ -342,7 +339,6 @@ p {
   border-radius: 4px;
   transition: 0.4s;
   font-weight: 500;
-  font-size: 1rem;
 }
 
 .removeButton:hover {

--- a/src/App.css
+++ b/src/App.css
@@ -384,7 +384,7 @@ p {
   margin: 0;
 }
 
-/* Tabs */
+/* React Tabs overwrite */
 .tabsList {
   padding: 0;
 }
@@ -392,7 +392,7 @@ p {
 .tab {
   background-color: #E6E2F1;
   border-radius: 999px;
-  font-size: 15px;
+  font-size: 0.875rem;
   padding-left: 2%;
   padding-right: 2%;
   margin-right: 1%;
@@ -442,12 +442,6 @@ li.page-item.active .page-link {
   -o-user-select: none;
   user-select: none;
 }
-
-/* React Tabs overwrite */
-.tab {
-  font-size: 0.875rem;
-}
-
 
 /* Mobile classes */
 .mobileTitle {

--- a/src/api/digitalMedia/FilterDigitalMedia.ts
+++ b/src/api/digitalMedia/FilterDigitalMedia.ts
@@ -11,8 +11,8 @@ const FilterDigitalMedia = (digitalMediaItem: DigitalMedia) => {
 
     let digitalMediaItemProperties: Dict = {};
 
-    if (!digitalMediaItem.data) {
-        digitalMediaItem.data = {};
+    if (!digitalMediaItem.digitalEntity.data) {
+        digitalMediaItem.digitalEntity.data = {};
     }
 
     if (digitalMediaItem) {
@@ -22,9 +22,9 @@ const FilterDigitalMedia = (digitalMediaItem: DigitalMedia) => {
             if (property in digitalMediaItem) {
                 propertyInfo = { ...DigitalMediaFilterLayer[property as property], ...{ value: digitalMediaItem[property as keyof DigitalMedia], } };
             } else if (`dwc:${property}` in digitalMediaItem) {
-                propertyInfo = { ...DigitalMediaFilterLayer[property as property], ...{ value: digitalMediaItem[`dwc:${property}`] } };
+                propertyInfo = { ...DigitalMediaFilterLayer[property as property], ...{ value: digitalMediaItem.digitalEntity[`dwc:${property}`] } };
             } else if (`dcterms:${property}` in digitalMediaItem) {
-                propertyInfo = { ...DigitalMediaFilterLayer[property as property], ...{ value: digitalMediaItem[`dcterms:${property}`] } };
+                propertyInfo = { ...DigitalMediaFilterLayer[property as property], ...{ value: digitalMediaItem.digitalEntity[`dcterms:${property}`] } };
             } else {
                 let defaultValue: any = "Undefined";
 

--- a/src/api/specimen/GetRecentSpecimens.ts
+++ b/src/api/specimen/GetRecentSpecimens.ts
@@ -32,7 +32,7 @@ const GetRecentSpecimens = async (pageSize: number, pageNumber?: number) => {
         }
 
         data.data.forEach((dataRow) => {
-            recentSpecimens.push(dataRow.attributes.digitalSpecimen as DigitalSpecimen);
+            recentSpecimens.push(dataRow.attributes as DigitalSpecimen);
         });
     } catch (error) {
         console.warn(error);

--- a/src/api/specimen/GetSpecimen.ts
+++ b/src/api/specimen/GetSpecimen.ts
@@ -28,7 +28,7 @@ const GetSpecimen = async (handle: string, version?: string) => {
             const data: JSONResult = result.data;
 
             /* Set Digital Specimen */
-            specimen = data.data.attributes.digitalSpecimen as DigitalSpecimen;
+            specimen = data.data.attributes as DigitalSpecimen;
         } catch (error) {
             console.warn(error);
         }

--- a/src/api/specimen/GetSpecimenDigitalMedia.ts
+++ b/src/api/specimen/GetSpecimenDigitalMedia.ts
@@ -22,7 +22,7 @@ const GetSpecimenDigitalMedia = async (handle: string) => {
             const data: JSONResultArray = result.data;
 
             data.data.forEach((dataRow) => {
-                specimenDigitalMedia.push(dataRow.attributes.digitalEntity as DigitalMedia);
+                specimenDigitalMedia.push(dataRow.attributes as DigitalMedia);
             });
         } catch (error) {
             console.warn(error);

--- a/src/api/specimen/GetSpecimenFull.ts
+++ b/src/api/specimen/GetSpecimenFull.ts
@@ -2,12 +2,13 @@
 import axios from 'axios';
 
 /* Import Types */
-import { DigitalSpecimen, DigitalMedia, Annotation, SpecimenAnnotations, JSONResult } from 'app/Types';
+import { DigitalSpecimen as DigitalSpecimenObject, DigitalMedia, Annotation, SpecimenAnnotations, JSONResult } from 'app/Types';
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
 
 
 const GetSpecimenFull = async (handle: string) => {
     if (handle) {
-        let specimen = {} as DigitalSpecimen;
+        let specimen = {} as DigitalSpecimenObject;
         let specimenDigitalMedia = [] as DigitalMedia[];
         let specimenAnnotations = {} as SpecimenAnnotations;
 
@@ -22,12 +23,19 @@ const GetSpecimenFull = async (handle: string) => {
             const data: JSONResult = result.data;
 
             specimen = {
-                ...data.data.attributes.digitalSpecimen,
-                originalData: data.data.attributes.originalData
-            } as DigitalSpecimen;
+                digitalSpecimen: data.data.attributes.digitalSpecimen as DigitalSpecimen,
+                originalData: data.data.attributes.originalData ?? {}
+            }
 
             /* Set Specimen Digital Media */
-            specimenDigitalMedia = data.data.attributes.digitalMediaObjects as DigitalMedia[];
+            if (data.data.attributes.digitalMediaObjects) {
+                data.data.attributes.digitalMediaObjects.forEach((digitalMediaObject) => {
+                    specimenDigitalMedia.push({
+                        digitalEntity: digitalMediaObject.digitalMediaObject.digitalEntity,
+                        originalData: digitalMediaObject.digitalMediaObject.originalData
+                    });
+                });
+            }
 
             /* Set Specimen Annotations with Model */
             const annotations: Annotation[] = data.data.attributes.annotations as Annotation[];

--- a/src/api/specimen/SearchSpecimens.ts
+++ b/src/api/specimen/SearchSpecimens.ts
@@ -46,7 +46,7 @@ const SearchSpecimens = async (searchFilters: SearchFilter[], pageSize: number, 
             links = data.links;
 
             data.data.forEach((dataRow) => {
-                searchResults.push(dataRow.attributes.digitalSpecimen as DigitalSpecimen);
+                searchResults.push(dataRow.attributes as DigitalSpecimen);
             });
             
             /* Set total records if present */

--- a/src/app/Types.ts
+++ b/src/app/Types.ts
@@ -25,8 +25,11 @@ export type JSONResult = {
         attributes: {
             digitalSpecimen?: DigitalSpecimenType,
             digitalEntity?: DigitalEntity,
-            digitalMediaObjects?: DigitalEntity[],
             originalData?: Dict,
+            digitalMediaObjects?: {
+                digitalMediaObject: DigitalMedia,
+                annotations: Annotation[]
+            }[],
             annotations?: Annotation[],
             [property: string]: any
         }
@@ -46,8 +49,8 @@ export type JSONResultArray = {
         attributes: {
             digitalSpecimen?: DigitalSpecimenType,
             digitalEntity?: DigitalEntity,
-            digitalMediaObjects?: DigitalEntity[],
             originalData?: Dict,
+            digitalMediaObjects?: DigitalMedia[],
             annotations?: Annotation[]
         }
     }[],
@@ -75,7 +78,8 @@ export interface SearchFilter {
 }
 
 /* Specimen Types */
-export interface DigitalSpecimen extends DigitalSpecimenType {
+export interface DigitalSpecimen {
+    digitalSpecimen: DigitalSpecimenType,
     originalData: Dict
 }
 
@@ -84,7 +88,8 @@ export interface SpecimenAnnotations {
 };
 
 /* Digital Media Types */
-export interface DigitalMedia extends DigitalEntity {
+export interface DigitalMedia {
+    digitalEntity: DigitalEntity
     originalData: Dict
 }
 

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -239,82 +239,84 @@ const DigitalMedia = () => {
     });
 
     return (
-        <div className="d-flex flex-column min-vh-100 overflow-hidden">
-            <Row>
+        <div className="h-100 overflow-hidden">
+            <Row className="h-100">
                 <Col className={classHeadCol}>
-                    <Header />
+                    <div className="h-100 d-flex flex-column">
+                        <Header />
 
-                    {Object.keys(digitalMedia).length > 0 &&
-                        <Container fluid className={`${styles.content} pt-5`}>
-                            <Row className="h-100">
-                                <Col className={`${classDigitalMediaContent} h-100 transition`}>
-                                    <div className="h-100 d-flex flex-column">
-                                        <Row className={styles.titleBar}>
-                                            <Col>
-                                                <TitleBar />
-                                            </Col>
-                                        </Row>
-                                        <Row className="py-4 flex-grow-1 overflow-scroll overflow-lg-hidden">
-                                            <Col lg={{ span: 3 }} className="h-100">
-                                                <IDCard />
-                                            </Col>
-                                            <Col lg={{ span: 9 }} className="ps-4 h-100 mt-4 m-lg-0">
-                                                <div className="h-100 d-flex flex-column">
-                                                    <Row>
-                                                        <Col className="col-md-auto">
-                                                            <VersionSelect target={digitalMedia.digitalEntity}
-                                                                versions={digitalMediaVersions}
-                                                            />
-                                                        </Col>
-                                                        <Col />
-                                                        {(digitalMedia.digitalEntity.type === '2DImageObject' && KeycloakService.IsLoggedIn()) &&
-                                                            <Col className="col-md-auto pe-0">
-                                                                <button type="button"
-                                                                    className={classImageAnnotateButton}
-                                                                    onClick={() => {
-                                                                        if (annotoriousMode === 'cursor') {
-                                                                            dispatch(setAnnotoriousMode('rectangle'))
-                                                                        } else {
-                                                                            dispatch(setAnnotoriousMode('cursor'))
-                                                                        }
-                                                                    }
-                                                                    }
-                                                                >
-                                                                    <FontAwesomeIcon icon={faVectorSquare}
-                                                                        className="fs-3"
-                                                                    />
-                                                                    <span className="fs-4 ms-2"> Make annotation </span>
-                                                                </button>
+                        {Object.keys(digitalMedia).length > 0 &&
+                            <Container fluid className="flex-grow-1 overflow-hidden pt-5">
+                                <Row className="h-100">
+                                    <Col className={`${classDigitalMediaContent} h-100 transition`}>
+                                        <div className="h-100 d-flex flex-column">
+                                            <Row className={styles.titleBar}>
+                                                <Col>
+                                                    <TitleBar />
+                                                </Col>
+                                            </Row>
+                                            <Row className="py-4 flex-grow-1 overflow-scroll overflow-lg-hidden">
+                                                <Col lg={{ span: 3 }} className="h-100">
+                                                    <IDCard />
+                                                </Col>
+                                                <Col lg={{ span: 9 }} className="ps-4 h-100 mt-4 m-lg-0">
+                                                    <div className="h-100 d-flex flex-column">
+                                                        <Row>
+                                                            <Col className="col-md-auto">
+                                                                <VersionSelect target={digitalMedia.digitalEntity}
+                                                                    versions={digitalMediaVersions}
+                                                                />
                                                             </Col>
-                                                        }
-                                                        <Col className="col-md-auto">
-                                                            <ActionsDropdown actions={digitalMediaActions}
-                                                                Actions={(action: string) => DigitalMediaActions(action)}
-                                                            />
-                                                        </Col>
-                                                    </Row>
-                                                    <Row className="flex-grow-1 overflow-hidden mt-3">
-                                                        <Col className="h-100 pb-2">
-                                                            <DigitalMediaFrame
-                                                                UpdateAnnotationsSource={(annotation: Annotation, remove: boolean) => UpdateAnnotationsSource(annotation, remove)}
-                                                            />
-                                                        </Col>
-                                                    </Row>
-                                                    <Row className={styles.digitalMediaListBlock}>
-                                                        <Col className="h-100">
-                                                            <DigitalMediaList />
-                                                        </Col>
-                                                    </Row>
-                                                </div>
-                                            </Col>
-                                        </Row>
-                                    </div>
-                                </Col>
-                            </Row>
-                        </Container >
-                    }
+                                                            <Col />
+                                                            {(digitalMedia.digitalEntity.type === '2DImageObject' && KeycloakService.IsLoggedIn()) &&
+                                                                <Col className="col-md-auto pe-0">
+                                                                    <button type="button"
+                                                                        className={classImageAnnotateButton}
+                                                                        onClick={() => {
+                                                                            if (annotoriousMode === 'cursor') {
+                                                                                dispatch(setAnnotoriousMode('rectangle'))
+                                                                            } else {
+                                                                                dispatch(setAnnotoriousMode('cursor'))
+                                                                            }
+                                                                        }
+                                                                        }
+                                                                    >
+                                                                        <FontAwesomeIcon icon={faVectorSquare}
+                                                                            className="fs-3"
+                                                                        />
+                                                                        <span className="fs-4 ms-2"> Make annotation </span>
+                                                                    </button>
+                                                                </Col>
+                                                            }
+                                                            <Col className="col-md-auto">
+                                                                <ActionsDropdown actions={digitalMediaActions}
+                                                                    Actions={(action: string) => DigitalMediaActions(action)}
+                                                                />
+                                                            </Col>
+                                                        </Row>
+                                                        <Row className="flex-grow-1 overflow-hidden mt-3">
+                                                            <Col className="h-100 pb-2">
+                                                                <DigitalMediaFrame
+                                                                    UpdateAnnotationsSource={(annotation: Annotation, remove: boolean) => UpdateAnnotationsSource(annotation, remove)}
+                                                                />
+                                                            </Col>
+                                                        </Row>
+                                                        <Row className={styles.digitalMediaListBlock}>
+                                                            <Col className="h-100">
+                                                                <DigitalMediaList />
+                                                            </Col>
+                                                        </Row>
+                                                    </div>
+                                                </Col>
+                                            </Row>
+                                        </div>
+                                    </Col>
+                                </Row>
+                            </Container >
+                        }
 
-                    <Footer />
+                        <Footer />
+                    </div>
                 </Col>
 
                 {/* Annotation Tools */}

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -72,7 +72,7 @@ const DigitalMedia = () => {
         const digitalMediaId = `${params.prefix}/${params.suffix}`;
 
         /* Fetch Digital Media if not present or not equal to params ID; if version has changed, refetch Digital Media with version */
-        if (isEmpty(digitalMedia) || digitalMedia['ods:id'].replace('https://doi.org/', '') !== digitalMediaId) {
+        if (isEmpty(digitalMedia) || digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '') !== digitalMediaId) {
             /* Check for version in url */
             let version: string = '';
 
@@ -84,14 +84,14 @@ const DigitalMedia = () => {
                 dispatch(setDigitalMedia(digitalMedia));
 
                 /* Get Digital Media annotations */
-                GetDigitalMediaAnnotations(digitalMedia['ods:id'].replace('https://doi.org/', '')).then((annotations) => {
+                GetDigitalMediaAnnotations(digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')).then((annotations) => {
                     dispatch(setDigitalMediaAnnotations(annotations));
                 }).catch(error => {
                     console.warn(error);
                 });
 
                 /* Get Digital Media versions */
-                GetDigitalMediaVersions(digitalMedia['ods:id'].replace('https://doi.org/', '')).then((versions) => {
+                GetDigitalMediaVersions(digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')).then((versions) => {
                     dispatch(setDigitalMediaVersions(versions));
                 }).catch(error => {
                     console.warn(error);
@@ -99,9 +99,9 @@ const DigitalMedia = () => {
             }).catch(error => {
                 console.warn(error);
             });
-        } else if (params.version && digitalMedia['ods:version'].toString() !== params.version) {
+        } else if (params.version && digitalMedia.digitalEntity['ods:version'].toString() !== params.version) {
             /* Get Specimen with version */
-            const originalVersion = digitalMedia.version;
+            const originalVersion = digitalMedia.digitalEntity.version;
 
             GetDigitalMedia(`${params['prefix']}/${params['suffix']}`, params.version).then((digitalMedia) => {
                 /* Set Digital Media */
@@ -126,7 +126,7 @@ const DigitalMedia = () => {
     const DigitalMediaActions = (action: string) => {
         switch (action) {
             case 'json':
-                window.open(`${process.env.REACT_APP_HOST_URL}/api/v1/digitalmedia/${digitalMedia['ods:id'].replace('https://doi.org/', '')}`);
+                window.open(`${process.env.REACT_APP_HOST_URL}/api/v1/digitalmedia/${digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')}`);
 
                 return;
             case 'sidePanel':
@@ -135,7 +135,7 @@ const DigitalMedia = () => {
                 return;
             case 'automatedAnnotations':
                 /* Set MAS Target */
-                dispatch(setMASTarget(digitalMedia));
+                dispatch(setMASTarget(digitalMedia.digitalEntity));
 
                 /* Open MAS Modal */
                 setAutomatedAnnotationsToggle(true);
@@ -199,7 +199,7 @@ const DigitalMedia = () => {
 
         dispatch(setAnnotateTarget({
             property: targetProperty ?? '',
-            target: digitalMedia,
+            target: digitalMedia.digitalEntity,
             targetType: 'digital_media',
             annotations: allAnnotations
         }));
@@ -210,7 +210,7 @@ const DigitalMedia = () => {
     /* Function for refreshing Annotations */
     const RefreshAnnotations = (targetProperty?: string) => {
         /* Refetch Digital Media Annotations */
-        GetDigitalMediaAnnotations(digitalMedia['ods:id'].replace('https://doi.org/', '')).then((annotations) => {
+        GetDigitalMediaAnnotations(digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')).then((annotations) => {
             /* Show with refreshed Annotations */
             ShowWithAnnotations(annotations, targetProperty);
 
@@ -262,12 +262,12 @@ const DigitalMedia = () => {
                                                 <div className="h-100 d-flex flex-column">
                                                     <Row>
                                                         <Col className="col-md-auto">
-                                                            <VersionSelect target={digitalMedia}
+                                                            <VersionSelect target={digitalMedia.digitalEntity}
                                                                 versions={digitalMediaVersions}
                                                             />
                                                         </Col>
                                                         <Col />
-                                                        {(digitalMedia.type === '2DImageObject' && KeycloakService.IsLoggedIn()) &&
+                                                        {(digitalMedia.digitalEntity.type === '2DImageObject' && KeycloakService.IsLoggedIn()) &&
                                                             <Col className="col-md-auto pe-0">
                                                                 <button type="button"
                                                                     className={classImageAnnotateButton}

--- a/src/components/digitalMedia/components/IDCard/IDCard.tsx
+++ b/src/components/digitalMedia/components/IDCard/IDCard.tsx
@@ -26,7 +26,7 @@ const IDCard = () => {
             dispatch(setAnnotateTarget({
                 property,
                 motivation: '',
-                target: digitalMedia,
+                target: digitalMedia.digitalEntity,
                 targetType: 'digital_media',
                 annotations: digitalMediaAnnotations[property] ? digitalMediaAnnotations[property] : []
             }));
@@ -54,7 +54,7 @@ const IDCard = () => {
                                             <p> ID Card </p>
                                         </Col>
                                         <Col className="fs-4 c-secondary col-md-auto fw-lightBold">
-                                            <p> {digitalMedia['ods:id'].replace('https://doi.org/', '')} </p>
+                                            <p> {digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')} </p>
                                         </Col>
                                     </Row>
                                 </Card.Subtitle>
@@ -72,37 +72,37 @@ const IDCard = () => {
                                                 onClick={() => ToggleSidePanel('mediaUrl')}
                                             >
                                                 <span className="fw-lightBold m-0 h-50">Media URL</span>
-                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia['ac:accessUri']} </span>
+                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia.digitalEntity['ac:accessUri']} </span>
                                             </Col>
                                         </Row>
                                         <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
                                             <Col className="m-0 py-1">
                                                 <span className="fw-lightBold m-0 h-50">Title</span>
-                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia['dcterms:description']} </span>
+                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia.digitalEntity['dcterms:description']} </span>
                                             </Col>
                                         </Row>
                                         <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
                                             <Col className="m-0 py-1">
                                                 <span className="fw-lightBold m-0 h-50">Format</span>
-                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia['dcterms:format']} </span>
+                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia.digitalEntity['dcterms:format']} </span>
                                             </Col>
                                         </Row>
                                         <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
                                             <Col className={`${classPropertyBlockHover} rounded-c py-1`}>
                                                 <span className="fw-lightBold m-0 h-50">Type</span>
-                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia['dcterms:type']} </span>
+                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia.digitalEntity['dcterms:type']} </span>
                                             </Col>
                                         </Row>
                                         <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
                                             <Col className={`${classPropertyBlockHover} rounded-c py-1 text-truncate`}>
                                                 <span className="fw-lightBold m-0 h-50">Publisher</span>
-                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia['dwc:institutionName']} </span>
+                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia.digitalEntity['dwc:institutionName']} </span>
                                             </Col>
                                         </Row>
                                         <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
                                             <Col className={`${classPropertyBlockHover} rounded-c py-1`}>
                                                 <span className="fw-lightBold m-0 h-50">Rightsholder</span>
-                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia['dcterms:rightsHolder']} </span>
+                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia.digitalEntity['dcterms:rightsHolder']} </span>
                                             </Col>
                                         </Row>
                                         <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
@@ -110,7 +110,7 @@ const IDCard = () => {
                                                 onClick={() => ToggleSidePanel('dcterms:license')}
                                             >
                                                 <span className="fw-lightBold m-0 h-50">License</span>
-                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia['dcterms:license']} </span>
+                                                <br /> <span className="fs-4 m-0 h-50"> {digitalMedia.digitalEntity['dcterms:license']} </span>
                                             </Col>
                                         </Row>
                                     </Col>

--- a/src/components/digitalMedia/components/TitleBar.tsx
+++ b/src/components/digitalMedia/components/TitleBar.tsx
@@ -25,7 +25,7 @@ const TitleBar = () => {
     let icon: IconDefinition;
 
     /* Declaring icon based on Digital Media type */
-    switch (digitalMedia.type) {
+    switch (digitalMedia.digitalEntity.type) {
         case '2DImageObject':
             icon = faImage;
 
@@ -57,7 +57,7 @@ const TitleBar = () => {
                         <FontAwesomeIcon icon={icon} className={`${styles.digitalMediaTitle} c-primary`} />
                     </Col>
                     <Col>
-                        <h2 className={styles.digitalMediaTitle}> {digitalMedia['ods:id'].replace('https://doi.org/', '')} </h2>
+                        <h2 className={styles.digitalMediaTitle}> {digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')} </h2>
                     </Col>
                 </Row>
             </Col>

--- a/src/components/digitalMedia/components/digitalMedia/DigitalMediaFrame.tsx
+++ b/src/components/digitalMedia/components/digitalMedia/DigitalMediaFrame.tsx
@@ -31,10 +31,10 @@ const DigitalMediaFrame = (props: Props) => {
     /* Check for the type of Digital Media and set content appropiate to it */
     let digitalMediaContent;
 
-    switch (digitalMedia.type) {
+    switch (digitalMedia.digitalEntity.type) {
         case '2DImageObject':
             digitalMediaContent = <Annotorious>
-                <ImageViewer mediaUrl={digitalMedia['ac:accessUri']}
+                <ImageViewer mediaUrl={digitalMedia.digitalEntity['ac:accessUri']}
                     UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
                 />
             </Annotorious>
@@ -49,8 +49,8 @@ const DigitalMediaFrame = (props: Props) => {
 
             break;
         default:
-            if (digitalMedia['dcterms:format'] === 'application/json' || digitalMedia['dcterms:format'] === 'application/ld+json') {
-                digitalMediaContent = <IIIFViewer mediaUrl={digitalMedia['ac:accessUri']} />
+            if (digitalMedia.digitalEntity['dcterms:format'] === 'application/json' || digitalMedia.digitalEntity['dcterms:format'] === 'application/ld+json') {
+                digitalMediaContent = <IIIFViewer mediaUrl={digitalMedia.digitalEntity['ac:accessUri']} />
             } else {
                 digitalMediaContent = <File digitalMedia={digitalMedia} />
             }

--- a/src/components/digitalMedia/components/digitalMedia/DigitalMediaList.tsx
+++ b/src/components/digitalMedia/components/digitalMedia/DigitalMediaList.tsx
@@ -25,7 +25,7 @@ const DigitalMediaList = () => {
 
     /* Search and fetch all other Digital Media items from target specimen */
     useEffect(() => {
-        GetSpecimenDigitalMedia(digitalMedia['ods:id'].replace('https://doi.org/', '')).then((specimenDigitalMedia) => {
+        GetSpecimenDigitalMedia(digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')).then((specimenDigitalMedia) => {
             if (specimenDigitalMedia) {
                 setSpecimenDigitalMedia(specimenDigitalMedia);
             }
@@ -40,7 +40,7 @@ const DigitalMediaList = () => {
     if (specimenDigitalMedia) {
         specimenDigitalMedia.forEach((specimenDigitalMedia) => {
             digitalMediaItems.push(
-                <DigitalMediaListItem key={specimenDigitalMedia['ods:id']} specimenDigitalMedia={specimenDigitalMedia} />
+                <DigitalMediaListItem key={specimenDigitalMedia.digitalEntity['ods:id']} specimenDigitalMedia={specimenDigitalMedia} />
             );
         });
     }

--- a/src/components/digitalMedia/components/digitalMedia/DigitalMediaListItem.tsx
+++ b/src/components/digitalMedia/components/digitalMedia/DigitalMediaListItem.tsx
@@ -40,10 +40,10 @@ const DigitalMediaListItem = (props: Props) => {
     /* Check for the type of Digital Media and set content appropiate to it */
     let digitalMediaContent: React.ReactElement;
 
-    switch (specimenDigitalMedia.type) {
+    switch (specimenDigitalMedia.digitalEntity.type) {
         case '2DImageObject':
-            digitalMediaContent = <img src={specimenDigitalMedia['ac:accessUri']}
-                alt={`Broken ${specimenDigitalMedia.format} link`}
+            digitalMediaContent = <img src={specimenDigitalMedia.digitalEntity['ac:accessUri']}
+                alt={`Broken ${specimenDigitalMedia.digitalEntity.format} link`}
                 className="h-100 mx-auto d-flex justify-content-around align-items-center"
             />
 
@@ -63,7 +63,7 @@ const DigitalMediaListItem = (props: Props) => {
 
             break;
         default:
-            if (specimenDigitalMedia.format === 'application/json' || specimenDigitalMedia.format === 'application/ld+json') {
+            if (specimenDigitalMedia.digitalEntity.format === 'application/json' || specimenDigitalMedia.digitalEntity.format === 'application/ld+json') {
                 digitalMediaContent = <div className="w-100 h-100 d-flex justify-content-center align-items-center">
                     <img src={IIIFLogo} alt="IIIF Logo" />
                 </div>;
@@ -81,27 +81,27 @@ const DigitalMediaListItem = (props: Props) => {
     /* ClassName for a Digital Media List Item */
     const classDigitalMediaListItem = classNames({
         [`${styles.digitalMediaListItem} h-100 d-inline-block bgc-grey overflow-hidden`]: true,
-        [`${styles.hover}`]: hover && (specimenDigitalMedia.id !== digitalMedia.id)
+        [`${styles.hover}`]: hover && (specimenDigitalMedia.digitalEntity.id !== digitalMedia.digitalEntity.id)
     });
 
     /* ClassName for Dynamic Image Title */
     const classImageTitle = classNames({
         [`${styles.digitalMediaListItemTitle} start-0 top-0 end-0 bottom-0 m-auto c-white position-absolute text-center z-1 fw-bold transition opacity-0`]: true,
-        'opacity-100': digitalMedia.id === specimenDigitalMedia.id || hover
+        'opacity-100': digitalMedia.digitalEntity.id === specimenDigitalMedia.digitalEntity.id || hover
     });
 
     /* ClassName for Dynamic Backdrop */
     const classBackdrop = classNames({
-        'position-absolute bg-dark w-100 h-100 start-0 top-0 opacity-50 transition': digitalMedia.id === specimenDigitalMedia.id || hover
+        'position-absolute bg-dark w-100 h-100 start-0 top-0 opacity-50 transition': digitalMedia.digitalEntity.id === specimenDigitalMedia.digitalEntity.id || hover
     });
 
     return (
         <div className={`${classDigitalMediaListItem} position-relative px-1`}
-            onMouseEnter={() => { if (specimenDigitalMedia.id !== digitalMedia.id) { setHover(true) } }}
-            onMouseLeave={() => { if (specimenDigitalMedia.id !== digitalMedia.id) { setHover(false) } }}
+            onMouseEnter={() => { if (specimenDigitalMedia.digitalEntity.id !== digitalMedia.digitalEntity.id) { setHover(true) } }}
+            onMouseLeave={() => { if (specimenDigitalMedia.digitalEntity.id !== digitalMedia.digitalEntity.id) { setHover(false) } }}
             onClick={() => {
-                if (specimenDigitalMedia.id !== digitalMedia.id) {
-                    navigate(`/dm/${specimenDigitalMedia['ods:id'].replace('https://doi.org/', '')}`)
+                if (specimenDigitalMedia.digitalEntity.id !== digitalMedia.digitalEntity.id) {
+                    navigate(`/dm/${specimenDigitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')}`)
                 }
             }}
         >
@@ -109,7 +109,7 @@ const DigitalMediaListItem = (props: Props) => {
                 {digitalMediaContent}
 
                 <div className={classImageTitle}>
-                    {specimenDigitalMedia['dcterms:type'] && Capitalize(specimenDigitalMedia['dcterms:type'])}
+                    {specimenDigitalMedia.digitalEntity['dcterms:type'] && Capitalize(specimenDigitalMedia.digitalEntity['dcterms:type'])}
                 </div>
 
                 <div className={classBackdrop} />

--- a/src/components/digitalMedia/digitalMedia.module.scss
+++ b/src/components/digitalMedia/digitalMedia.module.scss
@@ -1,14 +1,9 @@
 /* Custom styling for digital specimen page */
 
-.content {
-    height: calc(100vh - 140px)
-}
-
 .sidePanel {
     height: 100vh;
     width: Calc(100% / 3);
 }
-
 
 /* Title Bar */
 .digitalMediaTitle {

--- a/src/components/general/actionsDropdown/ActionsDropdown.tsx
+++ b/src/components/general/actionsDropdown/ActionsDropdown.tsx
@@ -24,13 +24,13 @@ const ActionsDropdown = (props: Props) => {
             styles={{
                 control: provided => ({
                     ...provided, backgroundColor: backgroundColor ?? '#4d59a2', border: '1px solid #4d59a2',
-                    borderRadius: '999px', fontWeight: '500', fontSize: '15px'
+                    borderRadius: '999px', fontWeight: '500', fontSize: '0.875rem'
                 }),
                 menu: provided => ({
-                    ...provided, zIndex: 100000, fontSize: '15px', width: 'max-content',
+                    ...provided, zIndex: 100000, fontSize: '0.875rem', width: 'max-content',
                     position: 'absolute', right: '0', color: '#333333'
                 }),
-                dropdownIndicator: provided => ({ ...provided, color: color ?? 'white', fontSize: '15px' }),
+                dropdownIndicator: provided => ({ ...provided, color: color ?? 'white', fontSize: '0.875rem' }),
                 singleValue: provided => ({
                     ...provided, color: color ?? 'white'
                 })

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
@@ -10,7 +10,9 @@ import { useAppSelector } from 'app/hooks';
 import { getMASTarget } from 'redux/annotate/AnnotateSlice';
 
 /* Impor Types */
-import { DigitalSpecimen, DigitalMedia, Dict } from 'app/Types';
+import { Dict } from 'app/Types';
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
+import { DigitalEntity } from 'app/types/DigitalEntity';
 
 /* Import Styles */
 import styles from 'components/specimen/specimen.module.scss';
@@ -41,7 +43,7 @@ const AutomatedAnnotationsModal = (props: Props) => {
     const location = useLocation();
 
     /* Base variables */
-    const target: DigitalSpecimen | DigitalMedia = useAppSelector(getMASTarget);
+    const target: DigitalSpecimen | DigitalEntity = useAppSelector(getMASTarget);
     const [targetMAS, setTargetMAS] = useState<Dict[]>([]);
 
     /* OnLoad: Fetch Specimen MAS */

--- a/src/components/general/breadCrumbs/BreadCrumbs.tsx
+++ b/src/components/general/breadCrumbs/BreadCrumbs.tsx
@@ -61,7 +61,7 @@ const BreadCrumbs = () => {
             });
 
             breadCrumbs.push({
-                crumb: specimen['ods:id']
+                crumb: specimen.digitalSpecimen['ods:id']
             });
 
             break;
@@ -72,7 +72,7 @@ const BreadCrumbs = () => {
             });
 
             breadCrumbs.push({
-                crumb: digitalMedia['ods:id'].replace('https://doi.org/', '')
+                crumb: digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')
             });
     }
 

--- a/src/components/general/footer/footer.module.scss
+++ b/src/components/general/footer/footer.module.scss
@@ -1,5 +1,5 @@
 .footer {
-    height: 60px;
+    min-height: 3.375em;
 }
 
 .footer.home {

--- a/src/components/general/header/Header.tsx
+++ b/src/components/general/header/Header.tsx
@@ -44,7 +44,7 @@ const Header = (props: Props) => {
 
     /* ClassNames */
     const classHeader = classNames({
-        [`${styles.header}`]: true,
+        [`${styles.header} d-flex flex-column-reverse`]: true,
         [`${styles.home}`]: location.pathname === '/'
     });
 

--- a/src/components/general/header/header.module.scss
+++ b/src/components/general/header/header.module.scss
@@ -1,6 +1,5 @@
 /* Custom styling for Header Component */
 
-/* Generic */
 .header {
     min-height: 4.5em;
 }

--- a/src/components/general/header/header.module.scss
+++ b/src/components/general/header/header.module.scss
@@ -2,7 +2,7 @@
 
 /* Generic */
 .header {
-    height: 80px;
+    min-height: 4.5em;
 }
 
 .header.home {

--- a/src/components/general/mediaTypes/Audio.tsx
+++ b/src/components/general/mediaTypes/Audio.tsx
@@ -15,7 +15,7 @@ const Audio = (props: Props) => {
     const { digitalMedia } = props;
 
     return (
-        <AudioPlayer source={digitalMedia['ac:accessUri']} />
+        <AudioPlayer source={digitalMedia.digitalEntity['ac:accessUri']} />
     );
 }
 

--- a/src/components/general/mediaTypes/File.tsx
+++ b/src/components/general/mediaTypes/File.tsx
@@ -27,7 +27,7 @@ const File = (props: Props) => {
                     />
                 </Col>
                 <Col>
-                    <p className="fs-4"> {digitalMedia['ac:accessUri']} </p>
+                    <p className="fs-4"> {digitalMedia.digitalEntity['ac:accessUri']} </p>
                 </Col>
             </Row>
         </div>

--- a/src/components/general/mediaTypes/Image.tsx
+++ b/src/components/general/mediaTypes/Image.tsx
@@ -27,8 +27,8 @@ const Image = (props: Props) => {
 
     return (
         <div className="d-flex position-relative h-100 w-100 justify-content-center">
-            <img src={digitalMedia['ac:accessUri']}
-                alt={digitalMedia['dcterms:description']}
+            <img src={digitalMedia.digitalEntity['ac:accessUri']}
+                alt={digitalMedia.digitalEntity['dcterms:description']}
                 className={`${classSizeOrientation} rounded`}
             />
 
@@ -36,7 +36,7 @@ const Image = (props: Props) => {
                 <div className={`${styles.imageHover} opacity-0 position-absolute transition 
                         h-100 w-100 top-0 d-flex justify-content-center align-items-center c-pointer px-3`
                 }>
-                    <p className="fw-bold"> {digitalMedia['ods:id'].replace('https://doi.org/', '')} </p>
+                    <p className="fw-bold"> {digitalMedia.digitalEntity['ods:id'].replace('https://doi.org/', '')} </p>
                 </div>
             }
         </div>

--- a/src/components/general/mediaTypes/ImageViewer.tsx
+++ b/src/components/general/mediaTypes/ImageViewer.tsx
@@ -73,7 +73,7 @@ const ImageViewer = (props: Props) => {
 
             image.onload = () => resolve(image);
             image.onerror = reject;
-            image.src = digitalMedia['ac:accessUri'];
+            image.src = digitalMedia.digitalEntity['ac:accessUri'];
         }).then((image: any) => {
             setImage(image);
         
@@ -201,7 +201,7 @@ const ImageViewer = (props: Props) => {
                                 type: 'FragmentSelector',
                                 value: `xywh=pixel:${x},${y},${w},${h}`
                             },
-                            source: digitalMedia.mediaUrl
+                            source: digitalMedia.digitalEntity.mediaUrl
                         }
                     });
                 }
@@ -231,7 +231,7 @@ const ImageViewer = (props: Props) => {
                     values: values
                 },
                 target: {
-                    id: digitalMedia['ods:id'],
+                    id: digitalMedia.digitalEntity['ods:id'],
                     type: 'MediaObject',
                     selector: {
                         type: 'FragmentSelector',

--- a/src/components/general/mediaTypes/Video.tsx
+++ b/src/components/general/mediaTypes/Video.tsx
@@ -24,18 +24,18 @@ const Video = (props: Props) => {
         'position-relative transition': hoverEffect
     });
 
-    if (digitalMedia['ac:accessUri'].includes('youtube')) {
+    if (digitalMedia.digitalEntity['ac:accessUri'].includes('youtube')) {
         return (
             <div className={`${classVideoHover} w-100 h-100`}>
-                <iframe className={`w-100 h-100`} src={digitalMedia['ac:accessUri']} />
+                <iframe className={`w-100 h-100`} src={digitalMedia.digitalEntity['ac:accessUri']} />
             </div>
         );
     } else {
         return (
             <div className={`${classVideoHover} w-100 h-100`}>
                 <video className="w-100 rounded">
-                    <source src={digitalMedia['ac:accessUri']} type="video/mp4" />
-                    <source src={digitalMedia['ac:accessUri']} type="video/ogg" />
+                    <source src={digitalMedia.digitalEntity['ac:accessUri']} type="video/mp4" />
+                    <source src={digitalMedia.digitalEntity['ac:accessUri']} type="video/ogg" />
                     Your browser does not support direct video
                 </video>
             </div>

--- a/src/components/general/nomenclatural/ScientificName.tsx
+++ b/src/components/general/nomenclatural/ScientificName.tsx
@@ -16,7 +16,7 @@ const ScientificName = (props: Props) => {
     let scientificNameElement: ReactElement;
 
     /* Format Scientific Name according to Nomenclatural Rules */
-    scientificNameElement = <span className="fst-italic"> {specimen['ods:specimenName']} </span>
+    scientificNameElement = <span className="fst-italic"> {specimen.digitalSpecimen['ods:specimenName']} </span>
 
     return scientificNameElement;
 }

--- a/src/components/general/versionSelect/VersionSelect.tsx
+++ b/src/components/general/versionSelect/VersionSelect.tsx
@@ -4,12 +4,13 @@ import Select from 'react-select';
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Types */
-import { DigitalSpecimen, DigitalMedia } from 'app/Types';
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
+import { DigitalEntity } from 'app/types/DigitalEntity';
 
 
 /* Props Typing */
 interface Props {
-    target: DigitalSpecimen | DigitalMedia,
+    target: DigitalSpecimen | DigitalEntity,
     versions: number[]
 };
 
@@ -53,15 +54,15 @@ const VersionSelect = (props: Props) => {
         <Row className="versionSelect">
             <Col>
                 <Select
-                    value={{ value: target.version, label: `Version ${target.version}` }}
+                    value={{ value: target.version, label: `Version ${target['ods:version'] ?? target.version}` }}
                     options={selectOptions}
                     styles={{
                         control: provided => ({
                             ...provided, backgroundColor: '#A1D8CA', border: 'none', borderRadius: '999px',
-                            fontWeight: '500', fontSize: '15px'
+                            fontWeight: '500', fontSize: '0.875rem'
                         }),
-                        menu: provided => ({ ...provided, zIndex: 100000, fontSize: '15px' }),
-                        dropdownIndicator: provided => ({ ...provided, color: '#333333', fontSize: '15px' })
+                        menu: provided => ({ ...provided, zIndex: 100000, fontSize: '0.875rem' }),
+                        dropdownIndicator: provided => ({ ...provided, color: '#333333', fontSize: '0.875rem' })
                     }}
                     onChange={(option) => { option?.value && ChangeVersion(option.value as number) }}
                 />

--- a/src/components/home/components/search/PIDSearch.tsx
+++ b/src/components/home/components/search/PIDSearch.tsx
@@ -41,7 +41,7 @@ const PIDSearch = () => {
                     dispatch(setSpecimen(specimen));
 
                     navigate({
-                        pathname: `/ds/${specimen['ods:id'].replace('https://doi.org/', '')}`,
+                        pathname: `/ds/${specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')}`,
                     });
                 } else {
                     setErrorActive(true);

--- a/src/components/home/components/search/PhysicalIDSearch.tsx
+++ b/src/components/home/components/search/PhysicalIDSearch.tsx
@@ -59,7 +59,7 @@ const PhysicalIDSearch = () => {
             SearchSpecimens([{ physicalSpecimenId: formData.idValue }], 25).then(({ specimens }) => {
                 if (!isEmpty(specimens)) {
                     navigate({
-                        pathname: `/ds/${specimens[0]['ods:id'].replace('https://doi.org/', '')}`,
+                        pathname: `/ds/${specimens[0].digitalSpecimen['ods:id'].replace('https://doi.org/', '')}`,
                     });
                 } else {
                     /* Display not found message */
@@ -81,7 +81,7 @@ const PhysicalIDSearch = () => {
                 SearchSpecimens([{ physicalSpecimenId: `${formData.idValue}:${formData.organisationId}` }], 25).then(({ specimens }) => {
                     if (!isEmpty(specimens)) {
                         navigate({
-                            pathname: `/ds/${specimens[0]['ods:id'].replace('https://doi.org/', '')}`,
+                            pathname: `/ds/${specimens[0].digitalSpecimen['ods:id'].replace('https://doi.org/', '')}`,
                         });
                     } else {
                         /* Display not found message */

--- a/src/components/home/home.module.scss
+++ b/src/components/home/home.module.scss
@@ -2,7 +2,7 @@
 
 /* Generic */
 .content {
-    margin-top: 80px;
+    margin-top: 4.5em;
 }
 
 /* Topic Discipine Filters */

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -9,9 +9,6 @@ import { Container, Row, Col } from 'react-bootstrap';
 import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { getUser, setUserProfile } from "redux/user/UserSlice";
 
-/* Import Styles */
-import styles from './profile.module.scss';
-
 /* Import Components */
 import Header from 'components/general/header/Header';
 import Passport from './components/user/Passport';

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -44,10 +44,10 @@ const Profile = () => {
     }, [user]);
 
     return (
-        <div className="d-flex flex-column min-vh-100">
+        <div className="d-flex flex-column h-100">
             <Header />
 
-            <Container fluid className={`${styles.profileContent} mt-5`}>
+            <Container fluid className="flex-grow-1 overflow-hidden mt-5">
                 <Row className="justify-content-center h-100">
                     <Col lg={{ span: 3 }} className="position-relative h-100">
                         <Passport />

--- a/src/components/profile/profile.module.scss
+++ b/src/components/profile/profile.module.scss
@@ -1,10 +1,5 @@
 /* Custom styling for Profile Page */
 
-/* Generic */
-.profileContent {
-    height: calc(100vh - 208px)
-}
-
 /* Passport */
 .passport {
     border: 1px solid var(--primary);

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -175,7 +175,7 @@ const Search = () => {
     });
 
     return (
-        <div className="d-flex flex-column min-vh-100">
+        <div className="d-flex flex-column h-100">
             <Header introTopics={[
                 { intro: 'search', title: 'About This Page' },
                 { intro: 'compare', title: 'Comparing Specimens' }
@@ -184,7 +184,7 @@ const Search = () => {
             <SearchSteps SetFilterToggle={(toggle: boolean) => setFilterToggle(toggle)} />
             <CompareSteps />
 
-            <Container fluid className={`${styles.content} pt-5 pb-4`}>
+            <Container fluid className="flex-grow-1 overflow-hidden pt-5 pb-4">
                 <Row className="h-100 position-relative">
                     <Col md={{ span: 10, offset: 1 }} className="h-100">
                         <div className="h-100 d-flex flex-column">

--- a/src/components/search/components/IDCard/IDCard.tsx
+++ b/src/components/search/components/IDCard/IDCard.tsx
@@ -42,12 +42,12 @@ const IDCard = (props: Props) => {
                                 />
                             </Col>
                             <Col>
-                                <h2 className="fs-2"> {specimen['ods:specimenName']} </h2>
+                                <h2 className="fs-2"> {specimen.digitalSpecimen['ods:specimenName']} </h2>
                             </Col>
                             <Col className="col-md-auto">
                                 <FontAwesomeIcon icon={faX}
                                     className="c-primary c-pointer"
-                                    onClick={() => OnClose(specimen.id)}
+                                    onClick={() => OnClose(specimen.digitalSpecimen.id)}
                                 />
                             </Col>
                         </Row>
@@ -55,7 +55,7 @@ const IDCard = (props: Props) => {
                         {/* Specimen Identifier */}
                         <Row>
                             <Col>
-                                <p className="fs-4 c-greyDark"> {specimen['ods:id'].replace('https://doi.org/', '')} </p>
+                                <p className="fs-4 c-greyDark"> {specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')} </p>
                             </Col>
                         </Row>
 
@@ -71,22 +71,22 @@ const IDCard = (props: Props) => {
                             <Col className="d-flex align-items-center mt-1">
                                 <Row>
                                     <Col className="col-md-auto">
-                                        <div className={`${styles.midsBlock} ${specimen['ods:midsLevel'] === 0 && styles.active} fw-lightBold`}>
+                                        <div className={`${styles.midsBlock} ${specimen.digitalSpecimen['ods:midsLevel'] === 0 && styles.active} fw-lightBold`}>
                                             MIDS 0
                                         </div>
                                     </Col>
                                     <Col className="col-md-auto">
-                                        <div className={`${styles.midsBlock} ${specimen['ods:midsLevel'] >= 1 && styles.active} fw-lightBold`}>
+                                        <div className={`${styles.midsBlock} ${specimen.digitalSpecimen['ods:midsLevel'] >= 1 && styles.active} fw-lightBold`}>
                                             MIDS 1
                                         </div>
                                     </Col>
                                     <Col className="col-md-auto">
-                                        <div className={`${styles.midsBlock} ${specimen['ods:midsLevel'] >= 2 && styles.active} fw-lightBold`}>
+                                        <div className={`${styles.midsBlock} ${specimen.digitalSpecimen['ods:midsLevel'] >= 2 && styles.active} fw-lightBold`}>
                                             MIDS 2
                                         </div>
                                     </Col>
                                     <Col className="col-md-auto">
-                                        <div className={`${styles.midsBlock} ${specimen['ods:midsLevel'] >= 3 && styles.active} fw-lightBold`}>
+                                        <div className={`${styles.midsBlock} ${specimen.digitalSpecimen['ods:midsLevel'] >= 3 && styles.active} fw-lightBold`}>
                                             MIDS 3
                                         </div>
                                     </Col>
@@ -98,13 +98,13 @@ const IDCard = (props: Props) => {
                         <Row className="mt-4">
                             <Col>
                                 <p className="fs-4">
-                                    <span className="fw-bold"> Scientific Name: </span> {/*specimen.specimenName*/ specimen['ods:id']}
+                                    <span className="fw-bold"> Scientific Name: </span> {/*specimen.specimenName*/ specimen.digitalSpecimen['ods:id']}
                                 </p>
                                 <p className="fs-4 mt-2">
-                                    <span className="fw-bold"> Specimen Type: </span> {specimen['ods:type']}
+                                    <span className="fw-bold"> Specimen Type: </span> {specimen.digitalSpecimen['ods:type']}
                                 </p>
                                 <p className="fs-4 mt-2">
-                                    <span className="fw-bold"> Physical Specimen ID ({specimen['ods:physicalSpecimenIdType']}): </span>
+                                    <span className="fw-bold"> Physical Specimen ID ({specimen.digitalSpecimen['ods:physicalSpecimenIdType']}): </span>
                                     {<PhysicalSpecimenIdProperty specimen={specimen} />}
                                 </p>
                                 <p className="fs-4 mt-2">

--- a/src/components/search/components/IDCard/MapMediaExt.tsx
+++ b/src/components/search/components/IDCard/MapMediaExt.tsx
@@ -42,7 +42,7 @@ const MapMediaExt = (props: Props) => {
     useEffect(() => {
         setDigitalMedia([]);
 
-        GetSpecimenDigitalMedia(specimen['ods:id'].replace('https://doi.org/', '')).then((digitalMedia) => {
+        GetSpecimenDigitalMedia(specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')).then((digitalMedia) => {
             if (digitalMedia) {
                 setDigitalMedia(digitalMedia);
             }
@@ -97,9 +97,9 @@ const MapMediaExt = (props: Props) => {
                         <div className={`${styles.digitalMediaSlider} h-100 w-auto`}>
                             {digitalMedia.map((mediaItem) => {
                                 return (
-                                    <img key={mediaItem['ods:id']} src={mediaItem['ac:accessUri']}
+                                    <img key={mediaItem.digitalEntity['ods:id']} src={mediaItem.digitalEntity['ac:accessUri']}
                                         className="h-100 me-3 rounded-c"
-                                        alt={mediaItem['ac:accessUri']}
+                                        alt={mediaItem.digitalEntity['ac:accessUri']}
                                     />
                                 );
                             })}
@@ -111,7 +111,7 @@ const MapMediaExt = (props: Props) => {
                 <Row className={styles.buttonBlock}>
                     <Col className="h-100 d-flex justify-content-end align-items-end">
                         <button type="button" className={`${styles.specimenButton} border-0 bgc-primary c-white fs-4 rounded-full transition fw-bold px-3`}
-                            onClick={() => navigate(`/ds/${specimen['ods:id'].replace('https://doi.org/', '')}`, {
+                            onClick={() => navigate(`/ds/${specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')}`, {
                                 state: {
                                     filters: searchParams.toString()
                                 }

--- a/src/components/search/components/IDCard/TaxonomyExt.tsx
+++ b/src/components/search/components/IDCard/TaxonomyExt.tsx
@@ -3,7 +3,7 @@ import { CheckProperty } from 'app/Utilities';
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Types */
-import { DigitalSpecimen } from 'app/Types';
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
 
 /* Import Icons */
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/src/components/search/components/compare/Compare.tsx
+++ b/src/components/search/components/compare/Compare.tsx
@@ -70,7 +70,7 @@ const Compare = () => {
         /* Remove from Compare Specimens */
         const copyCompareSpecimens = [...compareSpecimens];
 
-        copyCompareSpecimens.splice(compareSpecimens.findIndex((specimen) => specimen.id === specimenId), 1);
+        copyCompareSpecimens.splice(compareSpecimens.findIndex((specimen) => specimen.digitalSpecimen.id === specimenId), 1);
 
         dispatch(setCompareSpecimens(copyCompareSpecimens));
 
@@ -105,14 +105,14 @@ const Compare = () => {
                                 {compareSpecimens.map((specimen) => {
                                     /* Constructing ID Card Extensions */
                                     const extensions: ReactElement[] = [
-                                        <LocationExt key='location' specimen={specimen} />,
-                                        <TaxonomyExt key='taxonomy' specimen={specimen} />,
-                                        <OrganisationExt key='organisation' specimen={specimen} />,
-                                        <CollectionExt key='collection' specimen={specimen} />
+                                        <LocationExt key='location' specimen={specimen.digitalSpecimen} />,
+                                        <TaxonomyExt key='taxonomy' specimen={specimen.digitalSpecimen} />,
+                                        <OrganisationExt key='organisation' specimen={specimen.digitalSpecimen} />,
+                                        <CollectionExt key='collection' specimen={specimen.digitalSpecimen} />
                                     ];
 
                                     return (
-                                        <Col key={specimen['ods:id']}>
+                                        <Col key={specimen.digitalSpecimen['ods:id']}>
                                             <IDCard specimen={specimen}
                                                 extensions={extensions}
                                                 OnClose={(specimenId: string) => RemoveFromComparison(specimenId)}

--- a/src/components/search/components/compare/CompareBox.tsx
+++ b/src/components/search/components/compare/CompareBox.tsx
@@ -39,9 +39,9 @@ const CompareBox = () => {
 
         compareSpecimens.forEach((specimen, index) => {
             if (index === 0) {
-                compareRoute = compareRoute.concat(`ds=${specimen['ods:id'].replace('https://doi.org/', '')}`);
+                compareRoute = compareRoute.concat(`ds=${specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')}`);
             } else {
-                compareRoute = compareRoute.concat(`&ds=${specimen['ods:id'].replace('https://doi.org/', '')}`);
+                compareRoute = compareRoute.concat(`&ds=${specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')}`);
             }
         });
 
@@ -59,13 +59,13 @@ const CompareBox = () => {
 
                         {compareSpecimens.map((specimen, index) => {
                             return (
-                                <Row key={specimen['ods:id']} className="mt-3">
+                                <Row key={specimen.digitalSpecimen['ods:id']} className="mt-3">
                                     <Col className="col-md-auto pe-0">
                                         <FontAwesomeIcon icon={faCircle} className="c-secondary fs-5" />
                                     </Col>
                                     <Col>
                                         <p className="fw-lightBold"> {`Specimen #${index + 1}`} </p>
-                                        {specimen['ods:specimenName']}
+                                        {specimen.digitalSpecimen['ods:specimenName']}
                                     </Col>
                                 </Row>
                             );

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -58,14 +58,14 @@ const ResultsTable = (props: Props) => {
         dispatch(setSearchSpecimen(specimen));
 
         /* Unselect current Row */
-        const unselectedRow = tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.id !== specimen.id));
+        const unselectedRow = tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.id !== specimen.digitalSpecimen.id));
 
         if (unselectedRow) {
             unselectedRow.toggleSelected = false;
         }
 
         /* Select chosen Table Row */
-        const selectedRow = tableData.find((tableRow) => tableRow.id === specimen.id);
+        const selectedRow = tableData.find((tableRow) => tableRow.id === specimen.digitalSpecimen.id);
 
         if (selectedRow) {
             selectedRow.toggleSelected = true;
@@ -90,7 +90,7 @@ const ResultsTable = (props: Props) => {
             if (row.compareSelected === true) {
                 selectedRow.compareSelected = false;
 
-                const compareSpecimenIndex = compareSpecimens.findIndex((specimen) => specimen.id === row.id);
+                const compareSpecimenIndex = compareSpecimens.findIndex((specimen) => specimen.digitalSpecimen.id === row.id);
                 copyCompareSpecimens.splice(compareSpecimenIndex, 1);
             } else if (compareSpecimens.length < 3) {
                 selectedRow.compareSelected = true;
@@ -121,8 +121,8 @@ const ResultsTable = (props: Props) => {
     /* Function to check if selected Specimen is still selected after page change */
     useEffect(() => {
         if (!isEmpty(searchSpecimen)) {
-            if (!tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.id === searchSpecimen.id))) {
-                const currentRow = tableData.find((tableRow) => tableRow.id === searchSpecimen.id);
+            if (!tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.id === searchSpecimen.digitalSpecimen.id))) {
+                const currentRow = tableData.find((tableRow) => tableRow.id === searchSpecimen.digitalSpecimen.id);
 
                 if (currentRow) {
                     currentRow.toggleSelected = true;
@@ -223,14 +223,14 @@ const ResultsTable = (props: Props) => {
         searchResults.forEach((specimen, i) => {
             tableData.push({
                 index: i,
-                id: specimen['ods:id'],
-                specimen_name: specimen['ods:specimenName'] ?? '',
+                id: specimen.digitalSpecimen['ods:id'],
+                specimen_name: specimen.digitalSpecimen['ods:specimenName'] ?? '',
                 country: /*specimen.data['dwc:country'] ? specimen.data['dwc:country'] :*/ '-',
-                specimen_type: specimen['ods:type'],
-                organisation: specimen['dwc:institutionName'] ?? specimen['dwc:institutionId'] ?? '',
-                organisationId: specimen['dwc:institutionId'] ?? '',
+                specimen_type: specimen.digitalSpecimen['ods:type'],
+                organisation: specimen.digitalSpecimen['dwc:institutionName'] ?? specimen.digitalSpecimen['dwc:institutionId'] ?? '',
+                organisationId: specimen.digitalSpecimen['dwc:institutionId'] ?? '',
                 toggleSelected: false,
-                compareSelected: !!compareSpecimens.find((compareSpecimen) => compareSpecimen.id === specimen.id)
+                compareSelected: !!compareSpecimens.find((compareSpecimen) => compareSpecimen.digitalSpecimen.id === specimen.digitalSpecimen.id)
             });
         });
 

--- a/src/components/search/search.module.scss
+++ b/src/components/search/search.module.scss
@@ -1,10 +1,5 @@
 /* Custom styling for the Search Page */
 
-/* Generic */
-.content {
-    height: calc(100vh - 140px)
-}
-
 /* Compare Button */
 .compareButton {
     font-size: 15px;

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -219,8 +219,7 @@ const Specimen = () => {
                         />
 
                         <div className="flex-grow-1 overflow-hidden">
-                            {(specimen.digitalSpecimen['ods:id'] &&
-                                specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '') === `${params['prefix']}/${params['suffix']}`) &&
+                            {(specimen.digitalSpecimen['ods:id'] && specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '') === `${params['prefix']}/${params['suffix']}`) &&
                                 <Container fluid className="h-100 pt-5">
                                     <Row className="h-100">
                                         <Col className={`${classSpecimenContent} h-100 transition`}>

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -20,9 +20,6 @@ import { getScreenSize, pushToPromptMessages } from 'redux/general/GeneralSlice'
 /* Import Types */
 import { Annotation, SpecimenAnnotations } from 'app/Types';
 
-/* Import Styles */
-import styles from './specimen.module.scss';
-
 /* Import Components */
 import Header from 'components/general/header/Header';
 import TitleBar from './components/TitleBar';

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -204,51 +204,56 @@ const Specimen = () => {
     });
 
     return (
-        <div className="d-flex flex-column min-vh-100 overflow-hidden">
-            <Row>
+        <div className="h-100 overflow-hidden">
+            <Row className="h-100">
                 <Col className={classHeadCol}>
-                    <Header introTopics={[
-                        { intro: 'specimen', title: 'About This Page' },
-                        { intro: 'annotate', title: 'Using Annotations' },
-                        { intro: 'MAS', title: 'Machine Annotation Services' }
-                    ]} />
+                    <div className="h-100 d-flex flex-column">
+                        <Header introTopics={[
+                            { intro: 'specimen', title: 'About This Page' },
+                            { intro: 'annotate', title: 'Using Annotations' },
+                            { intro: 'MAS', title: 'Machine Annotation Services' }
+                        ]} />
 
-                    <SpecimenSteps SetSelectedTab={(tabIndex: number) => setSelectedTab(tabIndex)} />
-                    <AnnotateSteps ShowWithAnnotations={(annotations?: SpecimenAnnotations, property?: string) => ShowWithAnnotations(annotations, property)} />
-                    <MASSteps automatedAnnotationsToggle={automatedAnnotationsToggle}
-                        SetAutomatedAnnotationsToggle={(toggle: boolean) => setAutomatedAnnotationToggle(toggle)}
-                        ShowWithAnnotations={() => ShowWithAnnotations()}
-                    />
+                        <SpecimenSteps SetSelectedTab={(tabIndex: number) => setSelectedTab(tabIndex)} />
+                        <AnnotateSteps ShowWithAnnotations={(annotations?: SpecimenAnnotations, property?: string) => ShowWithAnnotations(annotations, property)} />
+                        <MASSteps automatedAnnotationsToggle={automatedAnnotationsToggle}
+                            SetAutomatedAnnotationsToggle={(toggle: boolean) => setAutomatedAnnotationToggle(toggle)}
+                            ShowWithAnnotations={() => ShowWithAnnotations()}
+                        />
 
-                    {(specimen.digitalSpecimen['ods:id'] && specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '') === `${params['prefix']}/${params['suffix']}`) &&
-                        <Container fluid className={`${styles.content} pt-5`}>
-                            <Row className="h-100">
-                                <Col className={`${classSpecimenContent} h-100 transition`}>
-                                    <div className="h-100 d-flex flex-column">
-                                        <Row className="titleBar">
-                                            <Col>
-                                                <TitleBar ShowWithAllAnnotations={() => ShowWithAnnotations()}
-                                                    ToggleAutomatedAnnotations={() => setAutomatedAnnotationToggle(!automatedAnnotationsToggle)}
-                                                />
-                                            </Col>
-                                        </Row>
-                                        <Row className="py-4 flex-grow-1 overflow-scroll overflow-lg-hidden">
-                                            <Col lg={{ span: 3 }} className={`${classIdCard} IDCard`}>
-                                                <IDCard />
-                                            </Col>
-                                            <Col lg={{ span: 9 }} className="contentBlock ps-4 h-100 mt-4 m-lg-0">
-                                                <ContentBlock selectedTab={selectedTab}
-                                                    SetSelectedTab={(tabIndex: number) => setSelectedTab(tabIndex)}
-                                                />
-                                            </Col>
-                                        </Row>
-                                    </div>
-                                </Col>
-                            </Row>
-                        </Container>
-                    }
+                        <div className="flex-grow-1 overflow-hidden">
+                            {(specimen.digitalSpecimen['ods:id'] &&
+                                specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '') === `${params['prefix']}/${params['suffix']}`) &&
+                                <Container fluid className="h-100 pt-5">
+                                    <Row className="h-100">
+                                        <Col className={`${classSpecimenContent} h-100 transition`}>
+                                            <div className="h-100 d-flex flex-column">
+                                                <Row className="titleBar">
+                                                    <Col>
+                                                        <TitleBar ShowWithAllAnnotations={() => ShowWithAnnotations()}
+                                                            ToggleAutomatedAnnotations={() => setAutomatedAnnotationToggle(!automatedAnnotationsToggle)}
+                                                        />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="py-4 flex-grow-1 overflow-scroll overflow-lg-hidden">
+                                                    <Col lg={{ span: 3 }} className={`${classIdCard} IDCard`}>
+                                                        <IDCard />
+                                                    </Col>
+                                                    <Col lg={{ span: 9 }} className="contentBlock ps-4 h-100 mt-4 m-lg-0">
+                                                        <ContentBlock selectedTab={selectedTab}
+                                                            SetSelectedTab={(tabIndex: number) => setSelectedTab(tabIndex)}
+                                                        />
+                                                    </Col>
+                                                </Row>
+                                            </div>
+                                        </Col>
+                                    </Row>
+                                </Container>
+                            }
+                        </div>
 
-                    <Footer />
+                        <Footer />
+                    </div>
                 </Col>
 
                 {/* Annotation Tools */}

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -64,7 +64,7 @@ const Specimen = () => {
         const specimenId = `${params.prefix}/${params.suffix}`;
 
         /* Fetch Full Specimen if not present or not equal to params ID; if version has changed, refetch Specimen with version */
-        if (isEmpty(specimen) || specimen['ods:id'].replace('https://doi.org/', '') !== specimenId) {
+        if (isEmpty(specimen.digitalSpecimen) || specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '') !== specimenId) {
             /* Check for version in url */
             let version: string = '';
 
@@ -79,13 +79,14 @@ const Specimen = () => {
                     dispatch(setSpecimen(fullSpecimen.specimen));
 
                     /* Set Specimen Digital Media */
+                    console.log(fullSpecimen.digitalMedia);
                     dispatch(setSpecimenDigitalMedia(fullSpecimen.digitalMedia));
 
                     /* Set Specimen Annotations */
                     dispatch(setSpecimenAnnotations(fullSpecimen.annotations));
 
                     /* Get Specimen Versions */
-                    GetSpecimenVersions(fullSpecimen.specimen['ods:id'].replace('https://doi.org/', '')).then((versions) => {
+                    GetSpecimenVersions(fullSpecimen.specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')).then((versions) => {
                         dispatch(setSpecimenVersions(versions));
                     }).catch(error => {
                         console.warn(error);
@@ -94,9 +95,9 @@ const Specimen = () => {
             }).catch(error => {
                 console.warn(error);
             });
-        } else if (params.version && specimen['ods:version'].toString() !== params.version) {
+        } else if (params.version && specimen.digitalSpecimen['ods:version'].toString() !== params.version) {
             /* Get Specimen with version */
-            const originalVersion = specimen.version;
+            const originalVersion = specimen.digitalSpecimen.version;
 
             GetSpecimen(`${params['prefix']}/${params['suffix']}`, params.version).then((specimen) => {
                 if (!isEmpty(specimen)) {
@@ -164,7 +165,7 @@ const Specimen = () => {
 
         dispatch(setAnnotateTarget({
             property: targetProperty ?? '',
-            target: specimen,
+            target: specimen.digitalSpecimen,
             targetType: 'digital_specimen',
             annotations: allAnnotations
         }));
@@ -175,7 +176,7 @@ const Specimen = () => {
     /* Function for refreshing Annotations */
     const RefreshAnnotations = (targetProperty?: string) => {
         /* Refetch Specimen Annotations */
-        GetSpecimenAnnotations(specimen['ods:id'].replace('https://doi.org/', '')).then((annotations) => {
+        GetSpecimenAnnotations(specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')).then((annotations) => {
             /* Show with refreshed Annotations */
             ShowWithAnnotations(annotations, targetProperty);
 
@@ -219,7 +220,7 @@ const Specimen = () => {
                         ShowWithAnnotations={() => ShowWithAnnotations()}
                     />
 
-                    {(specimen['ods:id'] && specimen['ods:id'].replace('https://doi.org/', '') === `${params['prefix']}/${params['suffix']}`) &&
+                    {(specimen.digitalSpecimen['ods:id'] && specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '') === `${params['prefix']}/${params['suffix']}`) &&
                         <Container fluid className={`${styles.content} pt-5`}>
                             <Row className="h-100">
                                 <Col className={`${classSpecimenContent} h-100 transition`}>

--- a/src/components/specimen/components/ContentBlock.tsx
+++ b/src/components/specimen/components/ContentBlock.tsx
@@ -37,8 +37,7 @@ const ContentBlock = (props: Props) => {
     });
 
     const classTab = classNames({
-        'react-tabs__tab tab': true,
-        [`${styles.tab}`]: true
+        'react-tabs__tab tab': true
     });
 
     const classTabPanel = classNames({

--- a/src/components/specimen/components/IDCard/IDCard.tsx
+++ b/src/components/specimen/components/IDCard/IDCard.tsx
@@ -26,6 +26,7 @@ const IDCard = () => {
     const specimen = useAppSelector(getSpecimen);
     const specimenAnnotations = useAppSelector(getSpecimenAnnotations);
     const specimenDigitalMedia = useAppSelector(getSpecimenDigitalMedia);
+    let bannerImage: string = '';
 
     /* Function for toggling the Annotate Modal */
     const ToggleSidePanel = (property: string) => {
@@ -33,7 +34,7 @@ const IDCard = () => {
             dispatch(setAnnotateTarget({
                 property,
                 motivation: '',
-                target: specimen,
+                target: specimen.digitalSpecimen,
                 targetType: 'digital_specimen',
                 annotations: specimenAnnotations[property] ? specimenAnnotations[property] : []
             }));
@@ -42,16 +43,25 @@ const IDCard = () => {
         dispatch(setSidePanelToggle(true));
     }
 
+    /* Check for 2D Digital Media item that fits banner */
+    specimenDigitalMedia.forEach((digitalMedia) => {
+        if (digitalMedia.digitalEntity['dcterms:type'] === 'Image' || digitalMedia.digitalEntity['dcterms:type'] === 'StillImage') {
+            bannerImage = digitalMedia.digitalEntity['ac:accessUri'];
+
+            return;
+        }
+    });
+
     return (
         <Row className="h-100">
             {/* ID Card Content */}
             <Col className="h-100">
                 <div className="h-100 d-flex flex-column">
                     {specimenDigitalMedia.length > 0 &&
-                        <Row className="h-25 overflow-hidden">
+                        <Row className="h-25 overflow-hidden pb-3">
                             <Col className="h-100">
                                 <div className="h-100 d-flex justify-content-center bgc-greyLight rounded-c">
-                                    <img src={specimenDigitalMedia[0]['ac:accessUri']} alt="banner"
+                                    <img src={bannerImage} alt="banner"
                                         className="h-100 position-relative rounded-c"
                                     />
                                 </div>
@@ -68,19 +78,20 @@ const IDCard = () => {
                                                 <p> ID Card </p>
                                             </Col>
                                             <Col className="fs-4 col-md-auto fw-lightBold">
-                                                <p> {specimen['ods:id'].replace('https://doi.org/', '')} </p>
+                                                <p> {specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')} </p>
                                             </Col>
                                         </Row>
                                     </Card.Subtitle>
 
                                     <Row className="flex-grow-1">
-                                        <Col className="col-md-auto h-100">
-                                            <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
-                                                <Col className={`scientificName ${styles.IDCardPropertyBlockHover} transition rounded-c py-1`}
+                                        <Col className="col-md-auto h-100 d-flex flex-column justify-content-between">
+                                            <Row className="fs-4">
+                                                <Col className={`scientificName ${styles.IDCardPropertyBlockHover} transition rounded-c py-1 textOverflow`}
                                                     onClick={() => ToggleSidePanel('ods:specimenName')}
                                                 >
-                                                    <span className="fw-lightBold m-0 h-50" role="sidePanelTrigger">Name in collection:</span>
-                                                    <br className="d-none d-lg-block" /> <span className="m-0 h-50"> {specimen['ods:specimenName']} </span>
+                                                    <span className="fw-lightBold" role="sidePanelTrigger">Name in collection:</span>
+                                                    <br className="d-none d-lg-block" />
+                                                    <span> {specimen.digitalSpecimen['ods:specimenName']} </span>
                                                 </Col>
                                                 {'ods:specimenName' in specimenAnnotations &&
                                                     <Col className="col-md-auto">
@@ -88,12 +99,13 @@ const IDCard = () => {
                                                     </Col>
                                                 }
                                             </Row>
-                                            <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
-                                                <Col className={`${styles.IDCardPropertyBlockHover} transition rounded-c py-1`}
+                                            <Row className="fs-4">
+                                                <Col className={`${styles.IDCardPropertyBlockHover} transition rounded-c py-1 textOverflow`}
                                                     onClick={() => ToggleSidePanel('ods:organisationId')}
                                                 >
-                                                    <span className="fw-lightBold m-0 h-50">Specimen provider:</span>
-                                                    <br className="d-none d-lg-block" /> <span className="m-0 h-50 c-accent">
+                                                    <span className="fw-lightBold">Specimen provider:</span>
+                                                    <br className="d-none d-lg-block" />
+                                                    <span className="c-accent">
                                                         {<OrganisationProperty specimen={specimen} />}
                                                     </span>
                                                 </Col>
@@ -103,20 +115,22 @@ const IDCard = () => {
                                                     </Col>
                                                 }
                                             </Row>
-                                            <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
-                                                <Col className="m-0 py-1">
-                                                    <span className="fw-lightBold m-0 h-50">Object Type:</span>
-                                                    <br className="d-none d-lg-block" /> <span className="m-0 h-50">Coming Soon!</span>
+                                            <Row className="fs-4">
+                                                <Col className="textOverflow">
+                                                    <span className="fw-lightBold">Object Type:</span>
+                                                    <br className="d-none d-lg-block" />
+                                                    <span>Coming Soon!</span>
                                                 </Col>
                                             </Row>
-                                            <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
-                                                <Col className={`${styles.IDCardPropertyBlockHover} transition rounded-c py-1`}
+                                            <Row className="fs-4">
+                                                <Col className={`${styles.IDCardPropertyBlockHover} transition rounded-c py-1 textOverflow`}
                                                     onClick={() => ToggleSidePanel('ods:physicalSpecimenId')}
                                                 >
-                                                    <span className="fw-lightBold m-0 h-50">
-                                                        Physical specimen ID ({specimen['ods:physicalSpecimenIdType']}):
+                                                    <span className="fw-lightBold">
+                                                        Physical specimen ID ({specimen.digitalSpecimen['ods:physicalSpecimenIdType']}):
                                                     </span>
-                                                    <br className="d-none d-lg-block" /> <span className="m-0 h-50"> {<PhysicalSpecimenIdProperty specimen={specimen} />} </span>
+                                                    <br className="d-none d-lg-block" />
+                                                    <span> {<PhysicalSpecimenIdProperty specimen={specimen} />} </span>
                                                 </Col>
                                                 {'ods:physicalSpecimenId' in specimenAnnotations &&
                                                     <Col className="col-md-auto">
@@ -124,18 +138,20 @@ const IDCard = () => {
                                                     </Col>
                                                 }
                                             </Row>
-                                            <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
-                                                <Col className="m-0 py-1">
-                                                    <span className="fw-lightBold m-0 h-50">Specimen Type:</span>
-                                                    <br className="d-none d-lg-block" /> <span className="m-0 h-50"> {specimen['ods:type']} </span>
+                                            <Row className="fs-4">
+                                                <Col className="textOverflow">
+                                                    <span className="fw-lightBold">Specimen Type:</span>
+                                                    <br className="d-none d-lg-block" />
+                                                    <span> {specimen.digitalSpecimen['ods:type']} </span>
                                                 </Col>
                                             </Row>
-                                            <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
+                                            <Row className="fs-4">
                                                 <Col className={`${styles.IDCardPropertyBlockHover} transition rounded-c py-1`}
                                                     onClick={() => ToggleSidePanel('ods:physicalSpecimenCollection')}
                                                 >
-                                                    <span className="fw-lightBold m-0 h-50">In collection:</span>
-                                                    <br className="d-none d-lg-block" /> <span className="m-0 h-50"> {specimen['dwc:collectionCode']} </span>
+                                                    <span className="fw-lightBold">In collection:</span>
+                                                    <br className="d-none d-lg-block" />
+                                                    <span className="m-0"> {specimen.digitalSpecimen['dwc:collectionCode']} </span>
                                                 </Col>
                                                 {'ods:physicalSpecimenCollection' in specimenAnnotations &&
                                                     <Col className="col-md-auto">
@@ -143,12 +159,13 @@ const IDCard = () => {
                                                     </Col>
                                                 }
                                             </Row>
-                                            <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
+                                            <Row className="fs-4">
                                                 <Col className={`${styles.IDCardPropertyBlockHover} transition rounded-c py-1 text-truncate`}
                                                     onClick={() => ToggleSidePanel('dcterms:license')}
                                                 >
                                                     <span className="fw-lightBold m-0 h-50">License:</span>
-                                                    <br className="d-none d-lg-block" /> <span className="m-0 h-50"> {specimen['dcterms:license']} </span>
+                                                    <br className="d-none d-lg-block" />
+                                                    <span className="m-0"> {specimen.digitalSpecimen['dcterms:license']} </span>
                                                 </Col>
                                                 {'dcterms:license' in specimenAnnotations &&
                                                     <Col className="col-md-auto">
@@ -156,10 +173,11 @@ const IDCard = () => {
                                                     </Col>
                                                 }
                                             </Row>
-                                            <Row className={`${styles.IDCardPropertyBlock} fs-4`}>
+                                            <Row className="fs-4">
                                                 <Col className="m-0 py-1">
                                                     <span className="fw-lightBold m-0 h-50">Source System:</span>
-                                                    <br className="d-none d-lg-block" /> <span className="m-0 h-50"> Coming Soon! </span>
+                                                    <br className="d-none d-lg-block" />
+                                                    <span className="m-0"> Coming Soon! </span>
                                                 </Col>
                                             </Row>
                                         </Col>

--- a/src/components/specimen/components/IDCard/IDCard.tsx
+++ b/src/components/specimen/components/IDCard/IDCard.tsx
@@ -44,13 +44,13 @@ const IDCard = () => {
     }
 
     /* Check for 2D Digital Media item that fits banner */
-    specimenDigitalMedia.forEach((digitalMedia) => {
+    for (let digitalMedia of specimenDigitalMedia) {
         if (digitalMedia.digitalEntity['dcterms:type'] === 'Image' || digitalMedia.digitalEntity['dcterms:type'] === 'StillImage') {
             bannerImage = digitalMedia.digitalEntity['ac:accessUri'];
 
-            return;
+            break;
         }
-    });
+    };
 
     return (
         <Row className="h-100">

--- a/src/components/specimen/components/IDCard/OrganisationProperty.tsx
+++ b/src/components/specimen/components/IDCard/OrganisationProperty.tsx
@@ -14,13 +14,13 @@ const OrganisationProperty = (props: Props) => {
     /* Base variables */
     let organisationText: string;
 
-    if (specimen['dwc:institutionName']) {
-        organisationText = specimen['dwc:institutionName'] ?? '';
+    if (specimen.digitalSpecimen['dwc:institutionName']) {
+        organisationText = specimen.digitalSpecimen['dwc:institutionName'] ?? '';
     } else {
-        organisationText = specimen['dwc:institutionId'] ?? '';
+        organisationText = specimen.digitalSpecimen['dwc:institutionId'] ?? '';
     }
 
-    return <a href={specimen['dwc:institutionId']} target="_blank" rel="noreferrer"> {organisationText} </a>;
+    return <a href={specimen.digitalSpecimen['dwc:institutionId']} target="_blank" rel="noreferrer"> {organisationText} </a>;
 
 }
 

--- a/src/components/specimen/components/IDCard/PhysicalSpecimenIdProperty.tsx
+++ b/src/components/specimen/components/IDCard/PhysicalSpecimenIdProperty.tsx
@@ -14,14 +14,14 @@ interface Props {
 const PhysicalSpecimenIdProperty = (props: Props) => {
     const { specimen } = props;
 
-    if (specimen.physicalSpecimenId && validator.isURL(specimen['ods:normalisedPhysicalSpecimenId'] ?? '')) {
-        return <a href={specimen['ods:normalisedPhysicalSpecimenId']} target="_blank" rel="noreferrer"
+    if (specimen.digitalSpecimen.physicalSpecimenId && validator.isURL(specimen.digitalSpecimen['ods:normalisedPhysicalSpecimenId'] ?? '')) {
+        return <a href={specimen.digitalSpecimen['ods:normalisedPhysicalSpecimenId']} target="_blank" rel="noreferrer"
             className="c-accent"
         >
-            {specimen['ods:normalisedPhysicalSpecimenId']}
+            {specimen.digitalSpecimen['ods:normalisedPhysicalSpecimenId']}
         </a>
     } else {
-        return <span> {specimen['ods:normalisedPhysicalSpecimenId']} </span>;
+        return <span> {specimen.digitalSpecimen['ods:normalisedPhysicalSpecimenId']} </span>;
     }
 }
 

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -56,7 +56,7 @@ const TitleBar = (props: Props) => {
         /* Create and click on link to download file */
         const link = document.createElement("a");
         link.href = URL.createObjectURL(jsonFile);
-        link.download = `${specimen['ods:id'].replace('https://doi.org/', '')}_${specimen.version}.json`;
+        link.download = `${specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')}_${specimen.digitalSpecimen.version}.json`;
 
         link.click();
     }
@@ -65,7 +65,7 @@ const TitleBar = (props: Props) => {
     const SpecimenActions = (action: string) => {
         switch (action) {
             case 'json':
-                window.open(`${process.env.REACT_APP_HOST_URL}/api/v1/specimens/${specimen['ods:id'].replace('https://doi.org/', '')}`);
+                window.open(`${process.env.REACT_APP_HOST_URL}/api/v1/specimens/${specimen.digitalSpecimen['ods:id'].replace('https://doi.org/', '')}`);
 
                 return;
             case 'sidePanel':
@@ -74,7 +74,7 @@ const TitleBar = (props: Props) => {
                 return;
             case 'automatedAnnotations':
                 /* Set MAS Target */
-                dispatch(setMASTarget(specimen));
+                dispatch(setMASTarget(specimen.digitalSpecimen));
 
                 /* Open MAS Modal */
                 ToggleAutomatedAnnotations();
@@ -105,7 +105,7 @@ const TitleBar = (props: Props) => {
                         <FontAwesomeIcon icon={faDiamond} className={`${styles.specimenTitle} c-primary`} />
                     </Col>
                     <Col>
-                        <h2 className={styles.specimenTitle}> {specimen['ods:specimenName']} </h2>
+                        <h2 className={styles.specimenTitle}> {specimen.digitalSpecimen['ods:specimenName']} </h2>
                     </Col>
                 </Row>
                 <Row>
@@ -124,22 +124,22 @@ const TitleBar = (props: Props) => {
                             <Col>
                                 <Row>
                                     <Col md={{ span: 3 }} className="d-flex align-items-center">
-                                        <div className={`${styles.midsBlock} ${specimen['ods:midsLevel'] === 0 && styles.active} fw-lightBold`}>
+                                        <div className={`${styles.midsBlock} ${specimen.digitalSpecimen['ods:midsLevel'] === 0 && styles.active} fw-lightBold`}>
                                             MIDS 0
                                         </div>
                                     </Col>
                                     <Col md={{ span: 3 }} className="d-flex align-items-center">
-                                        <div className={`${styles.midsBlock} ${specimen['ods:midsLevel'] >= 1 && styles.active} fw-lightBold`}>
+                                        <div className={`${styles.midsBlock} ${specimen.digitalSpecimen['ods:midsLevel'] >= 1 && styles.active} fw-lightBold`}>
                                             MIDS 1
                                         </div>
                                     </Col>
                                     <Col md={{ span: 3 }} className="d-flex align-items-center">
-                                        <div className={`${styles.midsBlock} ${specimen['ods:midsLevel'] >= 2 && styles.active} fw-lightBold`}>
+                                        <div className={`${styles.midsBlock} ${specimen.digitalSpecimen['ods:midsLevel'] >= 2 && styles.active} fw-lightBold`}>
                                             MIDS 2
                                         </div>
                                     </Col>
                                     <Col md={{ span: 3 }} className="d-flex align-items-center">
-                                        <div className={`${styles.midsBlock} ${specimen['ods:midsLevel'] >= 3 && styles.active} fw-lightBold`}>
+                                        <div className={`${styles.midsBlock} ${specimen.digitalSpecimen['ods:midsLevel'] >= 3 && styles.active} fw-lightBold`}>
                                             MIDS 3
                                         </div>
                                     </Col>
@@ -152,7 +152,7 @@ const TitleBar = (props: Props) => {
                         <Row>
                             <Col className="d-lg-none" />
                             <Col className="col-auto">
-                                <VersionSelect target={specimen}
+                                <VersionSelect target={specimen.digitalSpecimen}
                                     versions={specimenVersions}
                                 />
                             </Col>

--- a/src/components/specimen/components/contentBlocks/DigitalMedia.tsx
+++ b/src/components/specimen/components/contentBlocks/DigitalMedia.tsx
@@ -24,10 +24,10 @@ const DigitalMedia = () => {
 
     /* Sort Digital Media based upon type/format */
     specimenDigitalMedia.forEach((digitalMediaItem: DigitalMediaType) => {
-        switch (digitalMediaItem['ods:type']) {
+        switch (digitalMediaItem.digitalEntity['ods:type']) {
             case '2DImageObject':
                 (sortedDigitalMedia.images || (sortedDigitalMedia.images = [])).push(
-                    <Link to={`/dm/${digitalMediaItem['ods:id'].replace('https://doi.org/', '')}`}>
+                    <Link to={`/dm/${digitalMediaItem.digitalEntity['ods:id'].replace('https://doi.org/', '')}`}>
                         <Image digitalMedia={digitalMediaItem}
                             sizeOrientation='width' hoverEffect={true}
                         />

--- a/src/components/specimen/components/contentBlocks/OriginalData.tsx
+++ b/src/components/specimen/components/contentBlocks/OriginalData.tsx
@@ -28,7 +28,7 @@ const OriginalData = () => {
 
     /* OnLoad: Fetch Source System */
     useEffect(() => {
-        GetSourceSystem(specimen['ods:sourceSystem'].replace('https://hdl.handle.net/', '')).then((sourceSystem) => {
+        GetSourceSystem(specimen.digitalSpecimen['ods:sourceSystem'].replace('https://hdl.handle.net/', '')).then((sourceSystem) => {
             if (sourceSystem) {
                 setSourceSystem(sourceSystem);
             }

--- a/src/components/specimen/components/contentBlocks/SpecimenOverview.tsx
+++ b/src/components/specimen/components/contentBlocks/SpecimenOverview.tsx
@@ -29,7 +29,7 @@ const SpecimenOverview = () => {
             dispatch(setAnnotateTarget({
                 property,
                 motivation: '',
-                target: specimen,
+                target: specimen.digitalSpecimen,
                 targetType: 'digital_specimen',
                 annotations: specimenAnnotations[property] ? specimenAnnotations[property] : []
             }));

--- a/src/components/specimen/components/contentBlocks/specimenBlock/Organisation.tsx
+++ b/src/components/specimen/components/contentBlocks/specimenBlock/Organisation.tsx
@@ -23,8 +23,8 @@ const Organisation = (props: Props) => {
 
     /* Main properties */
     const properties = [
-        { name: 'Organisation ID', value: specimen['dwc:institutionId'] ?? '', property: 'dwc:institutionId' },
-        { name: 'Organisation Name', value: specimen['dwc:institutionName'] ?? '', property: 'dwc:institutionName' }
+        { name: 'Organisation ID', value: specimen.digitalSpecimen['dwc:institutionId'] ?? '', property: 'dwc:institutionId' },
+        { name: 'Organisation Name', value: specimen.digitalSpecimen['dwc:institutionName'] ?? '', property: 'dwc:institutionName' }
     ];
 
     return (

--- a/src/components/specimen/components/contentBlocks/specimenBlock/OrganisationLogo.tsx
+++ b/src/components/specimen/components/contentBlocks/specimenBlock/OrganisationLogo.tsx
@@ -16,8 +16,8 @@ const OrganisationLogo = () => {
     return (
         <Card className="h-100">
             <Card.Body className="h-100 d-flex flex-column">
-                {specimen['dwc:institutionId'] &&
-                    <OrganisationLogoImage organisationId={specimen['dwc:institutionId'].replace('https://ror.org/', '')} />
+                {specimen.digitalSpecimen['dwc:institutionId'] &&
+                    <OrganisationLogoImage organisationId={specimen.digitalSpecimen['dwc:institutionId'].replace('https://ror.org/', '')} />
                 }
             </Card.Body>
         </Card>

--- a/src/components/specimen/components/mids/MidsMeter.tsx
+++ b/src/components/specimen/components/mids/MidsMeter.tsx
@@ -54,7 +54,7 @@ const MidsMeter = () => {
                         </Row>
                         <Row>
                             <Col md={{ span: 10, offset: 1 }} className="specimen_midsMeterBar bg-green text-center fw-bold text-white">
-                                Lv {specimen['ods:midsLevel']}.
+                                Lv {specimen.digitalSpecimen['ods:midsLevel']}.
                             </Col>
                         </Row>
                     </Col>

--- a/src/components/specimen/specimen.module.scss
+++ b/src/components/specimen/specimen.module.scss
@@ -1,10 +1,6 @@
 /* Custom CSS for Specimen Page */
 
 /* Generic */
-.content {
-    height: calc(100vh - 140px)
-}
-
 .sidePanel {
     height: 100vh;
     width: Calc(100% / 3);

--- a/src/components/specimen/specimen.module.scss
+++ b/src/components/specimen/specimen.module.scss
@@ -12,13 +12,12 @@
 
 /* Title Bar */
 .specimenTitle {
-    font-size: 30px;
+    font-size: 1.875rem;
 }
 
 .midsBlock {
     color: #B9E8EE;
     transition: 0.3s;
-    font-size: 16px;
 }
 
 .midsBlock.active {
@@ -35,10 +34,6 @@
 
 .IDCardIdentifier {
     height: 6%;
-}
-
-.IDCardPropertyBlock {
-    max-height: Calc(100% / 8);
 }
 
 .IDCardPropertyBlockHover:hover {

--- a/src/components/specimen/steps/AnnotateSteps.tsx
+++ b/src/components/specimen/steps/AnnotateSteps.tsx
@@ -47,7 +47,7 @@ const AnnotateSteps = (props: Props) => {
         type: 'Annotation',
         motivation: 'commenting',
         target: {
-            id: specimen['ods:id'],   
+            id: specimen.digitalSpecimen['ods:id'],   
             type: 'digitalSpecimen',
             indvProp: 'ods:specimenName'
         },

--- a/src/components/specimen/steps/MASSteps.tsx
+++ b/src/components/specimen/steps/MASSteps.tsx
@@ -85,7 +85,7 @@ const MASSteps = (props: Props) => {
                         if ([3, 4, 5].includes(nextIndex)) {
                             /* On Step 4: Show Automated Annotations Modal and set MAS target */
                             SetAutomatedAnnotationsToggle(true);
-                            dispatch(setMASTarget(specimen));
+                            dispatch(setMASTarget(specimen.digitalSpecimen));
 
                             setTimeout(() => {
                                 resolve();

--- a/src/redux/annotate/AnnotateSlice.ts
+++ b/src/redux/annotate/AnnotateSlice.ts
@@ -3,7 +3,9 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { RootState } from 'app/store';
 
 /* Import Types */
-import { Annotation, AnnotateTarget, DigitalSpecimen, DigitalMedia } from 'app/Types';
+import { Annotation, AnnotateTarget } from 'app/Types';
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
+import { DigitalEntity } from 'app/types/DigitalEntity';
 
 
 export interface AnnotateState {
@@ -13,7 +15,7 @@ export interface AnnotateState {
     editAnnotation: Annotation;
     highlightAnnotationId: string;
     overviewAnnotations: Annotation[];
-    MASTarget: DigitalSpecimen | DigitalMedia
+    MASTarget: DigitalSpecimen | DigitalEntity
 }
 
 const initialState: AnnotateState = {
@@ -22,14 +24,14 @@ const initialState: AnnotateState = {
     annotateTarget: {
         property: '',
         motivation: '',
-        target: {} as DigitalSpecimen | DigitalMedia,
+        target: {} as DigitalSpecimen | DigitalEntity,
         targetType: '',
         annotations: [] as Annotation[]
     },
     editAnnotation: {} as Annotation,
     highlightAnnotationId: '',
     overviewAnnotations: [],
-    MASTarget: {} as DigitalSpecimen | DigitalMedia
+    MASTarget: {} as DigitalSpecimen | DigitalEntity
 };
 
 export const AnnotateSlice = createSlice({
@@ -54,7 +56,7 @@ export const AnnotateSlice = createSlice({
         setOverviewAnnotations: (state, action: PayloadAction<Annotation[]>) => {
             state.overviewAnnotations = action.payload;
         },
-        setMASTarget: (state, action: PayloadAction<DigitalSpecimen | DigitalMedia>) => {
+        setMASTarget: (state, action: PayloadAction<DigitalSpecimen | DigitalEntity>) => {
             state.MASTarget = action.payload;
         }
     },

--- a/src/redux/specimen/SpecimenSlice.ts
+++ b/src/redux/specimen/SpecimenSlice.ts
@@ -15,7 +15,10 @@ export interface SpecimenState {
 }
 
 const initialState: SpecimenState = {
-    specimen: {} as DigitalSpecimen,
+    specimen: {
+        digitalSpecimen: {},
+        originalData: {}
+    } as DigitalSpecimen,
     specimenVersions: [],
     specimenDigitalMedia: [] as DigitalMedia[],
     specimenAnnotations: {} as SpecimenAnnotations,

--- a/src/tests/mock/specimen/specimenFull.json
+++ b/src/tests/mock/specimen/specimenFull.json
@@ -47,18 +47,17 @@
             },
             "digitalMediaObjects": [
                 {
-                    "annotations": [],
                     "digitalMediaObject": {
-                        "created": "2022-09-16T13:39:24.289Z",
-                        "data": "null",
-                        "digitalSpecimenId": "20.5000.1025/DW0-BNT-FM0",
-                        "id": "20.5000.1025/PNA-TQX-HX7",
-                        "mediaUrl": "https://archimg.mnhn.lu/Collections/Collections/QG121-1.JPG",
-                        "originalData": "null",
-                        "sourceSystemId": "20.5000.1025/GW0-TYL-EWQ",
-                        "type": "Unknown",
-                        "version": 1
-                    }
+                        "digitalEntity": {
+                            "ods:id": "20.5000.1025/PNA-TQX-HX7",
+                            "ods:version": 1,
+                            "ods:created": "2022-09-16T13:39:24.289Z",
+                            "dcterms:type": "StillImage",
+                            "ac:accessUri": "https://archimg.mnhn.lu/Collections/Collections/QG121-1.JPG"      
+                        },
+                        "originalData": {}
+                    },
+                    "annotations": {}
                 }
             ],
             "annotations": [


### PR DESCRIPTION
PR scales the Specimen ID Card to fit its properties, the height is divided equally. Fixed the banner image not showing up, and also implemented a scalar for the general text in the application to make the interface appear the same, as well on smaller as bigger screens.

Commit also changes the digital specimen and media types. They now include the different levels of nesting as present in the API. This does require  an extra level of assigning or requesting properties, but should be better as it is inline with the source, namely: the API