### PR TITLE
Make properties tables collapsable

### DIFF
--- a/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AuomatedAnnotationsOverview.tsx
@@ -52,7 +52,7 @@ const AutomatedAnnotationsOverview = (props: Props) => {
                     id: machineJobRecord.id,
                     targetId: machineJobRecord.attributes.targetId,
                     scheduled: Moment(machineJobRecord.attributes.timeStarted).format('MMMM DD - YYYY'),
-                    completed: Moment(machineJobRecord.attributes.timeCompleted).format('MMMM DD - YYYY') ?? '--',
+                    completed: machineJobRecord.attributes.timeCompleted ? Moment(machineJobRecord.attributes.timeCompleted).format('MMMM DD - YYYY') : '--',
                     state: machineJobRecord.attributes.state
                 });
             });

--- a/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
+++ b/src/components/general/automatedAnnotations/automatedAnnotations/AutomatedAnnotationsForm.tsx
@@ -62,7 +62,7 @@ const AutomatedAnnotationsForm = (props: Props) => {
                     key: RandomString(),
                     message: 'Machine Annotation Service, committed successfully!',
                     template: 'success'
-                }))
+                }));
             }).catch(error => {
                 console.warn(error);
             });
@@ -73,7 +73,7 @@ const AutomatedAnnotationsForm = (props: Props) => {
                     key: RandomString(),
                     message: 'Machine Annotation Service, committed successfully!',
                     template: 'success'
-                }))
+                }));
             }).catch(error => {
                 console.warn(error);
             });

--- a/src/components/specimen/components/contentBlocks/Assertions.tsx
+++ b/src/components/specimen/components/contentBlocks/Assertions.tsx
@@ -1,13 +1,12 @@
 /* Import Dependencies */
-import { Card, Row, Col } from 'react-bootstrap';
-import classNames from "classnames";
+import { Card } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector } from "app/hooks";
 import { getSpecimen } from "redux/specimen/SpecimenSlice";
 
 /* Import Components */
-import PropertiesTable from './PropertiesTable';
+import PropertiesBlock from './PropertiesBlock';
 
 
 /* Props Typing */
@@ -28,37 +27,13 @@ const Assertions = (props: Props) => {
                 {specimen.digitalSpecimen.assertions?.map((assertion, index) => {
                     const key = `assertion${index}`;
 
-                    /* ClassNames */
-                    const CardClass = classNames({
-                        'mt-3': index > 0
-                    });
-
-                    return (
-                        <Card key={key} className={CardClass}>
-                            <Card.Body>
-                                <Row>
-                                    <Col>
-                                        <p className="fs-2 fw-lightBold">
-                                            {`Assertion #${++index}`}
-                                        </p>
-                                    </Col>
-                                </Row>
-                                <Row>
-                                    <Col>
-                                        <div className="mt-3">
-                                            <PropertiesTable
-                                                title="Properties"
-                                                properties={assertion}
-                                                ShowWithAnnotations={(property: string) =>
-                                                    ShowWithAnnotations(`assertions[${index - 1}]${property}`, index)
-                                                }
-                                            />
-                                        </div>
-                                    </Col>
-                                </Row>
-                            </Card.Body>
-                        </Card>
-                    );
+                    return <PropertiesBlock key={key}
+                        index={index}
+                        instanceName='Assertion'
+                        instanceLevel='assertions'
+                        instanceProperties={assertion}
+                        ShowWithAnnotations={(propertyName: string) => ShowWithAnnotations(propertyName, index)}
+                    />
                 })}
             </>
                 : <Card className="h-100 d-flex justify-content-center align-items-center">

--- a/src/components/specimen/components/contentBlocks/EntityRelationships.tsx
+++ b/src/components/specimen/components/contentBlocks/EntityRelationships.tsx
@@ -1,7 +1,6 @@
 /* Import Dependencies */
 import { useState } from 'react';
-import classNames from 'classnames';
-import { Card, Row, Col } from 'react-bootstrap';
+import { Card } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector } from 'app/hooks';
@@ -11,7 +10,7 @@ import { getSpecimen, getSpecimenAnnotations } from 'redux/specimen/SpecimenSlic
 import { Dict } from 'app/Types';
 
 /* Import Components */
-import PropertiesTable from './PropertiesTable';
+import PropertiesBlock from './PropertiesBlock';
 import ToggleButton from './entityRelationsBlock/ToggleButton';
 import Cytoscape from 'components/general/graphs/Cytoscape';
 
@@ -64,39 +63,17 @@ const EntityRelationships = (props: Props) => {
                 </div>
 
                 {specimen.digitalSpecimen.entityRelationships?.map((entityRelationship, index) => {
+                    console.log(entityRelationship);
+
                     const key = `entityRelationship${index}`;
 
-                    /* ClassNames */
-                    const CardClass = classNames({
-                        'mt-3': index > 0
-                    });
-
-                    return (
-                        <Card key={key} className={CardClass}>
-                            <Card.Body>
-                                <Row>
-                                    <Col>
-                                        <p className="fs-2 fw-lightBold">
-                                            {`Entity Relationship #${++index}`}
-                                        </p>
-                                    </Col>
-                                </Row>
-                                <Row>
-                                    <Col>
-                                        <div className="mt-3">
-                                            <PropertiesTable
-                                                title="Properties"
-                                                properties={entityRelationship}
-                                                ShowWithAnnotations={(property: string) =>
-                                                    ShowWithAnnotations(`entityRelationships[${index - 1}]${property}`, index)
-                                                }
-                                            />
-                                        </div>
-                                    </Col>
-                                </Row>
-                            </Card.Body>
-                        </Card>
-                    );
+                    return <PropertiesBlock key={key}
+                        index={index}
+                        instanceName='Entity Relationship'
+                        instanceLevel='entityRelationships'
+                        instanceProperties={entityRelationship}
+                        ShowWithAnnotations={(propertyName: string) => ShowWithAnnotations(propertyName, index)}
+                    />
                 })}
             </div>
         );

--- a/src/components/specimen/components/contentBlocks/Identifications.tsx
+++ b/src/components/specimen/components/contentBlocks/Identifications.tsx
@@ -11,7 +11,7 @@ import { getSpecimen } from 'redux/specimen/SpecimenSlice';
 import { Dict } from 'app/Types';
 
 /* Import Components */
-import PropertiesTable from './PropertiesTable';
+import PropertiesBlock from './PropertiesBlock';
 
 
 /* Props Typing */
@@ -59,44 +59,14 @@ const Identifications = (props: Props) => {
             {identifications.map((identification, index) => {
                 const key = `identification${index}`;
 
-                /* ClassNames */
-                const CardClass = classNames({
-                    'mt-3': index > 0
-                });
-
-                return (
-                    <Card key={key} className={CardClass}>
-                        <Card.Body>
-                            <Row>
-                                <Col>
-                                    <p className="fs-2 fw-lightBold">
-                                        {identification.properties['dwc:identificationVerificationStatus'] ?
-                                            <> {`Identification #${++index} (accepted)`} </>
-                                            : <> {`Identification #${++index}`} </>
-                                        }
-                                    </p>
-                                </Col>
-                            </Row>
-                            <Row>
-                                <Col>
-                                    {Object.keys(identification).map((identificationKey) => {
-                                        return (
-                                            <div key={identificationKey} className="mt-3">
-                                                <PropertiesTable
-                                                    title={identificationKey}
-                                                    properties={identification[identificationKey]}
-                                                    ShowWithAnnotations={(property: string) =>
-                                                        ShowWithAnnotations(`identifications[${index - 1}]${(identificationLevels[identificationKey.slice(0, identificationKey.indexOf('#')).replaceAll(' ', '') as keyof typeof identificationLevels] ?? '')}${property}`, index)
-                                                    }
-                                                />
-                                            </div>
-                                        );
-                                    })}
-                                </Col>
-                            </Row>
-                        </Card.Body>
-                    </Card>
-                );
+                return <PropertiesBlock key={key}
+                    index={index}
+                    instanceName='Identification'
+                    taxonAcceptedName='Accepted Identification'
+                    instanceLevel='identifications'
+                    instanceProperties={identification}
+                    ShowWithAnnotations={(propertyName: string) => ShowWithAnnotations(propertyName, index)}
+                />
             })}
         </>
     );

--- a/src/components/specimen/components/contentBlocks/Occurrences.tsx
+++ b/src/components/specimen/components/contentBlocks/Occurrences.tsx
@@ -1,7 +1,5 @@
 /* Import Dependencies */
 import { isEmpty, cloneDeep } from 'lodash';
-import classNames from 'classnames';
-import { Card, Row, Col } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector } from 'app/hooks';
@@ -11,7 +9,7 @@ import { getSpecimen } from 'redux/specimen/SpecimenSlice';
 import { Dict } from 'app/Types';
 
 /* Import Components */
-import PropertiesTable from './PropertiesTable';
+import PropertiesBlock from './PropertiesBlock';
 
 
 /* Props Typing */
@@ -83,39 +81,16 @@ const Occurrences = (props: Props) => {
             {occurrences.map((occurrence, index) => {
                 const key = `occurrence_${index}`;
 
-                /* ClassNames */
-                const CardClass = classNames({
-                    'mt-3': index > 0
-                });
+                console.log(occurrence);
 
-                return (
-                    <Card key={key} className={CardClass}>
-                        <Card.Body>
-                            <Row>
-                                <Col>
-                                    <p className="fs-2 fw-lightBold"> {`Occurrence #${++index}`} </p>
-                                </Col>
-                            </Row>
-                            <Row>
-                                <Col>
-                                    {Object.keys(occurrence).map((occurreneKey) => {
-                                        return (
-                                            <div key={occurreneKey} className="mt-3">
-                                                <PropertiesTable
-                                                    title={occurreneKey}
-                                                    properties={occurrence[occurreneKey as keyof typeof occurrence] as Dict}
-                                                    ShowWithAnnotations={(property: string) =>
-                                                        ShowWithAnnotations(`occurrences[${index - 1}]${occurrenceLevels[occurreneKey as keyof typeof occurrenceLevels] ?? ''}${property}`, index)
-                                                    }
-                                                />
-                                            </div>
-                                        );
-                                    })}
-                                </Col>
-                            </Row>
-                        </Card.Body>
-                    </Card>
-                );
+                return <PropertiesBlock key={key}
+                    index={index}
+                    instanceName='Occurrence'
+                    instanceLevel='occurrences'
+                    instanceLevels={occurrenceLevels}
+                    instanceProperties={occurrence}
+                    ShowWithAnnotations={(propertyName: string) => ShowWithAnnotations(propertyName, index)}
+                />
             })}
         </>
     );

--- a/src/components/specimen/components/contentBlocks/PropertiesBlock.tsx
+++ b/src/components/specimen/components/contentBlocks/PropertiesBlock.tsx
@@ -30,7 +30,7 @@ const PropertiesBlock = (props: Props) => {
     const { index, instanceName, taxonAcceptedName, instanceLevel, instanceLevels, instanceProperties, ShowWithAnnotations } = props;
 
     /* Base variables */
-    const [collapsed, setCollapsed] = useState<boolean>((index > 0) ? true : false);
+    const [collapsed, setCollapsed] = useState<boolean>(index > 0);
     let blockName: string;
     
     if (taxonAcceptedName && instanceProperties.properties['dwc:identificationVerificationStatus'] && instanceProperties.properties['dwc:identificationVerificationStatus'] === true) {

--- a/src/components/specimen/components/contentBlocks/PropertiesBlock.tsx
+++ b/src/components/specimen/components/contentBlocks/PropertiesBlock.tsx
@@ -1,0 +1,95 @@
+/* Import Dependencies */
+import { useState } from 'react';
+import classNames from 'classnames';
+import { Card, Row, Col } from 'react-bootstrap';
+
+/* Import Types */
+import { Dict } from 'app/Types';
+
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+
+/* Import Components */
+import PropertiesTable from './PropertiesTable';
+
+
+/* Props Typing */
+interface Props {
+    index: number,
+    instanceName: string,
+    taxonAcceptedName?: string,
+    instanceLevel: string,
+    instanceLevels?: Dict,
+    instanceProperties: Dict
+    ShowWithAnnotations: Function
+};
+
+
+const PropertiesBlock = (props: Props) => {
+    const { index, instanceName, taxonAcceptedName, instanceLevel, instanceLevels, instanceProperties, ShowWithAnnotations } = props;
+
+    /* Base variables */
+    const [collapsed, setCollapsed] = useState<boolean>((index > 0) ? true : false);
+    let blockName: string;
+    
+    if (taxonAcceptedName && instanceProperties.properties['dwc:identificationVerificationStatus'] && instanceProperties.properties['dwc:identificationVerificationStatus'] === true) {
+        blockName = taxonAcceptedName;
+    } else {
+        blockName = instanceName;
+    }
+
+    /* ClassNames */
+    const CardClass = classNames({
+        'mt-3': index > 0
+    });
+
+    return (
+        <Card key={`${instanceLevel}_${index}`} className={CardClass}>
+            <Card.Body>
+                <Row>
+                    <Col>
+                        <p className="fs-2 fw-lightBold"> {`${blockName} #${index + 1}`} </p>
+                    </Col>
+                    <Col className="col-md-auto">
+                        <FontAwesomeIcon icon={collapsed ? faChevronDown : faChevronUp}
+                            className="c-pointer"
+                            onClick={() => setCollapsed(!collapsed)}
+                        />
+                    </Col>
+                </Row>
+                {!collapsed &&
+                    <Row>
+                        <Col>
+                            {(typeof (instanceProperties[Object.keys(instanceProperties)[0]]) === 'object') ?
+                                <>
+                                    {Object.keys(instanceProperties).map((propertyKey) => {
+                                        return (
+                                            <div key={propertyKey} className="mt-3">
+                                                <PropertiesTable
+                                                    title={propertyKey}
+                                                    properties={instanceProperties[propertyKey as keyof typeof instanceProperties] as Dict}
+                                                    ShowWithAnnotations={(property: string) =>
+                                                        ShowWithAnnotations(`${instanceLevel}[${index}]${instanceLevels ? instanceLevels[propertyKey as keyof typeof instanceLevels] : ''}${property}`)
+                                                    }
+                                                />
+                                            </div>
+                                        )
+                                    })}
+                                </>
+                                : <PropertiesTable title="Properties"
+                                    properties={instanceProperties}
+                                    ShowWithAnnotations={(property: string) =>
+                                        ShowWithAnnotations(`${instanceLevel}[${index}]${property}`)
+                                    }
+                                />
+                            }
+                        </Col>
+                    </Row>
+                }
+            </Card.Body>
+        </Card>
+    );
+}
+
+export default PropertiesBlock;


### PR DESCRIPTION
PR makes all the properties tables on the Specimen page collapsable to make scrolling through them easier.

PR also fixes the issue about the completed time of a MAS job record being the direct time it was scheduled.

Adds:
- Component for properties block that is collapsable