### PR TITLE
Data model specimen identifications tab

### DIFF
--- a/src/components/specimen/components/ContentBlock.tsx
+++ b/src/components/specimen/components/ContentBlock.tsx
@@ -15,6 +15,7 @@ import styles from 'components/specimen/specimen.module.scss';
 import SpecimenOverview from './contentBlocks/SpecimenOverview';
 import DigitalMedia from './contentBlocks/DigitalMedia';
 import Occurrences from './contentBlocks/Occurrences';
+import Identifications from './contentBlocks/Identifications';
 import OriginalData from './contentBlocks/OriginalData';
 
 
@@ -80,7 +81,7 @@ const ContentBlock = (props: Props) => {
 
                             {/* Identifications View */}
                             <TabPanel className={classTabPanel}>
-                                
+                                <Identifications ShowWithAnnotations={(property: string) => ShowWithAnnotations(undefined, property)} />
                             </TabPanel>
 
                             {/* Entity Relationships View */}

--- a/src/components/specimen/components/contentBlocks/Identifications.tsx
+++ b/src/components/specimen/components/contentBlocks/Identifications.tsx
@@ -81,7 +81,7 @@ const Identifications = (props: Props) => {
                                             <div key={identificationKey} className="mt-3">
                                                 <PropertiesTable
                                                     title={identificationKey}
-                                                    properties={identification[identificationKey as keyof typeof identification] as Dict}
+                                                    properties={identification[identificationKey]}
                                                     ShowWithAnnotations={(property: string) => ShowWithAnnotations(property)}
                                                 />
                                             </div>

--- a/src/components/specimen/components/contentBlocks/Identifications.tsx
+++ b/src/components/specimen/components/contentBlocks/Identifications.tsx
@@ -1,0 +1,100 @@
+/* Import Dependencies */
+import { isEmpty, cloneDeep } from 'lodash';
+import classNames from 'classnames';
+import { Card, Row, Col } from 'react-bootstrap';
+
+/* Import Store */
+import { useAppSelector } from 'app/hooks';
+import { getSpecimen } from 'redux/specimen/SpecimenSlice';
+
+/* Import Types */
+import { Dict } from 'app/Types';
+
+/* Import Components */
+import PropertiesTable from './PropertiesTable';
+
+
+/* Props Typing */
+interface Props {
+    ShowWithAnnotations: Function
+}
+
+
+const Identifications = (props: Props) => {
+    const { ShowWithAnnotations } = props;
+
+    /* Base variables */
+    const specimen = useAppSelector(getSpecimen);
+    let identifications: {
+        properties: Dict,
+        [taxonIdentification: string]: Dict
+    }[] = [];
+
+    /* Craft identifications object to iterate over */
+    specimen.digitalSpecimen['dwc:identification']?.forEach((identification, index) => {
+        const copyIdentification = cloneDeep(identification);
+
+        /* Push new craft occurrence to array */
+        identifications.push({ properties: {} });
+
+        /* Check for Taxon Identifications */
+        if (!isEmpty(identification.taxonIdentifications)) {
+            identification.taxonIdentifications?.forEach((taxonIdentification, index) => {
+                /* Add Taxon Identification to craft identification */
+                identifications[index][`taxon Identification #${++index}`] = taxonIdentification;
+            });
+        }
+
+        /* Remove extensions from core occurrence object */
+        ['taxonIdentifications'].forEach((key) => delete copyIdentification[key]);
+
+        identifications[index].properties = copyIdentification;
+    });
+
+    return (
+        <>
+            {identifications.map((identification, index) => {
+                const key = `occurrence${index}`;
+
+                /* ClassNames */
+                const CardClass = classNames({
+                    'mt-3': index > 0
+                });
+
+                return (
+                    <Card key={key} className={CardClass}>
+                        <Card.Body>
+                            <Row>
+                                <Col>
+                                    <p className="fs-2 fw-lightBold">
+                                        {identification.properties['dwc:identificationVerificationStatus'] ?
+                                            <> {`Identification #${++index} (accepted)`} </>
+                                            : <> {`Identification #${++index}`} </>
+                                        }
+                                    </p>
+                                </Col>
+                            </Row>
+                            <Row>
+                                <Col>
+                                    {Object.keys(identification).map((identificationKey) => {
+                                        return (
+                                            <div key={identificationKey} className="mt-3">
+                                                <PropertiesTable
+                                                    title={identificationKey}
+                                                    properties={identification[identificationKey as keyof typeof identification] as Dict}
+                                                    ShowWithAnnotations={(property: string) => ShowWithAnnotations(property)}
+                                                />
+                                            </div>
+                                        );
+                                    })}
+                                </Col>
+                            </Row>
+                        </Card.Body>
+                    </Card>
+                );
+            })}
+        </>
+    );
+}
+
+export default Identifications;

--- a/src/components/specimen/components/contentBlocks/Occurrences.tsx
+++ b/src/components/specimen/components/contentBlocks/Occurrences.tsx
@@ -70,7 +70,7 @@ const Occurrences = (props: Props) => {
         /* Remove extensions from core occurrence object */
         ['location', 'assertions'].forEach((key) => delete copyOccurrence[key]);
 
-        occurrences[index].properties = copyOccurrence
+        occurrences[index].properties = copyOccurrence;
     });
 
     return (


### PR DESCRIPTION
PR adds content to the Identifications tab. The Properties Table is used to to display the properties. As an identification can have multiple taxon identifications, these are separated and shown in separate tables.

Adds:
- Identifications tab with content (identifications)