### PR TITLE
Machine Job Record overview

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -336,6 +336,10 @@ p {
   font-weight: 500;
 }
 
+.secondaryButton.disabled {
+  opacity: 0.6;
+}
+
 .secondaryButton:hover {
   background-color: var(--accent);
 }

--- a/src/api/digitalMedia/GetDigitalMediaMachineJobRecords.ts
+++ b/src/api/digitalMedia/GetDigitalMediaMachineJobRecords.ts
@@ -1,0 +1,33 @@
+/* Import Dependencies */
+import axios from 'axios';
+
+/* Import Types */
+import { JSONResultArray, Dict } from 'app/Types';
+
+
+const GetDigitalMediaMachineJobRecords = async (handle: string) => {
+    let specimenMachineJobRecords: Dict[] = [];
+
+    if (handle) {
+        const endPoint: string = `/digitalmedia/${handle}/mjr`;
+
+        try {
+            const result = await axios({
+                method: "get",
+                url: endPoint,
+                responseType: 'json'
+            });
+
+            /* Set Specimen MAS */
+            const data: JSONResultArray = result.data;
+
+            specimenMachineJobRecords = data.data;
+        } catch (error) {
+            console.warn(error);
+        }
+    }
+
+    return specimenMachineJobRecords;
+}
+
+export default GetDigitalMediaMachineJobRecords;

--- a/src/api/digitalMedia/GetDigitalMediaMachineJobRecords.ts
+++ b/src/api/digitalMedia/GetDigitalMediaMachineJobRecords.ts
@@ -6,7 +6,7 @@ import { JSONResultArray, Dict } from 'app/Types';
 
 
 const GetDigitalMediaMachineJobRecords = async (handle: string, pageSize: number, pageNumber: number) => {
-    let specimenMachineJobRecords: Dict[] = [];
+    let digitalMediaMachineJobRecords: Dict[] = [];
     let links: Dict = {};
 
     if (handle) {
@@ -23,10 +23,10 @@ const GetDigitalMediaMachineJobRecords = async (handle: string, pageSize: number
                 }
             });
 
-            /* Set Specimen Machine Job Records */
+            /* Set DigitalMedia Machine Job Records */
             const data: JSONResultArray = result.data;
 
-            specimenMachineJobRecords = data.data;
+            digitalMediaMachineJobRecords = data.data;
             links = data.links;
         } catch (error) {
             console.warn(error);
@@ -34,7 +34,7 @@ const GetDigitalMediaMachineJobRecords = async (handle: string, pageSize: number
     }
 
     return {
-        machineJobRecords: specimenMachineJobRecords,
+        machineJobRecords: digitalMediaMachineJobRecords,
         links: links
     };
 }

--- a/src/api/digitalMedia/GetDigitalMediaMachineJobRecords.ts
+++ b/src/api/digitalMedia/GetDigitalMediaMachineJobRecords.ts
@@ -18,7 +18,7 @@ const GetDigitalMediaMachineJobRecords = async (handle: string) => {
                 responseType: 'json'
             });
 
-            /* Set Specimen MAS */
+            /* Set Specimen Machine Job Records */
             const data: JSONResultArray = result.data;
 
             specimenMachineJobRecords = data.data;

--- a/src/api/digitalMedia/GetDigitalMediaMachineJobRecords.ts
+++ b/src/api/digitalMedia/GetDigitalMediaMachineJobRecords.ts
@@ -5,8 +5,9 @@ import axios from 'axios';
 import { JSONResultArray, Dict } from 'app/Types';
 
 
-const GetDigitalMediaMachineJobRecords = async (handle: string) => {
+const GetDigitalMediaMachineJobRecords = async (handle: string, pageSize: number, pageNumber: number) => {
     let specimenMachineJobRecords: Dict[] = [];
+    let links: Dict = {};
 
     if (handle) {
         const endPoint: string = `/digitalmedia/${handle}/mjr`;
@@ -15,19 +16,27 @@ const GetDigitalMediaMachineJobRecords = async (handle: string) => {
             const result = await axios({
                 method: "get",
                 url: endPoint,
-                responseType: 'json'
+                responseType: 'json',
+                params: {
+                    pageSize: pageSize,
+                    pageNumber: pageNumber ?? 1
+                }
             });
 
             /* Set Specimen Machine Job Records */
             const data: JSONResultArray = result.data;
 
             specimenMachineJobRecords = data.data;
+            links = data.links;
         } catch (error) {
             console.warn(error);
         }
     }
 
-    return specimenMachineJobRecords;
+    return {
+        machineJobRecords: specimenMachineJobRecords,
+        links: links
+    };
 }
 
 export default GetDigitalMediaMachineJobRecords;

--- a/src/api/specimen/GetSpecimenMachineJobRecords.ts
+++ b/src/api/specimen/GetSpecimenMachineJobRecords.ts
@@ -18,7 +18,7 @@ const GetSpecimenMachineJobRecords = async (handle: string) => {
                 responseType: 'json'
             });
 
-            /* Set Specimen MAS */
+            /* Set Specimen Machine Job Records */
             const data: JSONResultArray = result.data;
 
             specimenMachineJobRecords = data.data;

--- a/src/api/specimen/GetSpecimenMachineJobRecords.ts
+++ b/src/api/specimen/GetSpecimenMachineJobRecords.ts
@@ -5,8 +5,9 @@ import axios from 'axios';
 import { JSONResultArray, Dict } from 'app/Types';
 
 
-const GetSpecimenMachineJobRecords = async (handle: string) => {
+const GetSpecimenMachineJobRecords = async (handle: string, pageSize: number, pageNumber: number) => {
     let specimenMachineJobRecords: Dict[] = [];
+    let links: Dict = {};
 
     if (handle) {
         const endPoint: string = `/specimens/${handle}/mjr`;
@@ -15,19 +16,27 @@ const GetSpecimenMachineJobRecords = async (handle: string) => {
             const result = await axios({
                 method: "get",
                 url: endPoint,
-                responseType: 'json'
+                responseType: 'json',
+                params: {
+                    pageSize: pageSize,
+                    pageNumber: pageNumber ?? 1
+                }
             });
 
             /* Set Specimen Machine Job Records */
             const data: JSONResultArray = result.data;
 
             specimenMachineJobRecords = data.data;
+            links = data.links;
         } catch (error) {
             console.warn(error);
         }
     }
 
-    return specimenMachineJobRecords;
+    return {
+        machineJobRecords: specimenMachineJobRecords,
+        links: links
+    };
 }
 
 export default GetSpecimenMachineJobRecords;

--- a/src/api/specimen/GetSpecimenMachineJobRecords.ts
+++ b/src/api/specimen/GetSpecimenMachineJobRecords.ts
@@ -1,0 +1,33 @@
+/* Import Dependencies */
+import axios from 'axios';
+
+/* Import Types */
+import { JSONResultArray, Dict } from 'app/Types';
+
+
+const GetSpecimenMachineJobRecords = async (handle: string) => {
+    let specimenMachineJobRecords: Dict[] = [];
+
+    if (handle) {
+        const endPoint: string = `/specimens/${handle}/mjr`;
+
+        try {
+            const result = await axios({
+                method: "get",
+                url: endPoint,
+                responseType: 'json'
+            });
+
+            /* Set Specimen MAS */
+            const data: JSONResultArray = result.data;
+
+            specimenMachineJobRecords = data.data;
+        } catch (error) {
+            console.warn(error);
+        }
+    }
+
+    return specimenMachineJobRecords;
+}
+
+export default GetSpecimenMachineJobRecords;

--- a/src/api/user/GetUserMachineJobRecords.ts
+++ b/src/api/user/GetUserMachineJobRecords.ts
@@ -19,7 +19,7 @@ const GetUserMachineJobRecords = async (token: string | undefined, pageSize: num
                 responseType: 'json',
                 params: {
                     pageSize: pageSize,
-                    pageNumber: pageNumber ? pageNumber : 1
+                    pageNumber: pageNumber ?? 1
                 },
                 headers: {
                     'Content-type': 'application/json',

--- a/src/api/user/GetUserMachineJobRecords.ts
+++ b/src/api/user/GetUserMachineJobRecords.ts
@@ -3,15 +3,14 @@ import axios from 'axios';
 
 /* Import Types */
 import { JSONResultArray, Dict } from 'app/Types';
-import { Annotation } from 'app/types/Annotation';
 
 
-const GetUserAnnotations = async (token: string | undefined, pageSize: number, pageNumber?: number) => {
-    let userAnnotations = [] as Annotation[];
+const GetUserMachineJobRecords = async (token: string | undefined, pageSize: number, pageNumber: number) => {
+    let userMachineJobRecords: Dict[] = [];
     let links: Dict = {};
 
     if (token) {
-        const endPoint = 'annotations/creator';
+        const endPoint: string = `/users/mjr`;
 
         try {
             const result = await axios({
@@ -28,22 +27,20 @@ const GetUserAnnotations = async (token: string | undefined, pageSize: number, p
                 }
             });
 
-            /* Set User Annotations with model */
+            /* Set User Machine Job Records */
             const data: JSONResultArray = result.data;
+            
+            userMachineJobRecords = data.data;
             links = data.links;
-
-            data.data.forEach((dataRow) => {
-                userAnnotations.push(dataRow.attributes as Annotation);
-            });
         } catch (error) {
             console.warn(error);
         }
     }
 
     return {
-        userAnnotations: userAnnotations,
+        machineJobRecords: userMachineJobRecords,
         links: links
     };
 }
 
-export default GetUserAnnotations;
+export default GetUserMachineJobRecords;

--- a/src/app/tableConfig/MachineJobRecordTableConfig.ts
+++ b/src/app/tableConfig/MachineJobRecordTableConfig.ts
@@ -2,41 +2,50 @@
 import { TableColumn } from "react-data-table-component";
 
 
-const MachineJobRecordTableConfig = (idPrefix: string) => {
+const MachineJobRecordTableConfig = (idPrefix: string, showTargetId: boolean = false) => {
     interface DataRow {
         index: number,
         id: string,
+        targetId: string
         scheduled: string,
         completed: string,
         state: string
     };
 
     /* Set Datatable columns */
-    const tableColumns: TableColumn<DataRow>[] = [{
-        name: 'Job ID',
-        selector: row => row.id,
-        id: `${idPrefix}_machinejobrecord_jobid`,
-        sortable: true,
-        wrap: true
-    }, {
-        name: 'Scheduled',
-        selector: row => row.scheduled,
-        id: `${idPrefix}_machinejobrecord_scheduled`,
-        sortable: true,
-        wrap: true
-    }, {
-        name: 'Completed',
-        selector: row => row.completed,
-        id: `${idPrefix}_machinejobrecord_completed`,
-        sortable: true,
-        wrap: true
-    }, {
-        name: 'State',
-        selector: row => row.state,
-        id: `${idPrefix}_machinejobrecord_state`,
-        sortable: true,
-        wrap: true
-    }];
+    const tableColumns: TableColumn<DataRow>[] = [
+        {
+            name: 'TargetID',
+            selector: row => row.targetId,
+            id: `${idPrefix}_machinejobrecord_targetId`,
+            sortable: true,
+            wrap: true,
+            omit: showTargetId
+        }, {
+            name: 'Job ID',
+            selector: row => row.id,
+            id: `${idPrefix}_machinejobrecord_jobid`,
+            sortable: true,
+            wrap: true
+        }, {
+            name: 'Scheduled',
+            selector: row => row.scheduled,
+            id: `${idPrefix}_machinejobrecord_scheduled`,
+            sortable: true,
+            wrap: true
+        }, {
+            name: 'Completed',
+            selector: row => row.completed,
+            id: `${idPrefix}_machinejobrecord_completed`,
+            sortable: true,
+            wrap: true
+        }, {
+            name: 'State',
+            selector: row => row.state,
+            id: `${idPrefix}_machinejobrecord_state`,
+            sortable: true,
+            wrap: true
+        }];
 
     /* Custom styles for Data Table */
     const customStyles = {

--- a/src/app/tableConfig/MachineJobRecordTableConfig.ts
+++ b/src/app/tableConfig/MachineJobRecordTableConfig.ts
@@ -1,0 +1,73 @@
+/* Import Dependencies */
+import { TableColumn } from "react-data-table-component";
+
+
+const MachineJobRecordTableConfig = (idPrefix: string) => {
+    interface DataRow {
+        index: number,
+        id: string,
+        scheduled: string,
+        completed: string,
+        state: string
+    };
+
+    /* Set Datatable columns */
+    const tableColumns: TableColumn<DataRow>[] = [{
+        name: 'Job ID',
+        selector: row => row.id,
+        id: `${idPrefix}_machinejobrecord_jobid`,
+        sortable: true,
+        wrap: true
+    }, {
+        name: 'Scheduled',
+        selector: row => row.scheduled,
+        id: `${idPrefix}_machinejobrecord_scheduled`,
+        sortable: true,
+        wrap: true
+    }, {
+        name: 'Completed',
+        selector: row => row.completed,
+        id: `${idPrefix}_machinejobrecord_completed`,
+        sortable: true,
+        wrap: true
+    }, {
+        name: 'State',
+        selector: row => row.state,
+        id: `${idPrefix}_machinejobrecord_state`,
+        sortable: true,
+        wrap: true
+    }];
+
+    /* Custom styles for Data Table */
+    const customStyles = {
+        head: {
+            style: {
+                color: 'white',
+                fontSize: '14px'
+            }
+        },
+        headRow: {
+            style: {
+                backgroundColor: '#51a993'
+            }
+        },
+        rows: {
+            style: {
+                minHeight: '40px'
+            },
+            highlightOnHoverStyle: {
+                backgroundColor: '#98cdbf',
+            },
+            stripedStyle: {
+                backgroundColor: '#eef7f4'
+            }
+        }
+    };
+
+    return {
+        tableColumns: tableColumns,
+        customStyles: customStyles
+    };
+}
+
+export default MachineJobRecordTableConfig;

--- a/src/components/annotate/AnnotationTools.tsx
+++ b/src/components/annotate/AnnotationTools.tsx
@@ -2,6 +2,7 @@
 import classNames from "classnames";
 
 /* Import Types */
+import { Dict } from "app/Types";
 import { Annotation } from "app/types/Annotation";
 
 /* Import Components */
@@ -11,19 +12,23 @@ import SidePanel from "./sidePanel/SidePanel";
 
 /* Props Typing */
 interface Props {
+    targetId: string,
     sidePanelToggle: boolean,
     automatedAnnotationsToggle: boolean,
     SetAutomatedAnnotationToggle: Function,
     ShowWithAnnotations: Function,
     UpdateAnnotationsSource: Function,
-    RefreshAnnotations: Function
+    RefreshAnnotations: Function,
+    GetMachineJobRecords: {
+        (subString: string): Promise<Dict[]>
+    }
 };
 
 
 const AnnotationTools = (props: Props) => {
-    const {
-        sidePanelToggle, automatedAnnotationsToggle, SetAutomatedAnnotationToggle,
-        ShowWithAnnotations, UpdateAnnotationsSource, RefreshAnnotations
+    const { 
+        targetId, sidePanelToggle, automatedAnnotationsToggle, SetAutomatedAnnotationToggle,
+        ShowWithAnnotations, UpdateAnnotationsSource, RefreshAnnotations, GetMachineJobRecords
     } = props;
 
     /* Class Names */
@@ -36,8 +41,10 @@ const AnnotationTools = (props: Props) => {
     return (
         <>
             {/* Automated Annotations Modal */}
-            <AutomatedAnnotationsModal automatedAnnotationsToggle={automatedAnnotationsToggle}
+            <AutomatedAnnotationsModal targetId={targetId}
+                automatedAnnotationsToggle={automatedAnnotationsToggle}
                 HideAutomatedAnnotationsModal={() => SetAutomatedAnnotationToggle(false)}
+                GetMachineJobRecords={GetMachineJobRecords}
             />
 
             {/* Annotations Side Panel */}

--- a/src/components/annotate/AnnotationTools.tsx
+++ b/src/components/annotate/AnnotationTools.tsx
@@ -19,7 +19,7 @@ interface Props {
     ShowWithAnnotations: Function,
     UpdateAnnotationsSource: Function,
     RefreshAnnotations: Function,
-    GetMachineJobRecords: (subString: string) => Promise<Dict[]>
+    GetMachineJobRecords: (targetId: string, pageSize: number, pageNumber: number) => Promise<{machineJobRecords: Dict[], links: Dict}>
 };
 
 

--- a/src/components/annotate/AnnotationTools.tsx
+++ b/src/components/annotate/AnnotationTools.tsx
@@ -19,9 +19,7 @@ interface Props {
     ShowWithAnnotations: Function,
     UpdateAnnotationsSource: Function,
     RefreshAnnotations: Function,
-    GetMachineJobRecords: {
-        (subString: string): Promise<Dict[]>
-    }
+    GetMachineJobRecords: (subString: string) => Promise<Dict[]>
 };
 
 

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -46,6 +46,7 @@ import Footer from 'components/general/footer/Footer';
 import GetDigitalMedia from 'api/digitalMedia/GetDigitalMedia';
 import GetDigitalMediaAnnotations from 'api/digitalMedia/GetDigitalMediaAnnotations';
 import GetDigitalMediaVersions from 'api/digitalMedia/GetDigitalMediaVersions';
+import GetDigitalMediaMachineJobRecords from 'api/digitalMedia/GetDigitalMediaMachineJobRecords';
 
 
 const DigitalMedia = () => {
@@ -326,12 +327,14 @@ const DigitalMedia = () => {
                 </Col>
 
                 {/* Annotation Tools */}
-                <AnnotationTools sidePanelToggle={sidePanelToggle}
+                <AnnotationTools targetId={!isEmpty(digitalMedia.digitalEntity) ? digitalMedia.digitalEntity['ods:id'].replace(process.env.REACT_APP_DOI_URL as string, '') : ''}
+                    sidePanelToggle={sidePanelToggle}
                     automatedAnnotationsToggle={automatedAnnotationsToggle}
                     SetAutomatedAnnotationToggle={(toggle: boolean) => setAutomatedAnnotationsToggle(toggle)}
                     ShowWithAnnotations={() => ShowWithAnnotations()}
                     UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
                     RefreshAnnotations={(targetProperty: string) => RefreshAnnotations(targetProperty)}
+                    GetMachineJobRecords={GetDigitalMediaMachineJobRecords}
                 />
             </Row>
         </div>

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
@@ -1,28 +1,142 @@
 /* Import Dependencies */
-import { Row, Col } from 'react-bootstrap';
+import { useEffect, useState } from 'react';
+import Moment from 'moment';
+import DataTable, { TableColumn } from 'react-data-table-component';
 
-/* Import Styles */
-import styles from 'components/specimen/specimen.module.scss';
+/* Import Types */
+import { Dict } from 'app/Types';
 
 
-const AutomatedAnnotationsOverview = () => {
+/* Props Typing */
+interface Props {
+    targetId: string,
+    GetMachineJobRecords: {
+        (subString: string): Promise<Dict[]>
+    }
+};
+
+
+const AutomatedAnnotationsOverview = (props: Props) => {
+    const { targetId, GetMachineJobRecords } = props;
+
+    /* Declare type of a table row */
+    interface DataRow {
+        index: number,
+        id: string,
+        scheduled: string,
+        completed: string,
+        state: string
+    };
+
+    /* Base variables */
+    const [tableData, setTableData] = useState<DataRow[]>([]);
+
+    /* OnLoad: Fetch Machine Job Records */
+    useEffect(() => {
+        GetMachineJobRecords(targetId).then((machineJobRecords) => {
+            /* Construct table data */
+            const tableData: DataRow[] = [];
+
+            machineJobRecords.forEach((machineJobRecord, index) => {
+                tableData.push({
+                    index: index,
+                    id: machineJobRecord.id,
+                    scheduled: Moment(machineJobRecord.attributes.timeStarted).format('MMMM DD - YYYY'),
+                    completed: Moment(machineJobRecord.attributes.timeCompleted).format('MMMM DD - YYYY') ?? '--',
+                    state: machineJobRecord.attributes.state
+                });
+            });
+
+            setTableData(tableData);
+        }).catch(error => {
+            console.warn(error);
+        });
+    }, []);
+
+    /* Construct table columns */
+    const tableColumns: TableColumn<DataRow>[] = [{
+        name: 'Job ID',
+        selector: row => row.id,
+        id: 'mas_job_record_id',
+        sortable: true,
+        wrap: true
+    }, {
+        name: 'Scheduled',
+        selector: row => row.scheduled,
+        id: 'mas_job_record_scheduled',
+        sortable: true,
+        wrap: true
+    }, {
+        name: 'Completed',
+        selector: row => row.completed,
+        id: 'mas_job_record_completed',
+        sortable: true,
+        wrap: true
+    }, {
+        name: 'State',
+        selector: row => row.state,
+        id: 'mas_job_record_state',
+        sortable: true,
+        wrap: true
+    }];
+
+    /* Custom styles for Data Table */
+    const customStyles = {
+        table: {
+            style: {
+                width: '100%',
+                height: '100%'
+            }
+        },
+        tableWrapper: {
+            style: {
+                width: '100%',
+                height: '100%',
+                backgroundColor: 'white'
+            }
+        },
+        responsiveWrapper: {
+            style: {
+                width: '100%',
+                height: '100%'
+            }
+        },
+        head: {
+            style: {
+                fontSize: '0.875rem !important'
+            }
+        },
+        headRow: {
+            style: {
+                backgroundColor: '#51a993'
+            }
+        },
+        rows: {
+            style: {
+                minHeight: '40px',
+                fontSize: '0.875rem !important'
+            },
+            highlightOnHoverStyle: {
+                backgroundColor: '#98cdbf',
+            },
+            stripedStyle: {
+                backgroundColor: '#eef7f4'
+            }
+        }
+    };
+
     return (
-        <Row>
-            <Col>
-                {/* Overview headers */}
-                <Row>
-                    <Col md={{span: 6}}>
-                        <p className={styles.automatedAnnotationsHeader}> Service name </p>
-                    </Col>
-                    <Col md={{span: 4}}>
-                        <p className={styles.automatedAnnotationsHeader}> Issued </p>
-                    </Col>
-                    <Col md={{span: 2}}>
-                        <p className={styles.automatedAnnotationsHeader}> State </p>
-                    </Col>
-                </Row>
-            </Col>
-        </Row>
+        <DataTable
+            columns={tableColumns}
+            noDataComponent="No Machine Annotation job records found for this specimen"
+            data={tableData}
+            className='h-100 overflow-y-scroll z-1'
+            customStyles={customStyles}
+
+            striped
+            highlightOnHover
+            pointerOnHover
+        />
     );
 }
 

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
@@ -10,9 +10,7 @@ import { Dict } from 'app/Types';
 /* Props Typing */
 interface Props {
     targetId: string,
-    GetMachineJobRecords: {
-        (subString: string): Promise<Dict[]>
-    }
+    GetMachineJobRecords: (subString: string) => Promise<Dict[]>
 };
 
 

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
@@ -6,6 +6,9 @@ import DataTable, { TableColumn } from 'react-data-table-component';
 /* Import Types */
 import { Dict } from 'app/Types';
 
+/* Import Utilities */
+import MachineJobRecordTableConfig from 'app/tableConfig/MachineJobRecordTableConfig';
+
 
 /* Props Typing */
 interface Props {
@@ -51,77 +54,8 @@ const AutomatedAnnotationsOverview = (props: Props) => {
         });
     }, []);
 
-    /* Construct table columns */
-    const tableColumns: TableColumn<DataRow>[] = [{
-        name: 'Job ID',
-        selector: row => row.id,
-        id: 'mas_job_record_id',
-        sortable: true,
-        wrap: true
-    }, {
-        name: 'Scheduled',
-        selector: row => row.scheduled,
-        id: 'mas_job_record_scheduled',
-        sortable: true,
-        wrap: true
-    }, {
-        name: 'Completed',
-        selector: row => row.completed,
-        id: 'mas_job_record_completed',
-        sortable: true,
-        wrap: true
-    }, {
-        name: 'State',
-        selector: row => row.state,
-        id: 'mas_job_record_state',
-        sortable: true,
-        wrap: true
-    }];
-
-    /* Custom styles for Data Table */
-    const customStyles = {
-        table: {
-            style: {
-                width: '100%',
-                height: '100%'
-            }
-        },
-        tableWrapper: {
-            style: {
-                width: '100%',
-                height: '100%',
-                backgroundColor: 'white'
-            }
-        },
-        responsiveWrapper: {
-            style: {
-                width: '100%',
-                height: '100%'
-            }
-        },
-        head: {
-            style: {
-                fontSize: '0.875rem !important'
-            }
-        },
-        headRow: {
-            style: {
-                backgroundColor: '#51a993'
-            }
-        },
-        rows: {
-            style: {
-                minHeight: '40px',
-                fontSize: '0.875rem !important'
-            },
-            highlightOnHoverStyle: {
-                backgroundColor: '#98cdbf',
-            },
-            stripedStyle: {
-                backgroundColor: '#eef7f4'
-            }
-        }
-    };
+    /* Table Config */
+    const { tableColumns, customStyles} = MachineJobRecordTableConfig('MAS');
 
     return (
         <DataTable

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
@@ -27,14 +27,13 @@ import ScheduleDigitalMediaMAS from 'api/digitalMedia/ScheduleDigitalMediaMAS';
 
 /* Props Typing */
 interface Props {
-    targetId: string,
     availableMASList: Dict[],
-    HideAutomatedAnnotationsModal: Function
+    ReturnToOverview: Function
 };
 
 
 const AutomatedAnnotationsForm = (props: Props) => {
-    const { targetId, availableMASList, HideAutomatedAnnotationsModal } = props;
+    const { availableMASList, ReturnToOverview } = props;
 
     /* Hooks */
     const dispatch = useAppDispatch();
@@ -81,8 +80,8 @@ const AutomatedAnnotationsForm = (props: Props) => {
             });
         }
 
-        /* Hide MAS Modal */
-        HideAutomatedAnnotationsModal();
+        /* Return to overview tab */
+        ReturnToOverview();
     }
 
     /* ClassNames */

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
@@ -56,7 +56,7 @@ const AutomatedAnnotationsForm = (props: Props) => {
 
         /* Schedule MAS */
         if (location.pathname.includes('ds')) {
-            ScheduleSpecimenMAS(target['ods:id'], MASRecord, KeycloakService.GetToken()).then((specimenMAS) => {
+            ScheduleSpecimenMAS(target['ods:id'], MASRecord, KeycloakService.GetToken()).then((_specimenMAS) => {
                 /* Prompt the user the Machine Annotation Service is scheduled */
                 dispatch(pushToPromptMessages({
                     key: RandomString(),
@@ -67,7 +67,7 @@ const AutomatedAnnotationsForm = (props: Props) => {
                 console.warn(error);
             });
         } else if (location.pathname.includes('dm')) {
-            ScheduleDigitalMediaMAS(target['ods:id'], MASRecord, KeycloakService.GetToken()).then((digitalMediaMAS) => {
+            ScheduleDigitalMediaMAS(target['ods:id'], MASRecord, KeycloakService.GetToken()).then((_digitalMediaMAS) => {
                 /* Prompt the user the Machine Annotation Service is scheduled */
                 dispatch(pushToPromptMessages({
                     key: RandomString(),

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
@@ -1,14 +1,17 @@
 /* Import Dependencies */
+import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Formik, Form, Field, FieldArray } from 'formik';
 import KeycloakService from 'keycloak/Keycloak';
 import { RandomString } from 'app/Utilities';
+import classNames from 'classnames';
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { pushToPromptMessages } from 'redux/general/GeneralSlice';
 import { getMASTarget } from 'redux/annotate/AnnotateSlice';
+import { getUser } from 'redux/user/UserSlice';
 
 /* Import Types */
 import { Dict } from 'app/Types';
@@ -24,13 +27,14 @@ import ScheduleDigitalMediaMAS from 'api/digitalMedia/ScheduleDigitalMediaMAS';
 
 /* Props Typing */
 interface Props {
+    targetId: string,
     availableMASList: Dict[],
     HideAutomatedAnnotationsModal: Function
 };
 
 
 const AutomatedAnnotationsForm = (props: Props) => {
-    const { availableMASList, HideAutomatedAnnotationsModal } = props;
+    const { targetId, availableMASList, HideAutomatedAnnotationsModal } = props;
 
     /* Hooks */
     const dispatch = useAppDispatch();
@@ -38,6 +42,7 @@ const AutomatedAnnotationsForm = (props: Props) => {
 
     /* Base variables */
     const target = useAppSelector(getMASTarget);
+    const user = useAppSelector(getUser);
 
     /* Function for scheduling Machine Annotation Services */
     const ScheduleMachineAnnotations = (selectedMAS: string[]) => {
@@ -80,6 +85,12 @@ const AutomatedAnnotationsForm = (props: Props) => {
         HideAutomatedAnnotationsModal();
     }
 
+    /* ClassNames */
+    const classScheduleButton = classNames({
+        'secondaryButton px-3 py-1': true,
+        'disabled': !user.orcid
+    });
+
     return (
 
         <Formik initialValues={{
@@ -98,7 +109,6 @@ const AutomatedAnnotationsForm = (props: Props) => {
                     <div className="h-100 d-flex flex-column">
                         <Row className="flex-grow-1">
                             <Col>
-
                                 {/* Machine Annotation Services explanation */}
                                 <Row>
                                     <Col>
@@ -186,11 +196,21 @@ const AutomatedAnnotationsForm = (props: Props) => {
                             </Col>
                         </Row>
                         <Row>
-                            <Col>
-                                <button type="submit" className="secondaryButton px-3 py-1">
+                            <Col className="col-md-auto">
+                                <button type="submit"
+                                    className={classScheduleButton}
+                                    disabled={!user.orcid}
+                                >
                                     Schedule
                                 </button>
                             </Col>
+                            {!user.orcid &&
+                                <Col>
+                                    <p className="fs-5">
+                                        A user is required to link their ORCID to schedule Machine Annotation Services, please confirm this action in your profile
+                                    </p>
+                                </Col>
+                            }
                         </Row>
                     </div>
                 </Form>

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
@@ -1,5 +1,4 @@
 /* Import Dependencies */
-import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Formik, Form, Field, FieldArray } from 'formik';
 import KeycloakService from 'keycloak/Keycloak';

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
@@ -26,18 +26,23 @@ import GetSpecimenMAS from 'api/specimen/GetSpecimenMAS';
 import GetDigitalMediaMAS from 'api/digitalMedia/GetDigitalMediaMAS';
 
 /* Import Components */
+import AutomatedAnnotationsOverview from './AuomatedAnnotationsOverview';
 import AutomatedAnnotationsForm from './AutomatedAnnotationsForm';
 
 
 /* Props Typing */
 interface Props {
+    targetId: string,
     automatedAnnotationsToggle: boolean,
-    HideAutomatedAnnotationsModal: Function
+    HideAutomatedAnnotationsModal: Function,
+    GetMachineJobRecords: {
+        (subString: string): Promise<Dict[]>
+    }
 };
 
 
 const AutomatedAnnotationsModal = (props: Props) => {
-    const { automatedAnnotationsToggle, HideAutomatedAnnotationsModal } = props;
+    const { targetId, automatedAnnotationsToggle, HideAutomatedAnnotationsModal, GetMachineJobRecords } = props;
 
     /* Hooks */
     const location = useLocation();
@@ -96,12 +101,21 @@ const AutomatedAnnotationsModal = (props: Props) => {
                     <Col>
                         <Tabs className="h-100 d-flex flex-column">
                             <TabList className={classTabsList}>
-                                <Tab className={classTab} selectedClassName="active"> Schedule new Service </Tab>
+                                <Tab className={classTab} selectedClassName='active'> Services overview </Tab>
+                                <Tab className={classTab} selectedClassName="active"> Schedule a new Service </Tab>
                             </TabList>
 
+                            {/* Overview showing all current and past services */}
+                            <TabPanel className="react-tabs__tab-panel pt-1 px-3 flex-grow-1">
+                                <AutomatedAnnotationsOverview targetId={targetId}
+                                    GetMachineJobRecords={GetMachineJobRecords}
+                                />
+                            </TabPanel>
+
                             {/* Run a new automated annotation service */}
-                            <TabPanel className="pt-1 px-3 d-flex flex-grow-1">
-                                <AutomatedAnnotationsForm availableMASList={targetMAS}
+                            <TabPanel className="react-tabs__tab-panel pt-1 px-3 flex-grow-1">
+                                <AutomatedAnnotationsForm targetId={targetId}
+                                    availableMASList={targetMAS}
                                     HideAutomatedAnnotationsModal={() => HideAutomatedAnnotationsModal()}
                                 />
                             </TabPanel>

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
@@ -35,9 +35,7 @@ interface Props {
     targetId: string,
     automatedAnnotationsToggle: boolean,
     HideAutomatedAnnotationsModal: Function,
-    GetMachineJobRecords: {
-        (subString: string): Promise<Dict[]>
-    }
+    GetMachineJobRecords: (subString: string) => Promise<Dict[]>
 };
 
 

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
@@ -50,6 +50,7 @@ const AutomatedAnnotationsModal = (props: Props) => {
     /* Base variables */
     const target: DigitalSpecimen | DigitalEntity = useAppSelector(getMASTarget);
     const [targetMAS, setTargetMAS] = useState<Dict[]>([]);
+    const [selectedIndex, setSelectedIndex] = useState<number>(0);
 
     /* OnLoad: Fetch Specimen MAS */
     useEffect(() => {
@@ -99,7 +100,10 @@ const AutomatedAnnotationsModal = (props: Props) => {
             <Modal.Body>
                 <Row className="h-100">
                     <Col>
-                        <Tabs className="h-100 d-flex flex-column">
+                        <Tabs className="h-100 d-flex flex-column"
+                            selectedIndex={selectedIndex}
+                            onSelect={(index) => setSelectedIndex(index)}
+                        >
                             <TabList className={classTabsList}>
                                 <Tab className={classTab} selectedClassName='active'> Services overview </Tab>
                                 <Tab className={classTab} selectedClassName="active"> Schedule a new Service </Tab>
@@ -114,9 +118,8 @@ const AutomatedAnnotationsModal = (props: Props) => {
 
                             {/* Run a new automated annotation service */}
                             <TabPanel className="react-tabs__tab-panel pt-1 px-3 flex-grow-1">
-                                <AutomatedAnnotationsForm targetId={targetId}
-                                    availableMASList={targetMAS}
-                                    HideAutomatedAnnotationsModal={() => HideAutomatedAnnotationsModal()}
+                                <AutomatedAnnotationsForm availableMASList={targetMAS}
+                                    ReturnToOverview={() => setSelectedIndex(0)}
                                 />
                             </TabPanel>
                         </Tabs>

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsModal.tsx
@@ -35,7 +35,7 @@ interface Props {
     targetId: string,
     automatedAnnotationsToggle: boolean,
     HideAutomatedAnnotationsModal: Function,
-    GetMachineJobRecords: (subString: string) => Promise<Dict[]>
+    GetMachineJobRecords: (targetId: string, pageSize: number, pageNumber: number) => Promise<{machineJobRecords: Dict[], links: Dict}>
 };
 
 

--- a/src/components/profile/components/ProfileContent.tsx
+++ b/src/components/profile/components/ProfileContent.tsx
@@ -7,7 +7,8 @@ import { Row, Col } from 'react-bootstrap';
 import styles from 'components/profile/profile.module.scss';
 
 /* Import Components */
-import AnnotationsOverview from './annotate/AnnotationsOverview';
+import AnnotationsOverview from './tabs/AnnotationsOverview';
+import MachineJobRecordsOverview from './tabs/MachineJobRecordsOverview';
 
 
 const ProfileContent = () => {
@@ -30,11 +31,17 @@ const ProfileContent = () => {
                 <Tabs className="h-100 d-flex flex-column">
                     <TabList className={classTabsList}>
                         <Tab className={classTab} selectedClassName="active"> Annotations </Tab>
+                        <Tab className={classTab} selectedClassName="active"> Machine Job Records </Tab>
                     </TabList>
 
                     {/* User Annotations */}
                     <TabPanel className={classTabPanel}>
                         <AnnotationsOverview />
+                    </TabPanel>
+
+                    {/* Machine Job Records */}
+                    <TabPanel className={classTabPanel}>
+                        <MachineJobRecordsOverview />
                     </TabPanel>
                 </Tabs>
             </Col>

--- a/src/components/profile/components/tabs/AnnotationsOverview.tsx
+++ b/src/components/profile/components/tabs/AnnotationsOverview.tsx
@@ -121,43 +121,39 @@ const AnnotationsOverview = () => {
     };
 
     return (
-        <Row className="h-100">
-            <Col className="h-100">
-                <div className="h-100 d-flex flex-column">
-                    <Row className={`${styles.annotationsTable} flex-grow-1 pb-2`}>
-                        <Col className="h-100">
-                            <div className="h-100 overflow-scroll b-secondary rounded-c">
-                                <DataTable
-                                    columns={tableColumns}
-                                    data={tableData}
-                                    customStyles={customStyles}
-                                    onRowClicked={(row) => {
-                                        if (row.target.type === 'DigitalSpecimen') {
-                                            navigate(`/ds/${row.target.id.replace(process.env.REACT_APP_DOI_URL as string, '')}`);
-                                        } else if (row.target.type === 'DigitalMedia') {
-                                            navigate(`/dm/${row.target.id.replace(process.env.REACT_APP_DOI_URL as string, '')}`);
-                                        }
-                                    }}
+        <div className="h-100 d-flex flex-column">
+            <Row className={`${styles.overviewTable} flex-grow-1 pb-2`}>
+                <Col className="h-100">
+                    <div className="h-100 overflow-scroll b-secondary rounded-c">
+                        <DataTable
+                            columns={tableColumns}
+                            data={tableData}
+                            customStyles={customStyles}
+                            onRowClicked={(row) => {
+                                if (row.target.type === 'DigitalSpecimen') {
+                                    navigate(`/ds/${row.target.id.replace(process.env.REACT_APP_DOI_URL as string, '')}`);
+                                } else if (row.target.type === 'DigitalMedia') {
+                                    navigate(`/dm/${row.target.id.replace(process.env.REACT_APP_DOI_URL as string, '')}`);
+                                }
+                            }}
 
-                                    striped
-                                    highlightOnHover
-                                    pointerOnHover
-                                />
-                            </div>
-                        </Col>
-                    </Row>
-                    <Row className={`justify-content-center`}>
-                        <Col className="col-md-auto">
-                            <Paginator pageNumber={pageNumber}
-                                links={paginatorLinks}
+                            striped
+                            highlightOnHover
+                            pointerOnHover
+                        />
+                    </div>
+                </Col>
+            </Row>
+            <Row className={`justify-content-center`}>
+                <Col className="col-md-auto">
+                    <Paginator pageNumber={pageNumber}
+                        links={paginatorLinks}
 
-                                SetPageNumber={(pageNumber: number) => setPageNumber(pageNumber)}
-                            />
-                        </Col>
-                    </Row>
-                </div>
-            </Col>
-        </Row>
+                        SetPageNumber={(pageNumber: number) => setPageNumber(pageNumber)}
+                    />
+                </Col>
+            </Row>
+        </div>
     );
 }
 

--- a/src/components/profile/components/tabs/MachineJobRecordsOverview.tsx
+++ b/src/components/profile/components/tabs/MachineJobRecordsOverview.tsx
@@ -41,8 +41,6 @@ const MachineJobRecordsOverview = () => {
             const tableData: DataRow[] = [];
 
             machineJobRecords.forEach((machineJobRecord: Dict, index: number) => {
-                console.log(machineJobRecord);
-
                 tableData.push({
                     index: index,
                     id: machineJobRecord.id,

--- a/src/components/profile/components/tabs/MachineJobRecordsOverview.tsx
+++ b/src/components/profile/components/tabs/MachineJobRecordsOverview.tsx
@@ -1,12 +1,9 @@
 /* Import Dependencies */
 import { useEffect, useState } from 'react';
-import DataTable, { TableColumn } from 'react-data-table-component';
+import DataTable from 'react-data-table-component';
 import Moment from 'moment';
 import KeycloakService from 'keycloak/Keycloak';
 import { Row, Col } from 'react-bootstrap';
-
-/* Import Store */
-
 
 /* Import Types */
 import { Dict } from 'app/Types';
@@ -16,6 +13,9 @@ import styles from 'components/profile/profile.module.scss';
 
 /* Import Components */
 import Paginator from 'components/general/paginator/Paginator';
+
+/* Import Utilities */
+import MachineJobRecordTableConfig from 'app/tableConfig/MachineJobRecordTableConfig';
 
 /* Import API */
 import GetUserMachineJobRecords from 'api/user/GetUserMachineJobRecords';
@@ -61,58 +61,8 @@ const MachineJobRecordsOverview = () => {
         });
     }, [pageNumber]);
 
-    /* Set Datatable columns */
-    const tableColumns: TableColumn<DataRow>[] = [{
-        name: 'Job ID',
-        selector: row => row.id,
-        id: 'profile_machinejobrecord_jobid',
-        sortable: true,
-        wrap: true
-    }, {
-        name: 'Scheduled',
-        selector: row => row.scheduled,
-        id: 'profile_machinejobrecord_scheduled',
-        sortable: true,
-        wrap: true
-    }, {
-        name: 'Completed',
-        selector: row => row.completed,
-        id: 'profile_machinejobrecord_completed',
-        sortable: true,
-        wrap: true
-    }, {
-        name: 'State',
-        selector: row => row.state,
-        id: 'profile_machinejobrecord_state',
-        sortable: true,
-        wrap: true
-    }];
-
-    /* Custom styles for Data Table */
-    const customStyles = {
-        head: {
-            style: {
-                color: 'white',
-                fontSize: '14px'
-            }
-        },
-        headRow: {
-            style: {
-                backgroundColor: '#51a993'
-            }
-        },
-        rows: {
-            style: {
-                minHeight: '40px'
-            },
-            highlightOnHoverStyle: {
-                backgroundColor: '#98cdbf',
-            },
-            stripedStyle: {
-                backgroundColor: '#eef7f4'
-            }
-        }
-    };
+    /* Table Config */
+    const { tableColumns, customStyles } = MachineJobRecordTableConfig('profile');
 
     return (
         <div className="h-100 d-flex flex-column">

--- a/src/components/profile/components/tabs/MachineJobRecordsOverview.tsx
+++ b/src/components/profile/components/tabs/MachineJobRecordsOverview.tsx
@@ -8,9 +8,6 @@ import { Row, Col } from 'react-bootstrap';
 /* Import Types */
 import { Dict } from 'app/Types';
 
-/* Import Styles */
-import styles from 'components/profile/profile.module.scss';
-
 /* Import Components */
 import Paginator from 'components/general/paginator/Paginator';
 
@@ -24,13 +21,14 @@ import GetUserMachineJobRecords from 'api/user/GetUserMachineJobRecords';
 const MachineJobRecordsOverview = () => {
     /* Base variables */
     const [tableData, setTableData] = useState<DataRow[]>([]);
-    const pageSize = 25;
-    const [pageNumber, setPageNumber] = useState<number>(1);
     const [paginatorLinks, setPaginatorLinks] = useState<Dict>({});
+    const [pageNumber, setPageNumber] = useState<number>(1);
+    const pageSize = 25;
 
     interface DataRow {
         index: number,
         id: string,
+        targetId: string,
         scheduled: string,
         completed: string,
         state: string
@@ -43,9 +41,12 @@ const MachineJobRecordsOverview = () => {
             const tableData: DataRow[] = [];
 
             machineJobRecords.forEach((machineJobRecord: Dict, index: number) => {
+                console.log(machineJobRecord);
+
                 tableData.push({
                     index: index,
                     id: machineJobRecord.id,
+                    targetId: machineJobRecord.attributes.targetId,
                     scheduled: Moment(machineJobRecord.attributes.timeStarted).format('MMMM DD - YYYY'),
                     completed: Moment(machineJobRecord.attributes.timeCompleted).format('MMMM DD - YYYY') ?? '--',
                     state: machineJobRecord.attributes.state
@@ -62,11 +63,11 @@ const MachineJobRecordsOverview = () => {
     }, [pageNumber]);
 
     /* Table Config */
-    const { tableColumns, customStyles } = MachineJobRecordTableConfig('profile');
+    const { tableColumns, customStyles } = MachineJobRecordTableConfig('profile', true);
 
     return (
         <div className="h-100 d-flex flex-column">
-            <Row className={`${styles.annotationsTable} flex-grow-1 pb-2`}>
+            <Row className="flex-grow-1 pb-2">
                 <Col className="h-100">
                     <div className="h-100 overflow-scroll b-secondary rounded-c">
                         <DataTable
@@ -76,6 +77,7 @@ const MachineJobRecordsOverview = () => {
 
                             striped
                             highlightOnHover
+                            pointerOnHover
                         />
                     </div>
                 </Col>

--- a/src/components/profile/components/tabs/MachineJobRecordsOverview.tsx
+++ b/src/components/profile/components/tabs/MachineJobRecordsOverview.tsx
@@ -1,0 +1,146 @@
+/* Import Dependencies */
+import { useEffect, useState } from 'react';
+import DataTable, { TableColumn } from 'react-data-table-component';
+import Moment from 'moment';
+import KeycloakService from 'keycloak/Keycloak';
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Store */
+
+
+/* Import Types */
+import { Dict } from 'app/Types';
+
+/* Import Styles */
+import styles from 'components/profile/profile.module.scss';
+
+/* Import Components */
+import Paginator from 'components/general/paginator/Paginator';
+
+/* Import API */
+import GetUserMachineJobRecords from 'api/user/GetUserMachineJobRecords';
+
+
+const MachineJobRecordsOverview = () => {
+    /* Base variables */
+    const [tableData, setTableData] = useState<DataRow[]>([]);
+    const pageSize = 25;
+    const [pageNumber, setPageNumber] = useState<number>(1);
+    const [paginatorLinks, setPaginatorLinks] = useState<Dict>({});
+
+    interface DataRow {
+        index: number,
+        id: string,
+        scheduled: string,
+        completed: string,
+        state: string
+    };
+
+    /* OnChange of Pagination Range: try to fetch User Annotations by new range */
+    useEffect(() => {
+        GetUserMachineJobRecords(KeycloakService.GetToken(), pageSize, pageNumber).then(({ machineJobRecords, links }) => {
+            /* Construct and set table data */
+            const tableData: DataRow[] = [];
+
+            machineJobRecords.forEach((machineJobRecord: Dict, index: number) => {
+                tableData.push({
+                    index: index,
+                    id: machineJobRecord.id,
+                    scheduled: Moment(machineJobRecord.attributes.timeStarted).format('MMMM DD - YYYY'),
+                    completed: Moment(machineJobRecord.attributes.timeCompleted).format('MMMM DD - YYYY') ?? '--',
+                    state: machineJobRecord.attributes.state
+                });
+            });
+
+            setTableData(tableData);
+
+            /* Set Paginator links */
+            setPaginatorLinks(links);
+        }).catch(error => {
+            console.warn(error);
+        });
+    }, [pageNumber]);
+
+    /* Set Datatable columns */
+    const tableColumns: TableColumn<DataRow>[] = [{
+        name: 'Job ID',
+        selector: row => row.id,
+        id: 'profile_machinejobrecord_jobid',
+        sortable: true,
+        wrap: true
+    }, {
+        name: 'Scheduled',
+        selector: row => row.scheduled,
+        id: 'profile_machinejobrecord_scheduled',
+        sortable: true,
+        wrap: true
+    }, {
+        name: 'Completed',
+        selector: row => row.completed,
+        id: 'profile_machinejobrecord_completed',
+        sortable: true,
+        wrap: true
+    }, {
+        name: 'State',
+        selector: row => row.state,
+        id: 'profile_machinejobrecord_state',
+        sortable: true,
+        wrap: true
+    }];
+
+    /* Custom styles for Data Table */
+    const customStyles = {
+        head: {
+            style: {
+                color: 'white',
+                fontSize: '14px'
+            }
+        },
+        headRow: {
+            style: {
+                backgroundColor: '#51a993'
+            }
+        },
+        rows: {
+            style: {
+                minHeight: '40px'
+            },
+            highlightOnHoverStyle: {
+                backgroundColor: '#98cdbf',
+            },
+            stripedStyle: {
+                backgroundColor: '#eef7f4'
+            }
+        }
+    };
+
+    return (
+        <div className="h-100 d-flex flex-column">
+            <Row className={`${styles.annotationsTable} flex-grow-1 pb-2`}>
+                <Col className="h-100">
+                    <div className="h-100 overflow-scroll b-secondary rounded-c">
+                        <DataTable
+                            columns={tableColumns}
+                            data={tableData}
+                            customStyles={customStyles}
+
+                            striped
+                            highlightOnHover
+                        />
+                    </div>
+                </Col>
+            </Row>
+            <Row className={`justify-content-center`}>
+                <Col className="col-md-auto">
+                    <Paginator pageNumber={pageNumber}
+                        links={paginatorLinks}
+
+                        SetPageNumber={(pageNumber: number) => setPageNumber(pageNumber)}
+                    />
+                </Col>
+            </Row>
+        </div>
+    );
+}
+
+export default MachineJobRecordsOverview;

--- a/src/components/profile/profile.module.scss
+++ b/src/components/profile/profile.module.scss
@@ -34,8 +34,3 @@
 .userInfoSubmit:hover {
     background-color: var(--accent) !important;
 }
-
-/* Overview Table */
-.overviewTable {
-    height: 85%;
-}

--- a/src/components/profile/profile.module.scss
+++ b/src/components/profile/profile.module.scss
@@ -35,12 +35,7 @@
     background-color: var(--accent) !important;
 }
 
-/* Annotations Table */
-.annotationsTable {
+/* Overview Table */
+.overviewTable {
     height: 85%;
-}
-
-.annotationsTablePaginator {
-    margin-top: 2.5%;
-    height: 10%;
 }

--- a/src/components/specimen/Specimen.tsx
+++ b/src/components/specimen/Specimen.tsx
@@ -39,6 +39,7 @@ import GetSpecimen from 'api/specimen/GetSpecimen';
 import GetSpecimenFull from 'api/specimen/GetSpecimenFull';
 import GetSpecimenVersions from 'api/specimen/GetSpecimenVersions';
 import GetSpecimenAnnotations from 'api/specimen/GetSpecimenAnnotations';
+import GetSpecimenMachineJobRecords from 'api/specimen/GetSpecimenMachineJobRecords';
 
 
 const Specimen = () => {
@@ -270,12 +271,14 @@ const Specimen = () => {
                 </Col>
 
                 {/* Annotation Tools */}
-                <AnnotationTools sidePanelToggle={sidePanelToggle}
+                <AnnotationTools targetId={!isEmpty(specimen.digitalSpecimen) ? specimen.digitalSpecimen['ods:id'].replace(process.env.REACT_APP_DOI_URL as string, '') : ''}
+                    sidePanelToggle={sidePanelToggle}
                     automatedAnnotationsToggle={automatedAnnotationsToggle}
                     SetAutomatedAnnotationToggle={(toggle: boolean) => setAutomatedAnnotationToggle(toggle)}
                     ShowWithAnnotations={() => ShowWithAnnotations()}
                     UpdateAnnotationsSource={(annotation: Annotation, remove?: boolean) => UpdateAnnotationsSource(annotation, remove)}
                     RefreshAnnotations={(targetProperty: string) => RefreshAnnotations(targetProperty)}
+                    GetMachineJobRecords={GetSpecimenMachineJobRecords}
                 />
             </Row>
         </div>

--- a/src/components/specimen/components/TitleBar.tsx
+++ b/src/components/specimen/components/TitleBar.tsx
@@ -41,7 +41,7 @@ const TitleBar = (props: Props) => {
     const specimenActions = [
         { value: 'json', label: 'View JSON' },
         { value: 'sidePanel', label: 'View all Annotations' },
-        { value: 'automatedAnnotations', label: 'Trigger Automated Annotations', isDisabled: !KeycloakService.IsLoggedIn() },
+        { value: 'automatedAnnotations', label: 'Machine Annotation Services', isDisabled: !KeycloakService.IsLoggedIn() },
         { value: 'download', label: 'Download as JSON' }
     ];
 


### PR DESCRIPTION
PR adds support for the Machine Job Record.
Machine Job Records created for Specimen or Digital Media can be viewed inside the MAS modal.
The overview should help indicate the current state of the MAS that are running in the background, or have been completed.
After scheduling a MAS, the user will be redirected to the overview.

An overview of the Machine Job Records the user set in motion can be found on the Profile page.