### PR TITLE
Data model specimen entity relations tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "react-data-table-component": "^7.5.3",
         "react-datepicker": "^4.11.0",
         "react-dom": "^18.2.0",
+        "react-force-graph-2d": "^1.25.2",
         "react-i18next": "^12.2.2",
         "react-leaflet": "^4.2.1",
         "react-mark-image": "^0.2.3",
@@ -4092,6 +4093,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-21.0.0.tgz",
+      "integrity": "sha512-qVfOiFh0U8ZSkLgA6tf7kj2MciqRbSCWaJZRwftVO7UbtVDNsZAXpWXqvCDtIefvjC83UJB+vHTDOGm5ibXjEA=="
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
@@ -5163,6 +5169,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accessor-fn": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.0.tgz",
+      "integrity": "sha512-dml7D96DY/K5lt4Ra2jMnpL9Bhw5HEGws4p1OAIxFFj9Utd/RxNfEO3T3f0QIWFNwQU7gNxH9snUfqF/zNkP/w==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/acorn": {
@@ -6721,6 +6735,15 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/bfj": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
@@ -7038,6 +7061,17 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.2.1.tgz",
+      "integrity": "sha512-i5clg2pEdaWqHuEM/B74NZNLkHh5+OkXbA/T4iaBiaNDagkOCXkLNrhqUfdUugsRwuaNRU20e/OygzxWRor3yg==",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -8062,6 +8096,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw=="
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -8070,10 +8109,45 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.5.tgz",
+      "integrity": "sha512-tdwhAhoTYZY/a6eo9nR7HP3xSW/C6XvJTbeRpR92nlPzH6OiE+4MliN9feuSFd0tPtEUo+191qOhCTWx3NYifg==",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -8097,10 +8171,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-octree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.0.2.tgz",
+      "integrity": "sha512-Qxg4oirJrNXauiuC94uKMbgxwnhdda9xRLl9ihq45srlJ4Ga3CSgqGcAL8iW7N5CIv4Oz8x3E734ulxyvHPvwA=="
+    },
     "node_modules/d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "engines": {
         "node": ">=12"
       }
@@ -8116,6 +8203,26 @@
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "engines": {
         "node": ">=12"
       }
@@ -8157,6 +8264,39 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -10128,6 +10268,30 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/force-graph": {
+      "version": "1.43.4",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.43.4.tgz",
+      "integrity": "sha512-xIKcxTpUN12tq8+2ptbWUV68qbCufprNyJEkONzR6R2rmD8E7GljLa5zWqgavXcSQ+GxQOJ21rV8SDQMBB3uGg==",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 21",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "1",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "index-array-by": "1",
+        "kapsule": "^1.14",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz",
@@ -10326,6 +10490,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -11240,6 +11423,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.1.tgz",
+      "integrity": "sha512-Zu6THdrxQdyTuT2uA5FjUoBEsFHPzHcPIj18FszN6yXKHxSfGcR4TPLabfuT//E25q1Igyx9xta2WMvD/x9P/g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11892,6 +12083,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jerrypick": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.1.tgz",
+      "integrity": "sha512-XTtedPYEyVp4t6hJrXuRKr/jHj8SC4z+4K0b396PMkov6muL+i8IIamJIvZWe3jUspgIJak0P+BaWKawMYNBLg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/jest": {
@@ -13096,6 +13295,17 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.14.5.tgz",
+      "integrity": "sha512-H0iSpTynUzZw3tgraDmReprpFRmH5oP5GPmaNsurSwLx2H5iCpOMIkp5q+sfhB4Tz/UJd1E1IbEE9Z6ksnJ6RA==",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/keycloak-js": {
@@ -16112,6 +16322,22 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.1.tgz",
       "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.25.2.tgz",
+      "integrity": "sha512-dR5TYdz5HYnOPnL7BuhBUiHxXTQ55A0WrBed8oNA21s2+uD5mj17e1LqYMc3e5GR68vx2dplGrmmoyIwW2CwvA==",
+      "dependencies": {
+        "force-graph": "1",
+        "prop-types": "15",
+        "react-kapsule": "2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-i18next": {
       "version": "12.2.2",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-12.2.2.tgz",
@@ -16137,6 +16363,21 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.4.0.tgz",
+      "integrity": "sha512-w4Yv9CgWdj8kWGQEPNWFGJJ08dYEZHZpiaFR/DgZjCMBNqv9wus2Gy1qvHVJmJbzvAZbq6jdvFC+NYzEqAlNhQ==",
+      "dependencies": {
+        "fromentries": "^1.3.2",
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-leaflet": {
       "version": "4.2.1",
@@ -18421,6 +18662,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-data-table-component": "^7.5.3",
     "react-datepicker": "^4.11.0",
     "react-dom": "^18.2.0",
+    "react-force-graph-2d": "^1.25.2",
     "react-i18next": "^12.2.2",
     "react-leaflet": "^4.2.1",
     "react-mark-image": "^0.2.3",

--- a/src/App.css
+++ b/src/App.css
@@ -255,6 +255,15 @@ p {
   box-shadow: 5px 2px 11px 2px rgba(0, 0, 0, 0.54);
 }
 
+/* Overflow */
+.overflow-y-sroll {
+  overflow-y: scroll !important;
+}
+
+.overflow-x-hidden {
+  overflow-x: hidden;
+}
+
 /* Text overflow */
 .textOverflow {
   overflow: hidden;

--- a/src/components/general/graphs/RelationalGraph.tsx
+++ b/src/components/general/graphs/RelationalGraph.tsx
@@ -1,0 +1,186 @@
+// @ts-nocheck
+/* Import Dependencies */
+import { useEffect, useState, useCallback, useRef } from 'react';
+import ForceGraph2D from 'react-force-graph-2d';
+import classNames from 'classnames';
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Types */
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
+import { Dict } from 'app/Types';
+
+/* Import Styles */
+import styles from './graphs.module.scss';
+
+
+/* Props Typing */
+interface Props {
+    target: DigitalSpecimen,
+    relations: {
+        id: string,
+        name: string
+    }[]
+};
+
+
+const RelationalGraph = (props: Props) => {
+    const { target, relations } = props;
+
+    /* Hooks */
+    const graphRef = useRef(null);
+    const detailsBlockRef = useRef<HTMLDivElement>(null);
+
+    /* Base variables */
+    const [nodeTracker, setNodeTracker] = useState({
+        [target['ods:id']]: {
+            id: target['ods:id'],
+            name: target['ods:specimenName'],
+            color: '#4d59a2'
+        }
+    });
+    const [linkTracker, setLinkTracker] = useState<Dict>({});
+    const [canvas, setCanvas] = useState<Dict>();
+    const [detailsNode, setDetailsNode] = useState<Dict>();
+
+    /* Ref for graph canvas parent */
+    const MakeCanvas = useCallback((col: Dict) => {
+        if (col && !canvas) {
+            const newCanvas = {
+                width: col.getBoundingClientRect().width,
+                height: col.getBoundingClientRect().height
+            }
+
+            setCanvas(newCanvas);
+        }
+    }, []);
+
+    /* Hook for clicking outside of details block */
+    const UseDetailsBlock = () => {
+        useEffect(() => {
+            const detailsBlockElement = detailsBlockRef.current as HTMLDivElement;
+
+            const handleClickOutside = (event: Dict) => {
+                if (!detailsBlockElement.contains(event.target)) {
+                    if (detailsNode) {
+                        setDetailsNode(false);
+                    }
+                }
+            }
+
+            document.addEventListener("mousedown", handleClickOutside);
+
+            return () => {
+                document.removeEventListener("mousedown", handleClickOutside);
+            };
+        }, [detailsBlockRef, detailsNode])
+    }
+
+    UseDetailsBlock();
+
+    /* OnLoad: Create nodes and links between Enity Relationships */
+    useEffect(() => {
+        /* For each observed taxon, add to graph data */
+        if (relations.length > 0) {
+            const copyNodeTracker = { ...nodeTracker };
+            const copyLinkTracker = { ...linkTracker };
+
+            relations.forEach((relation) => {
+                copyNodeTracker[relation.id] = {
+                    id: relation.id,
+                    name: relation.name,
+                    color: '#51a993'
+                };
+
+                copyLinkTracker[`${relation.id}-${target['ods:id']}`] = {
+                    source: relation.id,
+                    target: target['ods:id']
+                };
+            });
+
+            setNodeTracker(copyNodeTracker);
+            setLinkTracker(copyLinkTracker);
+        }
+    }, [relations]);
+
+    /* Prepare graph nodes and links */
+    const nodes: Dict[] = [];
+
+    Object.entries(nodeTracker).forEach((value) => {
+        nodes.push(value[1]);
+    });
+
+    const links: Dict[] = [];
+
+    Object.entries(linkTracker).forEach((value) => {
+        links.push(value[1]);
+    });
+
+    const graphData = {
+        nodes: nodes,
+        links: links
+    };
+
+    /* Set Zoom */
+    if (graphRef.current) {
+        graphRef.current.zoom(5);
+    }
+
+    /* ClassNames */
+    const classDetailsBlock = classNames({
+        [`${styles.relationalGraphDetailsBlock} bottom-0 end-0`]: true,
+        'opacity-0': !detailsNode
+    });
+
+    return (
+        <Row className="h-100 w-100 py-4">
+            <Col className="h-100 w-100 mx-3 bg-white overflow-hidden position-relative" ref={MakeCanvas}>
+                {canvas &&
+                    <ForceGraph2D
+                        ref={graphRef}
+                        graphData={graphData}
+                        height={canvas['height']}
+                        width={canvas['width']}
+                        onNodeClick={(node) => setDetailsNode(node)}
+                        onBackgroundClick={() => setDetailsNode()}
+                        rendererConfig={{
+                            centerAt: [(canvas['height'] / 2), (canvas['width'] / 2)],
+                            pauseAnimation: true
+                        }}
+                        nodeCanvasObjectMode={() => "after"}
+                        nodeCanvasObject={(node, ctx, globalScale) => {
+                            const label = node.name;
+                            const fontSize = 10 / globalScale;
+                            ctx.font = `${fontSize}px Sans-Serif`;
+                            ctx.textAlign = node.isClusterNode ? "center" : "left";
+                            ctx.textBaseline = "middle";
+                            ctx.fillStyle = 'black';
+
+                            if (node.isClusterNode) {
+                                ctx.fillText(label, node.x as number, node.y as number);
+                            } else {
+                                ctx.fillText(label, node.x as number - 4, node.y as number);
+                            }
+                        }}
+                        nodeRelSize={8}
+                        enableNodeDrag={false}
+                    />
+                }
+
+                {/* Details Block */}
+                <div ref={detailsBlockRef}
+                    className={`${classDetailsBlock} position-absolute bgc-white b-primary z-1 rounded-c overflow-hidden`}
+                >
+                    <Row>
+                        <Col>
+                            <div className="bgc-primary px-3 py-2">
+                                <p className="fs-3 textOverflow fw-lightBold c-white"> {detailsNode?.name} </p>
+                            </div>
+                        </Col>
+                    </Row>
+                </div>
+            </Col>
+        </Row>
+    );
+}
+
+export default RelationalGraph;

--- a/src/components/general/graphs/RelationalGraph.tsx
+++ b/src/components/general/graphs/RelationalGraph.tsx
@@ -12,6 +12,9 @@ import { Dict } from 'app/Types';
 /* Import Styles */
 import styles from './graphs.module.scss';
 
+/* Import Webroot */
+import DiSSCoLogo from 'webroot/img/dissco-logo-web.svg';
+
 
 /* Props Typing */
 interface Props {
@@ -168,13 +171,30 @@ const RelationalGraph = (props: Props) => {
 
                 {/* Details Block */}
                 <div ref={detailsBlockRef}
-                    className={`${classDetailsBlock} position-absolute bgc-white b-primary z-1 rounded-c overflow-hidden`}
+                    className={`${classDetailsBlock} position-absolute bgc-white b-primary z-1 rounded-c overflow-hidden d-flex flex-column`}
                 >
                     <Row>
                         <Col>
                             <div className="bgc-primary px-3 py-2">
                                 <p className="fs-3 textOverflow fw-lightBold c-white"> {detailsNode?.name} </p>
                             </div>
+                        </Col>
+                    </Row>
+                    <Row className="flex-grow-1">
+                        <Col>
+                            <p className="fs-4 px-3 py-2">
+                                <a href={detailsNode?.id} target="_blank">
+                                    Link to source
+                                </a>
+                            </p>
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col>
+                            <img src={DiSSCoLogo}
+                                alt="DiSSCo logo"
+                                className="mx-5 my-2"    
+                            />
                         </Col>
                     </Row>
                 </div>

--- a/src/components/general/graphs/graphs.module.scss
+++ b/src/components/general/graphs/graphs.module.scss
@@ -3,5 +3,5 @@
 /* Relational graph */
 .relationalGraphDetailsBlock {
     width: 15rem;
-    height: 20rem;
+    height: auto;
 }

--- a/src/components/general/graphs/graphs.module.scss
+++ b/src/components/general/graphs/graphs.module.scss
@@ -1,0 +1,7 @@
+/* Custom styling for graph components */
+
+/* Relational graph */
+.relationalGraphDetailsBlock {
+    width: 15rem;
+    height: 20rem;
+}

--- a/src/components/specimen/components/ContentBlock.tsx
+++ b/src/components/specimen/components/ContentBlock.tsx
@@ -16,6 +16,7 @@ import SpecimenOverview from './contentBlocks/SpecimenOverview';
 import DigitalMedia from './contentBlocks/DigitalMedia';
 import Occurrences from './contentBlocks/Occurrences';
 import Identifications from './contentBlocks/Identifications';
+import EntityRelationships from './contentBlocks/EntityRelationships';
 import OriginalData from './contentBlocks/OriginalData';
 
 
@@ -43,7 +44,7 @@ const ContentBlock = (props: Props) => {
     });
 
     const classTabPanel = classNames({
-        'react-tabs__tab-panel flex-grow-1 overflow-hidden': true
+        'overflow-y-scroll overflow-x-hidden react-tabs__tab-panel flex-grow-1': true
     });
 
     return (
@@ -75,7 +76,7 @@ const ContentBlock = (props: Props) => {
                             </TabPanel>
 
                             {/* Occurrences View */}
-                            <TabPanel className={`${classTabPanel} ${'overflow-scroll'}`}>
+                            <TabPanel className={classTabPanel}>
                                 <Occurrences ShowWithAnnotations={(property: string) => ShowWithAnnotations(undefined, property)} />
                             </TabPanel>
 
@@ -86,7 +87,7 @@ const ContentBlock = (props: Props) => {
 
                             {/* Entity Relationships View */}
                             <TabPanel className={classTabPanel}>
-                                
+                                <EntityRelationships ShowWithAnnotations={(property: string) => ShowWithAnnotations(undefined, property)} />
                             </TabPanel>
 
                             {/* Original Data View */}

--- a/src/components/specimen/components/contentBlocks/EntityRelationships.tsx
+++ b/src/components/specimen/components/contentBlocks/EntityRelationships.tsx
@@ -7,11 +7,9 @@ import { Card, Row, Col } from 'react-bootstrap';
 import { useAppSelector } from 'app/hooks';
 import { getSpecimen } from 'redux/specimen/SpecimenSlice';
 
-/* Import Types */
-import { Dict } from 'app/Types';
-
 /* Import Components */
 import PropertiesTable from './PropertiesTable';
+import ToggleButton from './entityRelationsBlock/ToggleButton';
 import RelationalGraph from 'components/general/graphs/RelationalGraph';
 
 
@@ -27,7 +25,7 @@ const EntityRelationships = (props: Props) => {
     /* Base variables */
     const [viewToggle, setViewToggle] = useState<string>('graph');
     const specimen = useAppSelector(getSpecimen);
-    const relations: {id: string, name: string}[] = [];
+    const relations: { id: string, name: string }[] = [];
 
     /* OnLoad: Prepare relational graph data */
     specimen.digitalSpecimen.entityRelationships?.forEach((entityRelationship) => {
@@ -37,27 +35,12 @@ const EntityRelationships = (props: Props) => {
         })
     });
 
-    /* Template for button to toggle graph and table lay-out */
-    const ToggleButton = () => {
-        return (
-            <button className="position-absolute end-0 accentButton px-3 py-1 z-1 m-3"
-                onClick={() => {
-                    if (viewToggle === 'graph') {
-                        setViewToggle('table');
-                    } else {
-                        setViewToggle('graph');
-                    }
-                }}
-            >
-                {(viewToggle === 'graph') ? 'Table view' : 'Graph view'}
-            </button>
-        );
-    }
-
     if (viewToggle === 'table' && specimen.digitalSpecimen.entityRelationships?.length) {
         return (
             <div className="position-relative">
-                {ToggleButton()}
+                <ToggleButton viewToggle={viewToggle}
+                    SetViewToggle={(viewToggle: string) => setViewToggle(viewToggle)}
+                />
 
                 {specimen.digitalSpecimen.entityRelationships?.map((entityRelationship, index) => {
                     const key = `entityRelationship${index}`;
@@ -97,7 +80,9 @@ const EntityRelationships = (props: Props) => {
     } else if (viewToggle === 'graph' && specimen.digitalSpecimen.entityRelationships?.length) {
         return (
             <div className="h-100 position-relative">
-                {ToggleButton()}
+                <ToggleButton viewToggle={viewToggle}
+                    SetViewToggle={(viewToggle: string) => setViewToggle(viewToggle)}
+                />
 
                 <Card className="h-100">
                     <RelationalGraph target={specimen.digitalSpecimen}

--- a/src/components/specimen/components/contentBlocks/EntityRelationships.tsx
+++ b/src/components/specimen/components/contentBlocks/EntityRelationships.tsx
@@ -40,7 +40,7 @@ const EntityRelationships = (props: Props) => {
     /* Template for button to toggle graph and table lay-out */
     const ToggleButton = () => {
         return (
-            <button className="position-absolute end-0 accentButton px-3 py-1 z-1"
+            <button className="position-absolute end-0 accentButton px-3 py-1 z-1 m-3"
                 onClick={() => {
                     if (viewToggle === 'graph') {
                         setViewToggle('table');
@@ -49,7 +49,7 @@ const EntityRelationships = (props: Props) => {
                     }
                 }}
             >
-                {(viewToggle === 'graph') ? 'Table mode' : 'Graph mode'}
+                {(viewToggle === 'graph') ? 'Table view' : 'Graph view'}
             </button>
         );
     }

--- a/src/components/specimen/components/contentBlocks/EntityRelationships.tsx
+++ b/src/components/specimen/components/contentBlocks/EntityRelationships.tsx
@@ -1,0 +1,114 @@
+/* Import Dependencies */
+import { useState } from 'react';
+import classNames from 'classnames';
+import { Card, Row, Col } from 'react-bootstrap';
+
+/* Import Store */
+import { useAppSelector } from 'app/hooks';
+import { getSpecimen } from 'redux/specimen/SpecimenSlice';
+
+/* Import Types */
+import { Dict } from 'app/Types';
+
+/* Import Components */
+import PropertiesTable from './PropertiesTable';
+import RelationalGraph from 'components/general/graphs/RelationalGraph';
+
+
+/* Props Typing */
+interface Props {
+    ShowWithAnnotations: Function
+}
+
+
+const EntityRelationships = (props: Props) => {
+    const { ShowWithAnnotations } = props;
+
+    /* Base variables */
+    const [viewToggle, setViewToggle] = useState<string>('graph');
+    const specimen = useAppSelector(getSpecimen);
+    const relations: {id: string, name: string}[] = [];
+
+    /* OnLoad: Prepare relational graph data */
+    specimen.digitalSpecimen.entityRelationships?.forEach((entityRelationship) => {
+        relations.push({
+            id: entityRelationship.objectEntityIri,
+            name: entityRelationship.entityRelationshipType
+        })
+    });
+
+    /* Template for button to toggle graph and table lay-out */
+    const ToggleButton = () => {
+        return (
+            <button className="position-absolute end-0 accentButton px-3 py-1 z-1"
+                onClick={() => {
+                    if (viewToggle === 'graph') {
+                        setViewToggle('table');
+                    } else {
+                        setViewToggle('graph');
+                    }
+                }}
+            >
+                {(viewToggle === 'graph') ? 'Table mode' : 'Graph mode'}
+            </button>
+        );
+    }
+
+    if (viewToggle === 'table' && specimen.digitalSpecimen.entityRelationships?.length) {
+        return (
+            <div className="position-relative">
+                {ToggleButton()}
+
+                {specimen.digitalSpecimen.entityRelationships?.map((entityRelationship, index) => {
+                    const key = `entityRelationship${index}`;
+
+                    /* ClassNames */
+                    const CardClass = classNames({
+                        'mt-3': index > 0
+                    });
+
+                    return (
+                        <Card key={key} className={CardClass}>
+                            <Card.Body>
+                                <Row>
+                                    <Col>
+                                        <p className="fs-2 fw-lightBold">
+                                            {`Entity Relationship #${++index}`}
+                                        </p>
+                                    </Col>
+                                </Row>
+                                <Row>
+                                    <Col>
+                                        <div className="mt-3">
+                                            <PropertiesTable
+                                                title="Properties"
+                                                properties={entityRelationship}
+                                                ShowWithAnnotations={(property: string) => ShowWithAnnotations(property)}
+                                            />
+                                        </div>
+                                    </Col>
+                                </Row>
+                            </Card.Body>
+                        </Card>
+                    );
+                })}
+            </div>
+        );
+    } else if (viewToggle === 'graph' && specimen.digitalSpecimen.entityRelationships?.length) {
+        return (
+            <div className="h-100 position-relative">
+                {ToggleButton()}
+
+                <Card className="h-100">
+                    <RelationalGraph target={specimen.digitalSpecimen}
+                        relations={relations}
+                    />
+                </Card>
+            </div>
+        );
+    } else {
+        return <> </>
+    }
+}
+
+export default EntityRelationships;

--- a/src/components/specimen/components/contentBlocks/Identifications.tsx
+++ b/src/components/specimen/components/contentBlocks/Identifications.tsx
@@ -45,7 +45,7 @@ const Identifications = (props: Props) => {
             });
         }
 
-        /* Remove extensions from core occurrence object */
+        /* Remove extensions from core identification object */
         ['taxonIdentifications'].forEach((key) => delete copyIdentification[key]);
 
         identifications[index].properties = copyIdentification;
@@ -54,7 +54,7 @@ const Identifications = (props: Props) => {
     return (
         <>
             {identifications.map((identification, index) => {
-                const key = `occurrence${index}`;
+                const key = `identification${index}`;
 
                 /* ClassNames */
                 const CardClass = classNames({

--- a/src/components/specimen/components/contentBlocks/entityRelationsBlock/ToggleButton.tsx
+++ b/src/components/specimen/components/contentBlocks/entityRelationsBlock/ToggleButton.tsx
@@ -1,0 +1,26 @@
+/* Props Typing */
+interface Props {
+    viewToggle: string,
+    SetViewToggle: Function
+}
+
+
+const ToggleButton = (props: Props) => {
+    const { viewToggle, SetViewToggle } = props;
+
+    return (
+        <button className="position-absolute end-0 accentButton px-3 py-1 z-1 m-3"
+            onClick={() => {
+                if (viewToggle === 'graph') {
+                    SetViewToggle('table');
+                } else {
+                    SetViewToggle('graph');
+                }
+            }}
+        >
+            {(viewToggle === 'graph') ? 'Table view' : 'Graph view'}
+        </button>
+    );
+}
+
+export default ToggleButton;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,7 @@ import '@annotorious/react/annotorious-react.css';
 import App from './App';
 
 
-axios.defaults.baseURL = `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}/api/v1`;;
+axios.defaults.baseURL = `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}/api/v1`;
 
 const RenderRoot = () => {
   const root = ReactDOM.createRoot(


### PR DESCRIPTION
PR adds Entity Relationships tab containing two different views: a table view for displaying all the data in an orderly manner, and a graph view for visually indicating the relations to the specimen. A relation can be selected for more information. This still needs to be filled. The styling also needs to be reviewed.

Adds:
- Entity Relationships tab
- Table view for entity relationships
- Graph view for entity relationships