### PR TITLE
Migrate to Tan Stack table - Custom Data Table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fortawesome/react-fontawesome": "^0.1.19",
         "@react-keycloak/web": "^3.4.0",
         "@reduxjs/toolkit": "^1.9.5",
+        "@tanstack/match-sorter-utils": "^8.11.3",
         "@tanstack/react-table": "^8.11.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -4145,6 +4146,21 @@
       "integrity": "sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.11.3.tgz",
+      "integrity": "sha512-2XVYTN6fLFyeIPywDL/HGKIQce3V6oUch1FHweGwxruPKEXip6Z9qg+zWZwNE26WG6CktqJh6NqTq90a42jeEw==",
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -16908,6 +16924,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "node_modules/renderkid": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fortawesome/react-fontawesome": "^0.1.19",
         "@react-keycloak/web": "^3.4.0",
         "@reduxjs/toolkit": "^1.9.5",
+        "@tanstack/react-table": "^8.11.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
@@ -4144,6 +4145,37 @@
       "integrity": "sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.11.3.tgz",
+      "integrity": "sha512-Gwwm7po1MaObBguw69L+UiACkaj+eOtThQEArj/3fmUwMPiWaJcXvNG2X5Te5z2hg0HMx8h0T0Q7p5YmQlTUfw==",
+      "dependencies": {
+        "@tanstack/table-core": "8.11.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.11.3.tgz",
+      "integrity": "sha512-nkcFIL696wTf1QMvhGR7dEg60OIRwEZm1OqFTYYDTRc4JOWspgrsJO3IennsOJ7ptumHWLDjV8e5BjPkZcSZAQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fortawesome/react-fontawesome": "^0.1.19",
     "@react-keycloak/web": "^3.4.0",
     "@reduxjs/toolkit": "^1.9.5",
+    "@tanstack/match-sorter-utils": "^8.11.3",
     "@tanstack/react-table": "^8.11.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fortawesome/react-fontawesome": "^0.1.19",
     "@react-keycloak/web": "^3.4.0",
     "@reduxjs/toolkit": "^1.9.5",
+    "@tanstack/react-table": "^8.11.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/App.css
+++ b/src/App.css
@@ -132,15 +132,15 @@ p {
 }
 
 .c-primary {
-  color: var(--primary);
+  color: var(--primary) !important;
 }
 
 .c-secondary {
-  color: var(--secondary);
+  color: var(--secondary) !important;
 }
 
 .c-accent {
-  color: var(--accent);
+  color: var(--accent) !important;
 }
 
 .c-white {

--- a/src/App.css
+++ b/src/App.css
@@ -197,6 +197,10 @@ p {
   background-color: var(--greyLight);
 }
 
+.bgc-tableHover {
+  background-color: rgb(152, 205, 191);
+}
+
 /* Border */
 .b-none {
   border: none;

--- a/src/App.css
+++ b/src/App.css
@@ -222,6 +222,10 @@ p {
   border-top: 1px solid var(--grey);
 }
 
+.b-bottom-grey {
+  border-bottom: 1px solid var(--grey);
+}
+
 /* Border radius */
 .br-tl {
   border-top-left-radius: 8px;
@@ -275,6 +279,14 @@ p {
   overflow-y: scroll !important;
 }
 
+.overflow-x-scroll {
+  overflow-x: scroll !important;
+}
+
+.overflow-x-visible {
+  overflow-x: visible;
+}
+
 .overflow-x-hidden {
   overflow-x: hidden;
 }
@@ -308,7 +320,6 @@ p {
 
 
 /* Global Components Styling */
-
 .primaryButton {
   background-color: var(--primary);
   color: white;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,10 @@ import { DetectMobile } from 'app/Utilities';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
-import { getScreenSize, setScreenSize, getOrganisations, setOrganisations, setPhylopicBuild } from 'redux/general/GeneralSlice';
+import {
+  getScreenSize, setScreenSize, setWindowDimensions,
+  getOrganisations, setOrganisations, setPhylopicBuild
+} from 'redux/general/GeneralSlice';
 import { getUser, setUser } from 'redux/user/UserSlice';
 
 /* Import Styles */
@@ -51,6 +54,7 @@ const App = () => {
 
   /* Function to regulate PC and Mobile views */
   const UpdateWindowDimensions = () => {
+    /* Set screen size */
     if (DetectMobile()) {
       dispatch(setScreenSize('sm'));
     } else if (window.innerWidth <= 992) {
@@ -58,6 +62,12 @@ const App = () => {
     } else {
       dispatch(setScreenSize('lg'));
     }
+
+    /* Set window dimensions */
+    dispatch(setWindowDimensions({
+      vw: window.innerWidth,
+      vh: window.innerHeight
+    }))
   };
 
   useEffect(() => {

--- a/src/app/tableConfig/SearchResultsTableConfig.tsx
+++ b/src/app/tableConfig/SearchResultsTableConfig.tsx
@@ -1,0 +1,81 @@
+/* Import Dependencies */
+import { createColumnHelper } from '@tanstack/react-table';
+
+
+const SearchResultsTableConfig = () => {
+    /* Type interface */
+    interface SearchResult {
+        DOI: string,
+        taxonomyIconUrl: string,
+        accessionName: string,
+        accessionId: string,
+        scientificName: string,
+        specimenType: string,
+        origin: string,
+        collected: string,
+        holder: string
+    };
+
+    /* Base variables */
+    const columnHelper = createColumnHelper<SearchResult>();
+
+    const columns = [
+        columnHelper.accessor('DOI', {
+            cell: info => info.getValue().replace(process.env.REACT_APP_DOI_URL as string, ''),
+            meta: {
+                widthInRem: 10,
+                pinned: true
+            }
+        }),
+        columnHelper.accessor('accessionName', {
+            header: 'Accession Name',
+            meta: {
+                widthInRem: 14,
+                pinned: true
+            }
+        }),
+        columnHelper.accessor('accessionId', {
+            header: 'Accession ID',
+            meta: {
+                widthInRem: 14
+            }
+        }),
+        columnHelper.accessor('scientificName', {
+            header: 'Scientific Name',
+            meta: {
+                widthInRem: 14
+            }
+        }),
+        columnHelper.accessor('specimenType', {
+            header: 'Specimen Type',
+            meta: {
+                widthInRem: 10
+            }
+        }),
+        columnHelper.accessor('origin', {
+            header: 'Origin',
+            meta: {
+                widthInRem: 10
+            }
+        }),
+        columnHelper.accessor('collected', {
+            header: 'Collected',
+            meta: {
+                widthInRem: 10
+            }
+        }),
+        columnHelper.accessor('holder', {
+            header: 'Holder',
+            meta: {
+                widthInRem: 12
+            }
+        })
+    ];
+
+    /* Define pinned columns */
+    const pinnedColumns = ['DOI', 'accessionName'];
+
+    return { columns, pinnedColumns };
+}
+
+export default SearchResultsTableConfig;

--- a/src/app/tableConfig/SearchResultsTableConfig.tsx
+++ b/src/app/tableConfig/SearchResultsTableConfig.tsx
@@ -1,10 +1,15 @@
 /* Import Dependencies */
 import { createColumnHelper } from '@tanstack/react-table';
 
+/* Import Store */
+import { useAppSelector } from 'app/hooks';
+import { getCompareMode } from 'redux/search/SearchSlice';
+
 
 const SearchResultsTableConfig = () => {
     /* Type interface */
     interface SearchResult {
+        compareSelected: boolean,
         DOI: string,
         taxonomyIconUrl: string,
         accessionName: string,
@@ -17,9 +22,18 @@ const SearchResultsTableConfig = () => {
     };
 
     /* Base variables */
+    const compareMode = useAppSelector(getCompareMode);
     const columnHelper = createColumnHelper<SearchResult>();
 
     const columns = [
+        ...(compareMode ? [columnHelper.accessor('compareSelected', {
+            header: '',
+            cell: info => <input type="checkbox" defaultChecked={info.getValue()} />,
+            meta: {
+                widthInRem: 3,
+                pinned: true
+            }
+        })] : []),
         columnHelper.accessor('DOI', {
             cell: info => info.getValue().replace(process.env.REACT_APP_DOI_URL as string, ''),
             meta: {

--- a/src/app/tableConfig/SearchResultsTableConfig.tsx
+++ b/src/app/tableConfig/SearchResultsTableConfig.tsx
@@ -18,7 +18,7 @@ const SearchResultsTableConfig = () => {
         specimenType: string,
         origin: string,
         collected: string,
-        holder: string
+        holder: [string, string]
     };
 
     /* Base variables */
@@ -95,8 +95,15 @@ const SearchResultsTableConfig = () => {
         }),
         columnHelper.accessor('holder', {
             header: 'Holder',
+            cell: info => <a href={info.getValue()[1]}
+                target="_blank" rel="noreferer"
+                className="c-accent h-underline"
+            >
+                {info.getValue()[0]}
+            </a>,
             meta: {
                 widthInRem: 12,
+                link: true,
                 sortable: true
             }
         })

--- a/src/app/tableConfig/SearchResultsTableConfig.tsx
+++ b/src/app/tableConfig/SearchResultsTableConfig.tsx
@@ -72,10 +72,7 @@ const SearchResultsTableConfig = () => {
         })
     ];
 
-    /* Define pinned columns */
-    const pinnedColumns = ['DOI', 'accessionName'];
-
-    return { columns, pinnedColumns };
+    return { columns };
 }
 
 export default SearchResultsTableConfig;

--- a/src/app/tableConfig/SearchResultsTableConfig.tsx
+++ b/src/app/tableConfig/SearchResultsTableConfig.tsx
@@ -34,6 +34,17 @@ const SearchResultsTableConfig = () => {
                 pinned: true
             }
         })] : []),
+        columnHelper.accessor('taxonomyIconUrl', {
+            header: '',
+            cell: info => <img src={info.getValue()}
+                alt={info.getValue()}
+                className="w-100"
+            />,
+            meta: {
+                widthInRem: 4,
+                pinned: true
+            }
+        }),
         columnHelper.accessor('DOI', {
             cell: info => info.getValue().replace(process.env.REACT_APP_DOI_URL as string, ''),
             meta: {

--- a/src/app/tableConfig/SearchResultsTableConfig.tsx
+++ b/src/app/tableConfig/SearchResultsTableConfig.tsx
@@ -57,31 +57,36 @@ const SearchResultsTableConfig = () => {
         columnHelper.accessor('scientificName', {
             header: 'Scientific Name',
             meta: {
-                widthInRem: 14
+                widthInRem: 14,
+                sortable: true
             }
         }),
         columnHelper.accessor('specimenType', {
             header: 'Specimen Type',
             meta: {
-                widthInRem: 10
+                widthInRem: 10,
+                sortable: true
             }
         }),
         columnHelper.accessor('origin', {
             header: 'Origin',
             meta: {
-                widthInRem: 10
+                widthInRem: 10,
+                sortable: true
             }
         }),
         columnHelper.accessor('collected', {
             header: 'Collected',
             meta: {
-                widthInRem: 10
+                widthInRem: 10,
+                sortable: true
             }
         }),
         columnHelper.accessor('holder', {
             header: 'Holder',
             meta: {
-                widthInRem: 12
+                widthInRem: 12,
+                sortable: true
             }
         })
     ];

--- a/src/components/general/tables/DataTable.tsx
+++ b/src/components/general/tables/DataTable.tsx
@@ -1,0 +1,146 @@
+/* Import Dependencies */
+import '@tanstack/react-table'
+import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import classNames from 'classnames';
+
+/* Import Store */
+import { useAppSelector } from 'app/hooks';
+import { getWindowDimensions } from 'redux/general/GeneralSlice';
+
+/* Import Types */
+import { Dict } from 'app/Types';
+
+/* Import Styles */
+import styles from './tables.module.scss';
+
+
+/* Props Typing */
+interface Props {
+    columns: any,
+    data: Dict[],
+    pinnedColumns?: string[]
+};
+
+declare module '@tanstack/react-table' {
+    interface ColumnMeta<TData extends unknown, TValue> {
+        widthInRem?: number,
+        pinned?: boolean
+    }
+}
+
+
+const DataTable = (props: Props) => {
+    const { columns, data, pinnedColumns } = props;
+
+    /* Base variables */
+    const windowDimensions = useAppSelector(getWindowDimensions);
+    const oneRem = 0.85 * windowDimensions.vw / 100;
+
+    /* Table initiation */
+    const table = useReactTable({
+        columns: columns,
+        data: data,
+        getCoreRowModel: getCoreRowModel()
+    });
+
+    /* Function to determine table header class names */
+    const HeaderClassNames = (headerId: string) => {
+        return classNames({
+            'bgc-secondary c-white fs-4 px-3 py-3': true,
+            'position-sticky z-1': pinnedColumns?.includes(headerId)
+        });
+    }
+
+    /* Function to determine table row class names */
+    const RowClassNames = (rowId: string) => {
+        return classNames({
+            'bgc-white': true
+        });
+    }
+
+    /* Function to determine table column class names */
+    const ColumnClassNames = (columnId: string) => {
+        return classNames({
+            'fs-4 px-3 py-2 b-bottom-grey': true,
+            'position-sticky z-1 bgc-white': pinnedColumns?.includes(columnId)
+        });
+    }
+
+    return (
+        <div className="h-100 overflow-auto rounded-c">
+            <table className={`${styles.dataTable} w-100`}>
+                <thead className="position-sticky top-0 z-2">
+                    {table.getHeaderGroups().map(headerGroup => {
+                        let totalRowWidth: number = 0;
+
+                        return (
+                            <tr key={headerGroup.id}>
+                                {headerGroup.headers.map((header) => {
+                                    const headerWidth: number = header.column.columnDef.meta?.widthInRem ?
+                                        header.column.columnDef.meta.widthInRem * oneRem
+                                        : header.column.getSize();
+
+                                    totalRowWidth += headerWidth;
+
+                                    return (
+                                        <th key={header.id}
+                                            style={{
+                                                width: headerWidth,
+                                                minWidth: headerWidth,
+                                                ...(header.column.columnDef.meta?.pinned && { 'left': `${totalRowWidth - headerWidth}px` })
+                                            }}
+                                            className={HeaderClassNames(header.id)}
+                                        >
+                                            {header.isPlaceholder
+                                                ? null
+                                                : flexRender(
+                                                    header.column.columnDef.header,
+                                                    header.getContext()
+                                                )}
+                                        </th>
+                                    );
+                                })}
+                            </tr>
+                        );
+                    })}
+                </thead>
+
+                <tbody className="flex-grow-1 overflow-x-hidden overflow-y-scrol bgc-white">
+                    {table.getRowModel().rows.map(row => {
+                        let totalRowWidth: number = 0;
+
+                        return (
+                            <tr key={row.id}
+                                className={RowClassNames(row.id)}
+                            >
+                                {row.getVisibleCells().map((cell, index) => {
+                                    const columnWidth: number = cell.column.columnDef.meta?.widthInRem ?
+                                        cell.column.columnDef.meta.widthInRem * oneRem
+                                        : cell.column.getSize();
+
+                                    totalRowWidth += columnWidth;
+
+                                    return (
+                                        <td key={cell.id}
+                                            style={{
+                                                width: columnWidth,
+                                                minWidth: columnWidth,
+                                                ...(cell.column.columnDef.meta?.pinned && { left: `${totalRowWidth - columnWidth}px` }),
+                                                ...((pinnedColumns?.includes(cell.column.id) && (index + 1) === pinnedColumns.length) && { 'borderRight': '1px solid #D9D9DF' })
+                                            }}
+                                            className={ColumnClassNames(cell.column.id)}
+                                        >
+                                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                        </td>
+                                    );
+                                })}
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+export default DataTable;

--- a/src/components/general/tables/DataTable.tsx
+++ b/src/components/general/tables/DataTable.tsx
@@ -1,4 +1,5 @@
 /* Import Dependencies */
+import { useState } from 'react';
 import '@tanstack/react-table'
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import classNames from 'classnames';
@@ -35,6 +36,7 @@ const DataTable = (props: Props) => {
     /* Base variables */
     const windowDimensions = useAppSelector(getWindowDimensions);
     const oneRem = 0.85 * windowDimensions.vw / 100;
+    const [hoverRowId, setHoverRowId] = useState<number>(-1);
 
     /* Table initiation */
     const table = useReactTable({
@@ -54,15 +56,16 @@ const DataTable = (props: Props) => {
     /* Function to determine table row class names */
     const RowClassNames = (rowId: string) => {
         return classNames({
-            'bgc-white': true
+            [`${styles.dataTableRow} bgc-white`]: true
         });
     }
-
+ 
     /* Function to determine table column class names */
-    const ColumnClassNames = (columnId: string) => {
+    const ColumnClassNames = (columnId: string, rowIndex: number) => {
         return classNames({
-            'fs-4 px-3 py-2 b-bottom-grey': true,
-            'position-sticky z-1 bgc-white': pinnedColumns?.includes(columnId)
+            [`${styles.dataTableColumn} fs-4 px-3 py-2 b-bottom-grey c-pointer`]: true,
+            'position-sticky z-1 bgc-white': pinnedColumns?.includes(columnId),
+            'bgc-tableHover': hoverRowId === rowIndex
         });
     }
 
@@ -105,15 +108,18 @@ const DataTable = (props: Props) => {
                     })}
                 </thead>
 
-                <tbody className="flex-grow-1 overflow-x-hidden overflow-y-scrol bgc-white">
-                    {table.getRowModel().rows.map(row => {
+                <tbody className="flex-grow-1 overflow-x-hidden overflow-y-scrol bgc-white"
+                    onMouseLeave={() => setHoverRowId(-1)}
+                >
+                    {table.getRowModel().rows.map((row, rowIndex) => {
                         let totalRowWidth: number = 0;
 
                         return (
                             <tr key={row.id}
                                 className={RowClassNames(row.id)}
+                                onMouseEnter={() => setHoverRowId(Number(row.id))}
                             >
-                                {row.getVisibleCells().map((cell, index) => {
+                                {row.getVisibleCells().map((cell, cellIndex) => {
                                     const columnWidth: number = cell.column.columnDef.meta?.widthInRem ?
                                         cell.column.columnDef.meta.widthInRem * oneRem
                                         : cell.column.getSize();
@@ -126,9 +132,9 @@ const DataTable = (props: Props) => {
                                                 width: columnWidth,
                                                 minWidth: columnWidth,
                                                 ...(cell.column.columnDef.meta?.pinned && { left: `${totalRowWidth - columnWidth}px` }),
-                                                ...((pinnedColumns?.includes(cell.column.id) && (index + 1) === pinnedColumns.length) && { 'borderRight': '1px solid #D9D9DF' })
+                                                ...((pinnedColumns?.includes(cell.column.id) && (cellIndex + 1) === pinnedColumns.length) && { 'borderRight': '1px solid #D9D9DF' })
                                             }}
-                                            className={ColumnClassNames(cell.column.id)}
+                                            className={ColumnClassNames(cell.column.id, rowIndex)}
                                         >
                                             {flexRender(cell.column.columnDef.cell, cell.getContext())}
                                         </td>

--- a/src/components/general/tables/DataTable.tsx
+++ b/src/components/general/tables/DataTable.tsx
@@ -35,6 +35,7 @@ interface Props {
 declare module '@tanstack/react-table' {
     interface ColumnMeta<TData, TValue> {
         widthInRem?: number,
+        link?: boolean,
         sortable?: boolean,
         pinned?: boolean
     }
@@ -181,7 +182,6 @@ const DataTable = (props: Props) => {
                         return (
                             <tr key={row.id}
                                 className={RowClassNames(row.original.selected || row.original.compareSelected)}
-                                onClick={() => { if (!window.getSelection()?.toString() && SelectAction) { SelectAction(row.original) } }}
                                 onMouseEnter={() => setHoverRowId(Number(row.id))}
                             >
                                 {row.getVisibleCells().map((cell, cellIndex) => {
@@ -200,6 +200,7 @@ const DataTable = (props: Props) => {
                                                 ...((cell.column.columnDef.meta?.pinned && (cellIndex + 1) === pinnedCount) && { 'borderRight': '1px solid #D9D9DF' })
                                             }}
                                             className={ColumnClassNames(Number(row.id), row.original.selected || row.original.compareSelected, cell.column.columnDef.meta?.pinned)}
+                                            onClick={() => { if (!window.getSelection()?.toString() && SelectAction && !cell.column.columnDef.meta?.link) { SelectAction(row.original) } }}
                                         >
                                             {flexRender(cell.column.columnDef.cell, cell.getContext())}
                                         </td>

--- a/src/components/general/tables/DataTable.tsx
+++ b/src/components/general/tables/DataTable.tsx
@@ -1,7 +1,6 @@
 /* Import Dependencies */
 import { useState } from 'react';
 import classNames from 'classnames';
-import '@tanstack/react-table'
 import {
     flexRender,
     getCoreRowModel,
@@ -34,7 +33,7 @@ interface Props {
 };
 
 declare module '@tanstack/react-table' {
-    interface ColumnMeta<TData extends unknown, TValue> {
+    interface ColumnMeta<TData, TValue> {
         widthInRem?: number,
         sortable?: boolean,
         pinned?: boolean
@@ -143,29 +142,27 @@ const DataTable = (props: Props) => {
                                             className={HeaderClassNames(header.column.columnDef.meta?.pinned)}
                                         >
                                             {header.isPlaceholder ? null : (
-                                                <>
-                                                    <div className={header.column.columnDef.meta?.sortable
-                                                        ? 'c-pointer select-none'
-                                                        : ''
-                                                    }
-                                                        {...(header.column.columnDef.meta?.sortable && {
-                                                            onClick: header.column.getToggleSortingHandler()
-                                                        })}
-                                                    >
-                                                        {flexRender(
-                                                            header.column.columnDef.header,
-                                                            header.getContext()
-                                                        )}
-                                                        {{
-                                                            asc: <FontAwesomeIcon icon={faChevronUp}
-                                                                className="ms-2"
-                                                            />,
-                                                            desc: <FontAwesomeIcon icon={faChevronDown}
-                                                                className="ms-2"
-                                                            />
-                                                        }[header.column.getIsSorted() as string] ?? null}
-                                                    </div>
-                                                </>
+                                                <div className={header.column.columnDef.meta?.sortable
+                                                    ? 'c-pointer select-none'
+                                                    : ''
+                                                }
+                                                    {...(header.column.columnDef.meta?.sortable && {
+                                                        onClick: header.column.getToggleSortingHandler()
+                                                    })}
+                                                >
+                                                    {flexRender(
+                                                        header.column.columnDef.header,
+                                                        header.getContext()
+                                                    )}
+                                                    {{
+                                                        asc: <FontAwesomeIcon icon={faChevronUp}
+                                                            className="ms-2"
+                                                        />,
+                                                        desc: <FontAwesomeIcon icon={faChevronDown}
+                                                            className="ms-2"
+                                                        />
+                                                    }[header.column.getIsSorted() as string] ?? null}
+                                                </div>
                                             )}
                                         </th>
                                     );
@@ -176,6 +173,7 @@ const DataTable = (props: Props) => {
                 </thead>
 
                 <tbody className="flex-grow-1 overflow-x-hidden overflow-y-scrol bgc-white"
+                    role="presentation"
                     onMouseLeave={() => setHoverRowId(-1)}
                 >
                     {table.getRowModel().rows.map((row) => {

--- a/src/components/general/tables/DataTable.tsx
+++ b/src/components/general/tables/DataTable.tsx
@@ -19,7 +19,6 @@ import styles from './tables.module.scss';
 interface Props {
     columns: any,
     data: Dict[],
-    selectedRowId?: number,
     SelectAction?: Function
 };
 
@@ -32,7 +31,7 @@ declare module '@tanstack/react-table' {
 
 
 const DataTable = (props: Props) => {
-    const { columns, data, selectedRowId, SelectAction } = props;
+    const { columns, data, SelectAction } = props;
 
     /* Base variables */
     const windowDimensions = useAppSelector(getWindowDimensions);
@@ -45,6 +44,13 @@ const DataTable = (props: Props) => {
         columns: columns,
         data: data,
         getCoreRowModel: getCoreRowModel()
+    });
+
+    /* Count pinned columns */
+    columns.forEach((column: Dict) => {
+        if (column.meta.pinned) {
+            pinnedCount++;
+        }
     });
 
     /* Function to determine table header class names */
@@ -119,7 +125,7 @@ const DataTable = (props: Props) => {
 
                         return (
                             <tr key={row.id}
-                                className={RowClassNames(row.original.selected)}
+                                className={RowClassNames(row.original.selected || row.original.compareSelected)}
                                 onClick={() => { if (!window.getSelection()?.toString() && SelectAction) { SelectAction(row.original) } }}
                                 onMouseEnter={() => setHoverRowId(Number(row.id))}
                             >
@@ -138,7 +144,7 @@ const DataTable = (props: Props) => {
                                                 ...(cell.column.columnDef.meta?.pinned && { left: `${totalRowWidth - columnWidth}px` }),
                                                 ...((cell.column.columnDef.meta?.pinned && (cellIndex + 1) === pinnedCount) && { 'borderRight': '1px solid #D9D9DF' })
                                             }}
-                                            className={ColumnClassNames(Number(row.id), row.original.selected, cell.column.columnDef.meta?.pinned)}
+                                            className={ColumnClassNames(Number(row.id), row.original.selected || row.original.compareSelected, cell.column.columnDef.meta?.pinned)}
                                         >
                                             {flexRender(cell.column.columnDef.cell, cell.getContext())}
                                         </td>

--- a/src/components/general/tables/DataTable.tsx
+++ b/src/components/general/tables/DataTable.tsx
@@ -173,7 +173,6 @@ const DataTable = (props: Props) => {
                 </thead>
 
                 <tbody className="flex-grow-1 overflow-x-hidden overflow-y-scrol bgc-white"
-                    role="presentation"
                     onMouseLeave={() => setHoverRowId(-1)}
                 >
                     {table.getRowModel().rows.map((row) => {

--- a/src/components/general/tables/tables.module.scss
+++ b/src/components/general/tables/tables.module.scss
@@ -1,0 +1,7 @@
+/* Custom styles for custom table components */
+
+/* Data Table */
+.dataTable {
+    border-collapse: separate;
+    border-spacing: 0;
+}

--- a/src/components/general/tables/tables.module.scss
+++ b/src/components/general/tables/tables.module.scss
@@ -5,3 +5,15 @@
     border-collapse: separate;
     border-spacing: 0;
 }
+
+.dataTableRow {
+    transition: 0.15s;
+}
+
+.dataTableRow:hover {
+    background-color: rgb(152, 205, 191) !important;
+}
+
+.dataTableColumn {
+    transition: 0.15s;
+}

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -11,7 +11,7 @@ import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { getPaginationObject, setPaginationObject } from 'redux/general/GeneralSlice';
 import {
     getSearchResults, setSearchResults, getSearchSpecimen, setSearchSpecimen,
-    setSearchAggregations, getCompareMode, setCompareMode
+    setSearchAggregations, getCompareMode, setCompareMode, setCompareSpecimens
 } from 'redux/search/SearchSlice';
 
 /* Import Types */
@@ -63,6 +63,12 @@ const Search = () => {
     const [paginatorLinks, setPaginatorLinks] = useState<Dict>({});
     const [totalRecords, setTotalRecords] = useState<number>(0);
     const [filterToggle, setFilterToggle] = useState(isEmpty(searchSpecimen));
+    
+    /* OnLoad: disabel compare mode and reset compare specimens */
+    useEffect(() => {
+        dispatch(setCompareMode(false));
+        dispatch(setCompareSpecimens([]));
+    }, []);
 
     /* OnChange of search params: reset page number, then search specimens */
     useEffect(() => {

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -255,7 +255,7 @@ const Search = () => {
 
                                 <Col className={`${classSearchResults} h-100 searchResults`}>
                                     <Row className="h-100 position-relative">
-                                        <Col className={`${classSearchResultsTable} h-100`}>
+                                        <Col className={`${classSearchResultsTable} h-100 z-1`}>
                                             <Row className="h-100">
                                                 <Col className="h-100">
                                                     <div className="h-100 d-flex flex-column">

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -63,7 +63,7 @@ const ResultsTable = (props: Props) => {
         specimenType: string,
         origin: string,
         collected: string,
-        holder: string,
+        holder: [string, string],
         taxonomyIconUrl: string | undefined,
         selected: boolean,
         compareSelected: boolean
@@ -240,7 +240,9 @@ const ResultsTable = (props: Props) => {
                     specimenType: specimen.digitalSpecimen['ods:topicDiscipline'] ?? 'Unclassified',
                     origin: specimen.digitalSpecimen.occurrences?.[0]?.location?.['dwc:country'] ?? '',
                     collected: specimen.digitalSpecimen.occurrences?.[0]?.['dwc:eventDate'] ?? '',
-                    holder: specimen.digitalSpecimen['dwc:institutionName'] ?? (specimen.digitalSpecimen['dwc:institutionId'] ?? ''),
+                    holder: specimen.digitalSpecimen['dwc:institutionName'] ?
+                        [specimen.digitalSpecimen['dwc:institutionName'], specimen.digitalSpecimen['dwc:institutionId'] ?? '']
+                        : [specimen.digitalSpecimen['dwc:institutionId'] ?? '', specimen.digitalSpecimen['dwc:institutionId'] ?? ''],
                     taxonomyIconUrl: taxonomyIncluded ? taxonomyIconUrl : TopicDisciplineIcon(specimen.digitalSpecimen['ods:topicDiscipline']),
                     selected: false,
                     compareSelected: !!compareSpecimens.find((compareSpecimen) => compareSpecimen.digitalSpecimen['ods:id'] === specimen.digitalSpecimen['ods:id'])

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -1,7 +1,8 @@
 /* Import Dependencies */
 import { useEffect, useState } from 'react';
 import { isEmpty } from 'lodash';
-import DataTable, { TableColumn } from 'react-data-table-component';
+import { ColumnDef } from '@tanstack/react-table';
+// import DataTable, { TableColumn } from 'react-data-table-component';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
@@ -15,6 +16,9 @@ import {
 import { DigitalSpecimen, Dict } from 'app/Types';
 import { DigitalSpecimen as SpecimenType } from 'app/types/DigitalSpecimen';
 
+/* Import Utilities */
+import SearchResultsTableConfig from 'app/tableConfig/SearchResultsTableConfig';
+
 /* Import Styles */
 import styles from 'components/search/search.module.scss';
 
@@ -25,6 +29,7 @@ import Spinner from 'webroot/icons/spinner.svg';
 import ColumnLink from './ColumnLink';
 import ScientificName from 'components/general/nomenclatural/ScientificName';
 import TopicDisciplineIcon from 'components/general/icons/TopicDisciplineIcon';
+import DataTable from 'components/general/tables/DataTable';
 
 /* Import API */
 import GetPhylopicIcon from 'api/general/GetPhylopicIcon';
@@ -44,21 +49,31 @@ const ResultsTable = (props: Props) => {
     /* Hooks */
     const dispatch = useAppDispatch();
 
+    /* Table configuration */
+    const { columns, pinnedColumns } = SearchResultsTableConfig();
+
     /* Base variables */
     const searchResults = useAppSelector(getSearchResults);
     const searchSpecimen = useAppSelector(getSearchSpecimen);
     const compareMode = useAppSelector(getCompareMode);
     const compareSpecimens = useAppSelector(getCompareSpecimens);
     const phylopicBuild = useAppSelector(getPhylopicBuild);
+    const [tableColumns, setTableColumns] = useState(columns);
     const [tableData, setTableData] = useState<DataRow[]>([]);
     const staticTopicDisciplines = ['Anthropology', 'Astrogeology', 'Geology', 'Ecology', 'Other Biodiversity', 'Other Geodiversity', 'Unclassified'];
 
     /* Declare type of a table row */
     interface DataRow {
         index: number,
-        id: string,
+        DOI: string,
+        accessionName: string,
+        accessionId: string,
+        scientificName: string,
+        specimenType: string,
+        origin: string,
+        collected: string,
+        holder: string,
         taxonomyIconUrl: string,
-        specimen: SpecimenType,
         toggleSelected: boolean,
         compareSelected: boolean
     };
@@ -71,14 +86,14 @@ const ResultsTable = (props: Props) => {
         dispatch(setSearchSpecimen(specimen));
 
         /* Unselect current Row */
-        const unselectedRow = tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.id !== specimen.digitalSpecimen['ods:id']));
+        const unselectedRow = tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.DOI !== specimen.digitalSpecimen['ods:id']));
 
         if (unselectedRow) {
             unselectedRow.toggleSelected = false;
         }
 
         /* Select chosen Table Row */
-        const selectedRow = tableData.find((tableRow) => tableRow.id === specimen.digitalSpecimen['ods:id']);
+        const selectedRow = tableData.find((tableRow) => tableRow.DOI === specimen.digitalSpecimen['ods:id']);
 
         if (selectedRow) {
             selectedRow.toggleSelected = true;
@@ -95,7 +110,7 @@ const ResultsTable = (props: Props) => {
     /* Function for selecting a specimen for comparison */
     const SelectForComparison = (row: DataRow) => {
         /* Update table data and Compare Specimens array*/
-        const selectedRow = tableData.find((tableRow) => tableRow.id === row.id);
+        const selectedRow = tableData.find((tableRow) => tableRow.DOI === row.DOI);
         const copyCompareSpecimens = [...compareSpecimens];
 
         /* If deselected, remove from array */
@@ -103,7 +118,7 @@ const ResultsTable = (props: Props) => {
             if (row.compareSelected === true) {
                 selectedRow.compareSelected = false;
 
-                const compareSpecimenIndex = compareSpecimens.findIndex((specimen) => specimen.digitalSpecimen['ods:id'] === row.id);
+                const compareSpecimenIndex = compareSpecimens.findIndex((specimen) => specimen.digitalSpecimen['ods:id'] === row.DOI);
                 copyCompareSpecimens.splice(compareSpecimenIndex, 1);
             } else if (compareSpecimens.length < 3) {
                 selectedRow.compareSelected = true;
@@ -134,8 +149,8 @@ const ResultsTable = (props: Props) => {
     /* Function to check if selected Specimen is still selected after page change */
     useEffect(() => {
         if (!isEmpty(searchSpecimen)) {
-            if (!tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.id === searchSpecimen.digitalSpecimen['ods:id']))) {
-                const currentRow = tableData.find((tableRow) => tableRow.id === searchSpecimen.digitalSpecimen['ods:id']);
+            if (!tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.DOI === searchSpecimen.digitalSpecimen['ods:id']))) {
+                const currentRow = tableData.find((tableRow) => tableRow.DOI === searchSpecimen.digitalSpecimen['ods:id']);
 
                 if (currentRow) {
                     currentRow.toggleSelected = true;
@@ -157,127 +172,76 @@ const ResultsTable = (props: Props) => {
         }
     }
 
-    const tableColumns: TableColumn<DataRow>[] = [{
-        selector: row => row.taxonomyIconUrl,
-        id: 'search_taxonomyIcon',
-        cell: row => <img src={row.taxonomyIconUrl} alt={row.taxonomyIconUrl} className={styles.taxonomyIcon} />,
-        width: '3rem'
-    }, {
-        name: 'Accession Name',
-        selector: row => row.specimen['ods:specimenName'] ?? '',
-        id: 'search_accessionName',
-        cell: row => <div onClick={() => SelectAction(row)}
-            onKeyDown={() => SelectAction(row)}
-        >
-            <ScientificName specimenName={searchResults[row?.index]['digitalSpecimen']['ods:specimenName'] ?? ''} />
-        </div>,
-        sortable: true,
-        grow: 1.5
-    }, {
-        name: 'DOI',
-        selector: row => row.id.replace(process.env.REACT_APP_DOI_URL as string, ''),
-        id: 'search_specimenDOI',
-        grow: 1.5
-    }, {
-        name: 'Accession ID',
-        selector: row => row.specimen['ods:normalisedPhysicalSpecimenId'] ?? '',
-        id: 'search_accessionId',
-        grow: 2
-    }, {
-        name: 'Scientific Name',
-        selector: row => row.specimen['dwc:identification']?.find((identification) => identification['dwc:identificationVerificationStatus'])?.taxonIdentifications?.[0]['dwc:scientificName'] ?? '',
-        id: 'search_scientificName',
-        sortable: true,
-        grow: 2
-    }, {
-        name: 'Specimen type',
-        selector: row => row.specimen['ods:topicDiscipline'] as string ?? '',
-        id: 'search_specimenType',
-        sortable: true,
-        grow: 1.5
-    }, {
-        name: 'Origin',
-        selector: row => row.specimen.occurrences?.[0]?.location?.['dwc:country'] ?? '',
-        id: 'search_origin',
-        sortable: true
-    }, {
-        name: "Collected",
-        selector: row => row.specimen.occurrences?.[0]?.['dwc:eventDate'] ?? '',
-        id: 'search_collected',
-        sortable: true
-    }, {
-        name: 'Holder',
-        selector: row => row.specimen['dwc:institutionName'] ?? row.specimen['dwc:institutionId'] ?? '',
-        id: 'search_holder',
-        cell: row => <ColumnLink link={row.specimen['dwc:institutionId'] ?? ''} text={row.specimen['dwc:institutionName'] ?? row.specimen['dwc:institutionId'] ?? ''} />,
-        ignoreRowClick: true,
-        style: {
-            color: "#28bacb"
-        },
-        sortable: true,
-        grow: 2
-    }];
+    // const tableColumns: TableColumn<DataRow>[] = [{
+    //     selector: row => row.taxonomyIconUrl,
+    //     id: 'search_taxonomyIcon',
+    //     cell: row => <img src={row.taxonomyIconUrl} alt={row.taxonomyIconUrl} className={styles.taxonomyIcon} />,
+    //     width: '3rem'
+    // }, {
+    //     name: 'Accession Name',
+    //     selector: row => row.specimen['ods:specimenName'] ?? '',
+    //     id: 'search_accessionName',
+    //     cell: row => <div onClick={() => SelectAction(row)}
+    //         onKeyDown={() => SelectAction(row)}
+    //     >
+    //         <ScientificName specimenName={searchResults[row?.index]['digitalSpecimen']['ods:specimenName'] ?? ''} />
+    //     </div>,
+    //     sortable: true,
+    //     grow: 1.5
+    // }, {
+    //     name: 'DOI',
+    //     selector: row => row.id.replace(process.env.REACT_APP_DOI_URL as string, ''),
+    //     id: 'search_specimenDOI',
+    //     grow: 1.5
+    // }, {
+    //     name: 'Accession ID',
+    //     selector: row => row.specimen['ods:normalisedPhysicalSpecimenId'] ?? '',
+    //     id: 'search_accessionId',
+    //     grow: 2
+    // }, {
+    //     name: 'Scientific Name',
+    //     selector: row => row.specimen['dwc:identification']?.find((identification) => identification['dwc:identificationVerificationStatus'])?.taxonIdentifications?.[0]['dwc:scientificName'] ?? '',
+    //     id: 'search_scientificName',
+    //     sortable: true,
+    //     grow: 2
+    // }, {
+    //     name: 'Specimen type',
+    //     selector: row => row.specimen['ods:topicDiscipline'] as string ?? '',
+    //     id: 'search_specimenType',
+    //     sortable: true,
+    //     grow: 1.5
+    // }, {
+    //     name: 'Origin',
+    //     selector: row => row.specimen.occurrences?.[0]?.location?.['dwc:country'] ?? '',
+    //     id: 'search_origin',
+    //     sortable: true
+    // }, {
+    //     name: "Collected",
+    //     selector: row => row.specimen.occurrences?.[0]?.['dwc:eventDate'] ?? '',
+    //     id: 'search_collected',
+    //     sortable: true
+    // }, {
+    //     name: 'Holder',
+    //     selector: row => row.specimen['dwc:institutionName'] ?? row.specimen['dwc:institutionId'] ?? '',
+    //     id: 'search_holder',
+    //     cell: row => <ColumnLink link={row.specimen['dwc:institutionId'] ?? ''} text={row.specimen['dwc:institutionName'] ?? row.specimen['dwc:institutionId'] ?? ''} />,
+    //     ignoreRowClick: true,
+    //     style: {
+    //         color: "#28bacb"
+    //     },
+    //     sortable: true,
+    //     grow: 2
+    // }];
 
-    if (compareMode) {
-        tableColumns.unshift({
-            selector: row => row.id,
-            id: 'search_compareCheckbox',
-            cell: row => <input type="checkbox" checked={row.compareSelected} onChange={() => SelectForComparison(row)} />,
-            width: '40px',
-            ignoreRowClick: true
-        });
-    }
-
-    /* Custom styles for Data Table */
-    const customStyles = {
-        table: {
-            style: {
-                height: '100%'
-            }
-        },
-        tableWrapper: {
-            style: {
-                height: '100%',
-                backgroundColor: 'white'
-            }
-        },
-        responsiveWrapper: {
-            style: {
-                height: '100%'
-            }
-        },
-        head: {
-            style: {
-                color: 'white',
-                fontSize: '0.875rem !important'
-            }
-        },
-        headRow: {
-            style: {
-                backgroundColor: '#51a993'
-            }
-        },
-        rows: {
-            style: {
-                minHeight: '40px',
-                fontSize: '0.875rem !important'
-            },
-            highlightOnHoverStyle: {
-                backgroundColor: '#98cdbf',
-            },
-            stripedStyle: {
-                backgroundColor: '#eef7f4'
-            }
-        }
-    };
-
-    const conditionalRowStyles = [{
-        when: (row: any) => row.toggleSelected,
-        style: {
-            backgroundColor: '#98cdbf',
-            userSelect: 'none'
-        }
-    }];
+    // if (compareMode) {
+    //     tableColumns.unshift({
+    //         selector: row => row.id,
+    //         id: 'search_compareCheckbox',
+    //         cell: row => <input type="checkbox" checked={row.compareSelected} onChange={() => SelectForComparison(row)} />,
+    //         width: '40px',
+    //         ignoreRowClick: true
+    //     });
+    // }
 
     const LoopSearchResults = async (PushToTableData: Function, SetTableData: Function) => {
         const renderedIcons: Dict = {};
@@ -349,9 +313,15 @@ const ResultsTable = (props: Props) => {
                 /* Push record to table data */
                 tableData.push({
                     index: index,
-                    id: specimen.digitalSpecimen['ods:id'],
+                    DOI: specimen.digitalSpecimen['ods:id'],
+                    accessionName: specimen.digitalSpecimen['ods:specimenName'] ?? '',
+                    accessionId: specimen.digitalSpecimen['ods:normalisedPhysicalSpecimenId'] ?? '',
+                    scientificName: specimen.digitalSpecimen['dwc:identification']?.find((identification) => identification['dwc:identificationVerificationStatus'])?.taxonIdentifications?.[0]['dwc:scientificName'] ?? '',
+                    specimenType: specimen.digitalSpecimen['ods:topicDiscipline'] ?? 'Unclassified',
+                    origin: specimen.digitalSpecimen.occurrences?.[0]?.location?.['dwc:country'] ?? '',
+                    collected: specimen.digitalSpecimen.occurrences?.[0]?.['dwc:eventDate'] ?? '',
+                    holder: specimen.digitalSpecimen['dwc:institutionName'] ?? (specimen.digitalSpecimen['dwc:institutionId'] ?? ''),
                     taxonomyIconUrl: taxonomyIconUrl ?? TopicDisciplineIcon(specimen.digitalSpecimen['ods:topicDiscipline']),
-                    specimen: specimen.digitalSpecimen,
                     toggleSelected: false,
                     compareSelected: !!compareSpecimens.find((compareSpecimen) => compareSpecimen.digitalSpecimen['ods:id'] === specimen.digitalSpecimen['ods:id'])
                 });
@@ -369,7 +339,7 @@ const ResultsTable = (props: Props) => {
 
     return (
         <div className="h-100 position-relative b-secondary rounded-c">
-            <DataTable
+            {/* <DataTable
                 columns={tableColumns}
                 data={tableData}
                 className='h-100 overflow-y-scroll z-1'
@@ -386,6 +356,11 @@ const ResultsTable = (props: Props) => {
                 striped
                 highlightOnHover
                 pointerOnHover
+            /> */}
+
+            <DataTable columns={columns}
+                data={tableData}
+                pinnedColumns={pinnedColumns}
             />
         </div>
     );

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -1,8 +1,6 @@
 /* Import Dependencies */
 import { useEffect, useState } from 'react';
 import { isEmpty } from 'lodash';
-import { ColumnDef } from '@tanstack/react-table';
-// import DataTable, { TableColumn } from 'react-data-table-component';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/hooks';
@@ -14,20 +12,14 @@ import {
 
 /* Import Types */
 import { DigitalSpecimen, Dict } from 'app/Types';
-import { DigitalSpecimen as SpecimenType } from 'app/types/DigitalSpecimen';
 
 /* Import Utilities */
 import SearchResultsTableConfig from 'app/tableConfig/SearchResultsTableConfig';
-
-/* Import Styles */
-import styles from 'components/search/search.module.scss';
 
 /* Import Webroot */
 import Spinner from 'webroot/icons/spinner.svg';
 
 /* Import Components */
-import ColumnLink from './ColumnLink';
-import ScientificName from 'components/general/nomenclatural/ScientificName';
 import TopicDisciplineIcon from 'components/general/icons/TopicDisciplineIcon';
 import DataTable from 'components/general/tables/DataTable';
 
@@ -60,7 +52,6 @@ const ResultsTable = (props: Props) => {
     const phylopicBuild = useAppSelector(getPhylopicBuild);
     const [tableColumns, setTableColumns] = useState(columns);
     const [tableData, setTableData] = useState<DataRow[]>([]);
-    const [selectedRowId, setSelectedRowId] = useState<number>();
     const staticTopicDisciplines = ['Anthropology', 'Astrogeology', 'Geology', 'Ecology', 'Other Biodiversity', 'Other Geodiversity', 'Unclassified'];
 
     /* Declare type of a table row */
@@ -173,77 +164,6 @@ const ResultsTable = (props: Props) => {
         }
     }
 
-    // const tableColumns: TableColumn<DataRow>[] = [{
-    //     selector: row => row.taxonomyIconUrl,
-    //     id: 'search_taxonomyIcon',
-    //     cell: row => <img src={row.taxonomyIconUrl} alt={row.taxonomyIconUrl} className={styles.taxonomyIcon} />,
-    //     width: '3rem'
-    // }, {
-    //     name: 'Accession Name',
-    //     selector: row => row.specimen['ods:specimenName'] ?? '',
-    //     id: 'search_accessionName',
-    //     cell: row => <div onClick={() => SelectAction(row)}
-    //         onKeyDown={() => SelectAction(row)}
-    //     >
-    //         <ScientificName specimenName={searchResults[row?.index]['digitalSpecimen']['ods:specimenName'] ?? ''} />
-    //     </div>,
-    //     sortable: true,
-    //     grow: 1.5
-    // }, {
-    //     name: 'DOI',
-    //     selector: row => row.id.replace(process.env.REACT_APP_DOI_URL as string, ''),
-    //     id: 'search_specimenDOI',
-    //     grow: 1.5
-    // }, {
-    //     name: 'Accession ID',
-    //     selector: row => row.specimen['ods:normalisedPhysicalSpecimenId'] ?? '',
-    //     id: 'search_accessionId',
-    //     grow: 2
-    // }, {
-    //     name: 'Scientific Name',
-    //     selector: row => row.specimen['dwc:identification']?.find((identification) => identification['dwc:identificationVerificationStatus'])?.taxonIdentifications?.[0]['dwc:scientificName'] ?? '',
-    //     id: 'search_scientificName',
-    //     sortable: true,
-    //     grow: 2
-    // }, {
-    //     name: 'Specimen type',
-    //     selector: row => row.specimen['ods:topicDiscipline'] as string ?? '',
-    //     id: 'search_specimenType',
-    //     sortable: true,
-    //     grow: 1.5
-    // }, {
-    //     name: 'Origin',
-    //     selector: row => row.specimen.occurrences?.[0]?.location?.['dwc:country'] ?? '',
-    //     id: 'search_origin',
-    //     sortable: true
-    // }, {
-    //     name: "Collected",
-    //     selector: row => row.specimen.occurrences?.[0]?.['dwc:eventDate'] ?? '',
-    //     id: 'search_collected',
-    //     sortable: true
-    // }, {
-    //     name: 'Holder',
-    //     selector: row => row.specimen['dwc:institutionName'] ?? row.specimen['dwc:institutionId'] ?? '',
-    //     id: 'search_holder',
-    //     cell: row => <ColumnLink link={row.specimen['dwc:institutionId'] ?? ''} text={row.specimen['dwc:institutionName'] ?? row.specimen['dwc:institutionId'] ?? ''} />,
-    //     ignoreRowClick: true,
-    //     style: {
-    //         color: "#28bacb"
-    //     },
-    //     sortable: true,
-    //     grow: 2
-    // }];
-
-    // if (compareMode) {
-    //     tableColumns.unshift({
-    //         selector: row => row.id,
-    //         id: 'search_compareCheckbox',
-    //         cell: row => <input type="checkbox" checked={row.compareSelected} onChange={() => SelectForComparison(row)} />,
-    //         width: '40px',
-    //         ignoreRowClick: true
-    //     });
-    // }
-
     const LoopSearchResults = async (PushToTableData: Function, SetTableData: Function) => {
         const renderedIcons: Dict = {};
 
@@ -340,25 +260,6 @@ const ResultsTable = (props: Props) => {
 
     return (
         <div className="h-100 position-relative b-secondary rounded-c">
-            {/* <DataTable
-                columns={tableColumns}
-                data={tableData}
-                className='h-100 overflow-y-scroll z-1'
-                customStyles={customStyles}
-                onRowClicked={(row) => {
-                    if (compareMode) {
-                        SelectForComparison(row);
-                    } else {
-                        OnSpecimenSelect(row);
-                    }
-                }}
-                conditionalRowStyles={conditionalRowStyles}
-
-                striped
-                highlightOnHover
-                pointerOnHover
-            /> */}
-
             <DataTable columns={columns}
                 data={tableData}
                 SelectAction={(row: DataRow) => SelectAction(row)}

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -64,7 +64,7 @@ const ResultsTable = (props: Props) => {
         origin: string,
         collected: string,
         holder: string,
-        taxonomyIconUrl: string,
+        taxonomyIconUrl: string | undefined,
         selected: boolean,
         compareSelected: boolean
     };
@@ -189,7 +189,7 @@ const ResultsTable = (props: Props) => {
             }
 
             if (taxonomyIdentification && taxonomyIdentification in renderedIcons) {
-                PushToTableData(specimen, index, renderedIcons[taxonomyIdentification]);
+                PushToTableData(specimen, index, renderedIcons[taxonomyIdentification], true);
 
                 SetTableData(index);
             } else if (taxonomyIdentification && (specimen.digitalSpecimen['ods:topicDiscipline'] && !(staticTopicDisciplines.includes(specimen.digitalSpecimen['ods:topicDiscipline'])))) {
@@ -197,7 +197,7 @@ const ResultsTable = (props: Props) => {
                 PushToTableData(specimen, index, Spinner);
 
                 GetPhylopicIcon(phylopicBuild ?? '292', taxonomyIdentification).then((taxonomyIconUrl) => {
-                    PushToTableData(specimen, index, taxonomyIconUrl);
+                    PushToTableData(specimen, index, taxonomyIconUrl, true);
 
                     /* Add to rendered icons */
                     renderedIcons[taxonomyIdentification] = taxonomyIconUrl;
@@ -206,13 +206,13 @@ const ResultsTable = (props: Props) => {
                 }).catch(error => {
                     console.warn(error);
 
-                    PushToTableData(specimen, index);
+                    PushToTableData(specimen, index, undefined, true);
 
                     SetTableData(index);
                 });
             } else {
                 /* Use topic discipline icon */
-                PushToTableData(specimen, index);
+                PushToTableData(specimen, index, undefined);
 
                 SetTableData(index);
             }
@@ -224,11 +224,11 @@ const ResultsTable = (props: Props) => {
         /* Construct table data */
         const tableData: DataRow[] = [];
 
-        const PushToTableData = (specimen: DigitalSpecimen, index: number, taxonomyIconUrl?: string) => {
+        const PushToTableData = (specimen: DigitalSpecimen, index: number, taxonomyIconUrl?: string, taxonomyIncluded: boolean = false) => {
             /* Check if index exists in table data */
             if (tableData.find(record => record.index === index)) {
                 /* Replace record in table data */
-                tableData[index].taxonomyIconUrl = taxonomyIconUrl ?? TopicDisciplineIcon(specimen.digitalSpecimen['ods:topicDiscipline'])
+                tableData[index].taxonomyIconUrl = taxonomyIncluded ? taxonomyIconUrl : TopicDisciplineIcon(specimen.digitalSpecimen['ods:topicDiscipline'])
             } else {
                 /* Push record to table data */
                 tableData.push({
@@ -241,7 +241,7 @@ const ResultsTable = (props: Props) => {
                     origin: specimen.digitalSpecimen.occurrences?.[0]?.location?.['dwc:country'] ?? '',
                     collected: specimen.digitalSpecimen.occurrences?.[0]?.['dwc:eventDate'] ?? '',
                     holder: specimen.digitalSpecimen['dwc:institutionName'] ?? (specimen.digitalSpecimen['dwc:institutionId'] ?? ''),
-                    taxonomyIconUrl: taxonomyIconUrl ?? TopicDisciplineIcon(specimen.digitalSpecimen['ods:topicDiscipline']),
+                    taxonomyIconUrl: taxonomyIncluded ? taxonomyIconUrl : TopicDisciplineIcon(specimen.digitalSpecimen['ods:topicDiscipline']),
                     selected: false,
                     compareSelected: !!compareSpecimens.find((compareSpecimen) => compareSpecimen.digitalSpecimen['ods:id'] === specimen.digitalSpecimen['ods:id'])
                 });

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -50,7 +50,6 @@ const ResultsTable = (props: Props) => {
     const compareMode = useAppSelector(getCompareMode);
     const compareSpecimens = useAppSelector(getCompareSpecimens);
     const phylopicBuild = useAppSelector(getPhylopicBuild);
-    const [tableColumns, setTableColumns] = useState(columns);
     const [tableData, setTableData] = useState<DataRow[]>([]);
     const staticTopicDisciplines = ['Anthropology', 'Astrogeology', 'Geology', 'Ecology', 'Other Biodiversity', 'Other Geodiversity', 'Unclassified'];
 

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -57,13 +57,13 @@ const ResultsTable = (props: Props) => {
     interface DataRow {
         index: number,
         DOI: string,
-        accessionName: string,
-        accessionId: string,
-        scientificName: string,
-        specimenType: string,
-        origin: string,
-        collected: string,
-        holder: [string, string],
+        accessionName: string | undefined,
+        accessionId: string | undefined,
+        scientificName: string | undefined,
+        specimenType: string | undefined,
+        origin: string | undefined,
+        collected: string | undefined,
+        holder: [string | undefined, string | undefined],
         taxonomyIconUrl: string | undefined,
         selected: boolean,
         compareSelected: boolean
@@ -234,15 +234,15 @@ const ResultsTable = (props: Props) => {
                 tableData.push({
                     index: index,
                     DOI: specimen.digitalSpecimen['ods:id'],
-                    accessionName: specimen.digitalSpecimen['ods:specimenName'] ?? '',
-                    accessionId: specimen.digitalSpecimen['ods:normalisedPhysicalSpecimenId'] ?? '',
-                    scientificName: specimen.digitalSpecimen['dwc:identification']?.find((identification) => identification['dwc:identificationVerificationStatus'])?.taxonIdentifications?.[0]['dwc:scientificName'] ?? '',
+                    accessionName: specimen.digitalSpecimen['ods:specimenName'],
+                    accessionId: specimen.digitalSpecimen['ods:normalisedPhysicalSpecimenId'],
+                    scientificName: specimen.digitalSpecimen['dwc:identification']?.find((identification) => identification['dwc:identificationVerificationStatus'])?.taxonIdentifications?.[0]['dwc:scientificName'],
                     specimenType: specimen.digitalSpecimen['ods:topicDiscipline'] ?? 'Unclassified',
-                    origin: specimen.digitalSpecimen.occurrences?.[0]?.location?.['dwc:country'] ?? '',
-                    collected: specimen.digitalSpecimen.occurrences?.[0]?.['dwc:eventDate'] ?? '',
+                    origin: specimen.digitalSpecimen.occurrences?.[0]?.location?.['dwc:country'],
+                    collected: specimen.digitalSpecimen.occurrences?.[0]?.['dwc:eventDate'],
                     holder: specimen.digitalSpecimen['dwc:institutionName'] ?
-                        [specimen.digitalSpecimen['dwc:institutionName'], specimen.digitalSpecimen['dwc:institutionId'] ?? '']
-                        : [specimen.digitalSpecimen['dwc:institutionId'] ?? '', specimen.digitalSpecimen['dwc:institutionId'] ?? ''],
+                        [specimen.digitalSpecimen['dwc:institutionName'], specimen.digitalSpecimen['dwc:institutionId']]
+                        : [specimen.digitalSpecimen['dwc:institutionId'], specimen.digitalSpecimen['dwc:institutionId']],
                     taxonomyIconUrl: taxonomyIncluded ? taxonomyIconUrl : TopicDisciplineIcon(specimen.digitalSpecimen['ods:topicDiscipline']),
                     selected: false,
                     compareSelected: !!compareSpecimens.find((compareSpecimen) => compareSpecimen.digitalSpecimen['ods:id'] === specimen.digitalSpecimen['ods:id'])

--- a/src/components/search/components/searchResults/ResultsTable.tsx
+++ b/src/components/search/components/searchResults/ResultsTable.tsx
@@ -50,7 +50,7 @@ const ResultsTable = (props: Props) => {
     const dispatch = useAppDispatch();
 
     /* Table configuration */
-    const { columns, pinnedColumns } = SearchResultsTableConfig();
+    const { columns } = SearchResultsTableConfig();
 
     /* Base variables */
     const searchResults = useAppSelector(getSearchResults);
@@ -60,6 +60,7 @@ const ResultsTable = (props: Props) => {
     const phylopicBuild = useAppSelector(getPhylopicBuild);
     const [tableColumns, setTableColumns] = useState(columns);
     const [tableData, setTableData] = useState<DataRow[]>([]);
+    const [selectedRowId, setSelectedRowId] = useState<number>();
     const staticTopicDisciplines = ['Anthropology', 'Astrogeology', 'Geology', 'Ecology', 'Other Biodiversity', 'Other Geodiversity', 'Unclassified'];
 
     /* Declare type of a table row */
@@ -74,7 +75,7 @@ const ResultsTable = (props: Props) => {
         collected: string,
         holder: string,
         taxonomyIconUrl: string,
-        toggleSelected: boolean,
+        selected: boolean,
         compareSelected: boolean
     };
 
@@ -86,17 +87,17 @@ const ResultsTable = (props: Props) => {
         dispatch(setSearchSpecimen(specimen));
 
         /* Unselect current Row */
-        const unselectedRow = tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.DOI !== specimen.digitalSpecimen['ods:id']));
+        const unselectedRow = tableData.find((tableRow) => (tableRow.selected && tableRow.DOI !== specimen.digitalSpecimen['ods:id']));
 
         if (unselectedRow) {
-            unselectedRow.toggleSelected = false;
+            unselectedRow.selected = false;
         }
 
         /* Select chosen Table Row */
         const selectedRow = tableData.find((tableRow) => tableRow.DOI === specimen.digitalSpecimen['ods:id']);
 
         if (selectedRow) {
-            selectedRow.toggleSelected = true;
+            selectedRow.selected = true;
         }
 
         const copyTableData = [...tableData];
@@ -134,10 +135,10 @@ const ResultsTable = (props: Props) => {
     useEffect(() => {
         if (isEmpty(searchSpecimen)) {
             /* Unselect current Row */
-            const currentRow = tableData.find((tableRow) => tableRow.toggleSelected);
+            const currentRow = tableData.find((tableRow) => tableRow.selected);
 
             if (currentRow) {
-                currentRow.toggleSelected = false;
+                currentRow.selected = false;
             }
         }
 
@@ -149,11 +150,11 @@ const ResultsTable = (props: Props) => {
     /* Function to check if selected Specimen is still selected after page change */
     useEffect(() => {
         if (!isEmpty(searchSpecimen)) {
-            if (!tableData.find((tableRow) => (tableRow.toggleSelected && tableRow.DOI === searchSpecimen.digitalSpecimen['ods:id']))) {
+            if (!tableData.find((tableRow) => (tableRow.selected && tableRow.DOI === searchSpecimen.digitalSpecimen['ods:id']))) {
                 const currentRow = tableData.find((tableRow) => tableRow.DOI === searchSpecimen.digitalSpecimen['ods:id']);
 
                 if (currentRow) {
-                    currentRow.toggleSelected = true;
+                    currentRow.selected = true;
 
                     const copyTableData = [...tableData];
 
@@ -322,7 +323,7 @@ const ResultsTable = (props: Props) => {
                     collected: specimen.digitalSpecimen.occurrences?.[0]?.['dwc:eventDate'] ?? '',
                     holder: specimen.digitalSpecimen['dwc:institutionName'] ?? (specimen.digitalSpecimen['dwc:institutionId'] ?? ''),
                     taxonomyIconUrl: taxonomyIconUrl ?? TopicDisciplineIcon(specimen.digitalSpecimen['ods:topicDiscipline']),
-                    toggleSelected: false,
+                    selected: false,
                     compareSelected: !!compareSpecimens.find((compareSpecimen) => compareSpecimen.digitalSpecimen['ods:id'] === specimen.digitalSpecimen['ods:id'])
                 });
             }
@@ -360,7 +361,7 @@ const ResultsTable = (props: Props) => {
 
             <DataTable columns={columns}
                 data={tableData}
-                pinnedColumns={pinnedColumns}
+                SelectAction={(row: DataRow) => SelectAction(row)}
             />
         </div>
     );

--- a/src/redux/general/GeneralSlice.ts
+++ b/src/redux/general/GeneralSlice.ts
@@ -8,6 +8,10 @@ import { PaginationObject } from 'app/Types';
 
 export interface GeneralState {
     screenSize: string,
+    windowDimensions: {
+        vw: number,
+        vh: number
+    }
     promptMessages: {
         key: string,
         message: string,
@@ -23,6 +27,7 @@ export interface GeneralState {
 
 const initialState: GeneralState = {
     screenSize: 'lg',
+    windowDimensions: {vw: 0, vh: 0},
     promptMessages: [],
     language: 'EN',
     introTopic: '',
@@ -38,6 +43,9 @@ export const GeneralSlice = createSlice({
     reducers: {
         setScreenSize: (state, action: PayloadAction<string>) => {
             state.screenSize = action.payload;
+        },
+        setWindowDimensions: (state, action: PayloadAction<{vw: number, vh: number}>) => {
+            state.windowDimensions = action.payload;
         },
         setPromptMessages: (state, action: PayloadAction<{ key: string, message: string, template?: string }[]>) => {
             state.promptMessages = action.payload;
@@ -72,6 +80,7 @@ export const GeneralSlice = createSlice({
 /* Action Creators */
 export const {
     setScreenSize,
+    setWindowDimensions,
     setPromptMessages,
     pushToPromptMessages,
     removeFromPromptMessages,
@@ -85,6 +94,7 @@ export const {
 
 /* Connect with Root State */
 export const getScreenSize = (state: RootState) => state.general.screenSize;
+export const getWindowDimensions = (state: RootState) => state.general.windowDimensions;
 export const getPromptMessages = (state: RootState) => state.general.promptMessages;
 export const getLanguage = (state: RootState) => state.general.language;
 export const getIntroTopic = (state: RootState) => state.general.introTopic;


### PR DESCRIPTION
Proud to announce the new and improved Data Table for global usage within DiSSCover.
The new data table component is built by using the Tan Stack table library, which is a headless library.
Headless means that it does not provide a full component to be used, but rather an API that can be requested and used for passing functionality onto a plain HTML table.

The custom Data Table component has several options built in at the moment:
- Functionality for filtering per column
- Sticky header when scrolling down
- Row selection
- Pinned columns
- Dynamic width of table columns based upon REM value

The columns and data to pass to the data table should be defined loosely from the component itself.
That is why table configuration files have been introduced to take care of the column configuration.
Most of this code is repeatable and takes a lot of space, these files should help prevent code from becoming messier.

New features to the Data Table component may be introduced in the future by demand.