### PR TITLE
Annotation wizard define motivation and values step

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -125,6 +125,10 @@ p {
   color: var(--greyDark);
 }
 
+.tc-error {
+  color: var(--error);
+}
+
 /* Width */
 .w-0 {
   width: 0 !important;

--- a/src/app/Types.ts
+++ b/src/app/Types.ts
@@ -104,6 +104,17 @@ export type ParentClass = {
     dependent?: boolean
 };
 
+/* Annotation form property */
+export type AnnotationFormProperty = {
+    key: string,
+    name: string,
+    jsonPath: string,
+    type: string,
+    currentValue?: string | number | boolean | Dict,
+    subClassIndex?: number,
+    properties?: AnnotationFormProperty[]
+};
+
 /* Dropdown item */
 export type DropdownItem = {
     label: string,

--- a/src/app/Types.ts
+++ b/src/app/Types.ts
@@ -111,7 +111,6 @@ export type AnnotationFormProperty = {
     jsonPath: string,
     type: string,
     currentValue?: string | number | boolean | Dict,
-    subClassIndex?: number,
     properties?: AnnotationFormProperty[]
 };
 

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -87,11 +87,11 @@ const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClas
 };
 
 /**
- * Function that returns all of the annotation motivations as options
+ * Function that returns all of the annotation motivations as options (excluding deletion as this is handled systematically)
+ * @param givenMotivation An already selected motivation that impacts the choice in motivation
  */
-const GetAnnotationMotivations = () => ({
-    'ods:adding': 'Addition',
-    'ods:deleting': 'Deletion',
+const GetAnnotationMotivations = (givenMotivation?: string) => ({
+    ...(givenMotivation === 'ods:adding' && {'ods:adding': 'Addition'}),
     'oa:assessing': 'Assessment',
     'oa:editing': "Modification",
     'oa:commenting': "Comment"

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -2,16 +2,69 @@
 import jp from 'jsonpath';
 
 /* Import Utilities */
-import { ExtractFromSchema, ExtractClassesAndTermsFromSchema } from 'app/utilities/SchemaUtilities';
+import { ExtractFromSchema, ExtractClassesAndTermsFromSchema, MakeJsonPathReadableString } from 'app/utilities/SchemaUtilities';
 
 /* Import Types */
 import { DigitalSpecimen } from "app/types/DigitalSpecimen";
 import { DigitalMedia } from "app/types/DigitalMedia";
-import { AnnotationFormProperty, Dict } from "app/Types";
+import { AnnotationFormProperty, AnnotationTarget, ParentClass, Dict } from "app/Types";
 
 
 /* Utilities associated with annotating */
 
+
+/**
+ * Function to extract parent classes from a given super class and provide all their associated information
+ * @param params An object containing: the annotationTarget, superClass and parentClasses properties
+ * @returns The extracted parent classes
+ */
+const ExtractParentClasses = (params: {
+    annotationTarget: AnnotationTarget,
+    superClass: DigitalSpecimen | DigitalMedia | Dict
+}) => {
+    const { annotationTarget, superClass } = params;
+
+    /* Base variables */
+    const pathArray: string[] = ['$'];
+    const parents = jp.parse(annotationTarget.jsonPath).slice(1, -1);
+    const parentClasses: ParentClass[] = [];
+
+    /* For each parant, find and extract its class information */
+    parents.forEach((parent, index) => {
+        /* Filter path from schemas */
+        let parentName = parent.expression.value.replace('ods:', '').replace('dwc:', '').replace('dcterms:', '');
+
+        /* Add to pathArray */
+        pathArray.push(parent.expression.value);
+
+        if (parentName.includes('has') || parentName[0] === parentName[0].toUpperCase()) {
+            /* If a parent class is empty, it needs to be targeted, if it is not completely empty, check for indexes */
+            const parentNodes = jp.nodes(superClass, jp.stringify(pathArray).replaceAll('][', ']..[').replaceAll('"', "'"));
+
+            if (!parentNodes.length) {
+                parentClasses.push({
+                    jsonPath: jp.stringify(pathArray).replaceAll('"', "'"),
+                    name: MakeJsonPathReadableString(jp.stringify(pathArray)),
+                    ...(index > 0 && { parentName: pathArray[index] }),
+                    present: false
+                });
+            }
+
+            parentNodes.forEach((parentNode, parentIndex) => {
+                parentClasses.push({
+                    jsonPath: jp.stringify(parentNode.path).replaceAll('"', "'"),
+                    name: MakeJsonPathReadableString(jp.stringify(parentNode.path)),
+                    ...(index > 0 && { parentName: MakeJsonPathReadableString(pathArray[index]) }),
+                    present: (Array.isArray(parentNode.value) && !!parentNode.value.length) || (!Array.isArray(parentNode.value) && typeof (parentNode.value) === 'object'),
+                    ...(parentNode.value.length && { options: parentNode.value.length }),
+                    ...(parentClasses[parentIndex]?.options && { dependent: true })
+                });
+            });
+        }
+    });
+
+    return parentClasses;
+};
 
 /**
  * Function that formats a JSON path string and replaces the connections with lower dashes
@@ -115,6 +168,7 @@ const ProvideReadableMotivation = (motivation: 'ods:adding' | 'ods:deleting' | '
 };
 
 export {
+    ExtractParentClasses,
     GenerateAnnotationFormFieldProperties,
     GetAnnotationMotivations,
     ProvideReadableMotivation

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -1,4 +1,79 @@
+/* Import Dependencies */
+import jp from 'jsonpath';
+import { lowerFirst } from "lodash";
+
+/* Import Utilities */
+import { ExtractFromSchema, ExtractClassesAndTermsFromSchema } from 'app/utilities/SchemaUtilities';
+import { MakeJsonPathReadableString } from 'app/utilities/SchemaUtilities';
+
+/* Import Types */
+import { DigitalSpecimen } from "app/types/DigitalSpecimen";
+import { DigitalMedia } from "app/types/DigitalMedia";
+import { AnnotationFormProperty, Dict } from "app/Types";
+
+
 /* Utilities associated with annotating */
+
+
+/**
+ * Function to generate and return a dictionary containing all classes and terms of the schema adhering to the provided schema name
+ * @param jsonPath The JSON path that leads to the schema to be used
+ */
+const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClass: DigitalSpecimen | DigitalMedia | Dict, schemaTitle: string) => {
+    const annotationFormFieldProperties: {
+        [propertyName: string]: AnnotationFormProperty
+    } = {};
+
+    /* Format schema name to match the data model naming convention */
+    // const schemaName: string = lowerFirst(MakeJsonPathReadableString(jsonPath === '$' ? schemaTitle : jsonPath).replaceAll(/[0-9]/g, '').replaceAll(' ', ''));
+
+    /* Extract main schema */
+    await ExtractFromSchema(jsonPath).then(async (schema) => {
+        await ExtractClassesAndTermsFromSchema(schema).then(({
+            classesList,
+            termsList
+        }) => {
+            /* For each class, add it as a key property to the annotation form fields dictionary */
+            classesList.forEach(classProperty => {
+                annotationFormFieldProperties[classProperty.label] = {
+                    key: classProperty.key,
+                    name: classProperty.label,
+                    jsonPath: classProperty.value.replace(`$`, jsonPath),
+                    type: classProperty.value.includes('has') ? 'array' : 'object',
+                    properties: []
+                };
+
+                /* For each term of class, add it to the properties array of the corresponding class in the annotation form fields dictionary */
+                const termProperties = termsList.find(termsListOption => termsListOption.label === classProperty.label);
+
+                termProperties?.options.forEach(termOption => {
+                    const currentValue: string = jp.value(superClass, termOption.value.replace(`$`, jsonPath));
+
+                    annotationFormFieldProperties[classProperty.label].properties?.push({
+                        key: termOption.key,
+                        name: termOption.label,
+                        jsonPath: termOption.value,
+                        type: 'string',
+                        currentValue
+                    })
+                });
+            });
+        })
+    });
+
+    return annotationFormFieldProperties;
+};
+
+/**
+ * Function that returns all of the annotation motivations as options
+ */
+const GetAnnotationMotivations = () => ({
+    'ods:adding': 'Addition',
+    'ods:deleting': 'Deletion',
+    'oa:assessing': 'Assessment',
+    'oa:editing': "Modification",
+    'oa:commenting': "Comment"
+});
 
 /**
  * Function to provide a readable motivation based on the motivation vocabulary
@@ -18,5 +93,7 @@ const ProvideReadableMotivation = (motivation: 'ods:adding' | 'ods:deleting' | '
 };
 
 export {
+    GenerateAnnotationFormFieldProperties,
+    GetAnnotationMotivations,
     ProvideReadableMotivation
 };

--- a/src/app/utilities/SchemaUtilities.ts
+++ b/src/app/utilities/SchemaUtilities.ts
@@ -1,5 +1,5 @@
 /* Import Dependencies */
-import { lowerCase, lowerFirst } from "lodash";
+import { lowerFirst } from "lodash";
 
 /* Import Utilities */
 import { MakeReadableString } from "app/Utilities";

--- a/src/app/utilities/SchemaUtilities.ts
+++ b/src/app/utilities/SchemaUtilities.ts
@@ -1,3 +1,6 @@
+/* Import Dependencies */
+import { lowerCase, lowerFirst } from "lodash";
+
 /* Import Utilities */
 import { MakeReadableString } from "app/Utilities";
 
@@ -11,27 +14,28 @@ import { Dict } from "app/Types";
  * @returns Dictionary containing the generated classes and terms list
  */
 const ExtractClassesAndTermsFromSchema = async (schema: Dict) => {
-    const classesList: { label: string, value: string }[] = [];
-    const termsList: { label: string, options: { label: string, value: string }[] }[] = [];
+    const classesList: { key: string, label: string, value: string }[] = [];
+    const termsList: { label: string, options: { key: string, label: string, value: string }[] }[] = [];
 
     /**
-     * 
+     * Function to push to the classes list
      * @param classOption 
      */
-    const PushToClassesList = (classOption: { label: string, value: string }) => {
+    const PushToClassesList = (classOption: { key: string, label: string, value: string }) => {
         classesList.push(classOption);
     };
 
     /**
-     * 
+     * Function to push to the terms list
      * @param termsOption 
      */
-    const PushToTermsList = (termsOption: { label: string, options: { label: string, value: string }[] }) => {
+    const PushToTermsList = (termsOption: { label: string, options: { key: string, label: string, value: string }[] }) => {
         termsList.push(termsOption);
     };
 
     /* Push super class to classes list */
     PushToClassesList({
+        key: schema.title,
         label: MakeReadableString(schema.title),
         value: '$'
     });
@@ -59,10 +63,68 @@ const ExtractClassesAndTermsFromSchema = async (schema: Dict) => {
  * @param schemaName The name of the schema to extract from 
  * @returns Dictionary of the requested schema
  */
-const ExtractFromSchema = async (schemaName: string) => {
-    const strippedSchemaName: string = schemaName.replace('ods:', '').replace('has', '')[0].toLowerCase() + schemaName.replace('ods:', '').replace('has', '').slice(1);
+const ExtractFromSchema = async (jsonPath: string) => {
+    /* Base variables */
+    let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll('[', '').replaceAll(']', '').replaceAll("'", '');
 
-    return await import(`../../sources/dataModel/${strippedSchemaName}.json`);
+    if (classSeparatedString.at(-1) === '_') {
+        classSeparatedString = classSeparatedString.slice(0, -1);
+    }
+
+    /**
+     * Function to strip a schema string to remove all schema specific string occurrences
+     * @param jsonPath The provided JSON path to strip
+     * @returns Stripped schema string
+     */
+    const StripSchemaString = (jsonPath: string) => {
+        const strippedSchemaName: string = lowerFirst(jsonPath.replaceAll('ods:', '').replaceAll('has', ''));
+
+        return strippedSchemaName;
+    };
+
+    const strippedSchemaName = lowerFirst(StripSchemaString(classSeparatedString).split('_').at(-1));
+
+    /* Try to import schema from data model sources, if it fails, try and search for the schema via its parents untill its found */
+    try {
+        return await import(`../../sources/dataModel/${strippedSchemaName}.json`);
+    } catch {
+        /* Try to iterate through the different schema levels and search for properties */
+        const schemaClasses: string[] = classSeparatedString.split('_');
+        const targetedSchemaName: string = schemaClasses.at(-1) as string;
+        let lowestLevelSchema: Dict | undefined;
+        let crashCheck: boolean = false;
+
+        /* Find lowest level schema */
+        while (!(lowestLevelSchema && targetedSchemaName in lowestLevelSchema.properties) && !crashCheck) {
+            try {
+                await ExtractFromSchema(schemaClasses[0]).then((schema: Dict) => {
+                    lowestLevelSchema = schema;
+                });
+            } catch {
+                crashCheck = true;
+            };
+
+            /* Remove index from array */
+            schemaClasses.shift();
+        };
+
+        /* For remaining parent levels, dig through the lowest schema's levels to uncover the targeted schema */
+        schemaClasses.forEach(schemaClass => {
+            lowestLevelSchema = lowestLevelSchema?.properties[schemaClass];
+
+            if (lowestLevelSchema?.items) {
+                lowestLevelSchema = { ...lowestLevelSchema,
+                    ...lowestLevelSchema.items,
+                };
+            }
+
+            if (lowestLevelSchema && !lowestLevelSchema.title) {
+                lowestLevelSchema.title = MakeJsonPathReadableString(schemaClass);
+            }
+        });
+
+        return lowestLevelSchema;
+    };
 };
 
 /**
@@ -81,7 +143,7 @@ const IterateOverSchemaLayer = async (params: {
 }) => {
     const { schema, jsonPath, schemaName, PushToClassesList, PushToTermsList } = params;
 
-    const localTermsList: { label: string, value: string }[] = [];
+    const localTermsList: { key: string, label: string, value: string }[] = [];
 
     /* Iterate over schema layer properties and determine if it is a class or term by checking the ods:has pattern */
     for (let i = 0; i < Object.keys(schema).length; i++) {
@@ -115,6 +177,7 @@ const IterateOverSchemaLayer = async (params: {
         } else {
             /* Treat as a stand alone term */
             localTermsList.push({
+                key,
                 label: MakeJsonPathReadableString(key),
                 value: `${jsonPath}['${key}']`
             });
@@ -156,5 +219,6 @@ const MakeJsonPathReadableString = (jsonPath: string): string => {
 
 export {
     ExtractClassesAndTermsFromSchema,
+    ExtractFromSchema,
     MakeJsonPathReadableString
 };

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
@@ -42,9 +42,7 @@ const AnnotationWizard = (props: Props) => {
         annotationSelectInstance: <AnnotationSelectInstanceStep superClass={superClass}
             schemaTitle={schema.title}
         />,
-        annotationForm: <AnnotationFormStep schema={schema}
-            superClass={superClass}
-        />
+        annotationForm: <AnnotationFormStep superClass={superClass} />
     };
 
     /* Base variables */
@@ -175,7 +173,7 @@ const AnnotationWizard = (props: Props) => {
 
                         }}
                     >
-                        {({ values, setFieldValue }) => (
+                        {({ values, setFieldValue, setValues }) => (
                             <Form className="h-100 d-flex flex-column overflow-none">
                                 {/* Previous and next step buttons */}
                                 <Row>
@@ -215,6 +213,7 @@ const AnnotationWizard = (props: Props) => {
                                             tabProps={{
                                                 formValues: values,
                                                 SetFieldValue: setFieldValue,
+                                                SetFormValues: setValues,
                                                 SetAnnotationTarget,
                                                 GoToStep: GoToStep
                                             }}

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
@@ -42,7 +42,9 @@ const AnnotationWizard = (props: Props) => {
         annotationSelectInstance: <AnnotationSelectInstanceStep superClass={superClass}
             schemaTitle={schema.title}
         />,
-        annotationForm: <AnnotationFormStep />
+        annotationForm: <AnnotationFormStep schema={schema}
+            superClass={superClass}
+        />
     };
 
     /* Base variables */
@@ -70,12 +72,20 @@ const AnnotationWizard = (props: Props) => {
         jsonPath: string | undefined,
         parentClassDropdownValues: {
             [parentClass: string]: number
+        },
+        motivation: 'ods:adding' | 'ods:deleting' | 'oa:assessing' | 'oa:editing' | 'oa:commenting' | undefined,
+        annotationValues: {
+            [className: string]: {
+                [termName: string]: string
+            }
         }
     } = {
         class: undefined,
         term: undefined,
         jsonPath: undefined,
-        parentClassDropdownValues: {}
+        parentClassDropdownValues: {},
+        motivation: undefined,
+        annotationValues: {}
     };
 
     /**

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
@@ -45,7 +45,7 @@ const AnnotationFormSegment = (props: Props) => {
 
     /* Render form segment based on the type of the annotation form field property */
     switch (annotationFormFieldProperty.type) {
-        case 'object':
+        case 'object': {
             /* Determine annotation form field property title */
             const annotationFormFieldPropertyTitle: string = `${annotationFormFieldProperty.name}${annotationFormFieldProperty.jsonPath !== formValues?.jsonPath &&
                 typeof (index) !== 'undefined' ? ` #${Number(index) + 1}` : ''
@@ -102,7 +102,7 @@ const AnnotationFormSegment = (props: Props) => {
 
                         fieldName = fieldName.concat(`${annotationFormFieldProperty.jsonPath.replaceAll('.', '_').replaceAll('][', '_').replaceAll('[', '').replaceAll(']', '')}`);
 
-                        if (typeof(index) !== 'undefined') {
+                        if (typeof (index) !== 'undefined') {
                             fieldValue = formValues?.annotationValues?.[fieldName]?.[index]?.[`${fieldProperty.key}`];
                             fieldName = fieldName.concat(`[${index}]`);
                         } else {
@@ -130,7 +130,7 @@ const AnnotationFormSegment = (props: Props) => {
                     })}
                 </div>
             );
-        case 'array':
+        } case 'array': {
             /* Format field name for field array sub class */
             const fieldName = `${annotationFormFieldProperty.jsonPath.replaceAll('.', '_').replaceAll('][', '_').replaceAll('[', '').replaceAll(']', '')}`;
 
@@ -187,6 +187,7 @@ const AnnotationFormSegment = (props: Props) => {
                     </FieldArray>
                 </div>
             );
+        }
     };
 };
 

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
@@ -1,0 +1,184 @@
+/* Import Dependencies */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classNames from 'classnames';
+import { Field, FieldArray } from 'formik';
+import { useState } from 'react';
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Types */
+import { AnnotationFormProperty, Dict } from 'app/Types';
+
+/* Import Icons */
+import { faChevronUp, faChevronDown, faPlus, faTrashCan } from '@fortawesome/free-solid-svg-icons';
+
+/* Import Components */
+import { Button } from 'components/elements/customUI/CustomUI';
+
+
+/* Props Type */
+type Props = {
+    annotationFormFieldProperty: AnnotationFormProperty,
+    formValues?: Dict,
+    Remove?: Function
+};
+
+
+/**
+ * Component that returns a segment of the annotation form based upon the provided annotation form field property
+ * @returns JSX Component
+ */
+const AnnotationFormSegment = (props: Props) => {
+    const { annotationFormFieldProperty, formValues, Remove } = props;
+
+    /* Base variables */
+    const [isHidden, setIsHidden] = useState<boolean>(annotationFormFieldProperty.jsonPath !== formValues?.jsonPath);
+
+    /* Class Names */
+    const formFieldsDivClass = classNames({
+        'd-none': isHidden
+    });
+
+    // console.log(formValues);
+
+    /* Render form segment based on the type of the annotation form field property */
+    switch (annotationFormFieldProperty.type) {
+        case 'object':
+            /* Determine annotation form field property title */
+            const annotationFormFieldPropertyTitle: string = `${annotationFormFieldProperty.name}${annotationFormFieldProperty.jsonPath !== formValues?.jsonPath &&
+                typeof (annotationFormFieldProperty.subClassIndex) !== 'undefined' ? ` #${Number(annotationFormFieldProperty.subClassIndex) + 1}` : ''
+                }`;
+
+            return (
+                <div className="b-grey br-corner mb-3 px-3 py-2">
+                    <Row className="py-1">
+                        <Col className="d-flex align-items-center">
+                            <p className="tc-primary fw-lightBold">
+                                {annotationFormFieldPropertyTitle}
+                            </p>
+                        </Col>
+
+                        {Remove &&
+                            <Col lg="auto"
+                                className="pe-1"
+                            >
+                                <Button type="button"
+                                    variant="blank"
+                                    className="px-0 py-0"
+                                    OnClick={() => {
+                                        if (window.confirm(`Are you sure, you want to remove the sub class: ${annotationFormFieldPropertyTitle}?`)) {
+                                            Remove();
+                                        }
+                                    }}
+                                >
+                                    <FontAwesomeIcon icon={faTrashCan}
+                                        size="lg"
+                                        className="tc-error"
+                                    />
+                                </Button>
+                            </Col>
+                        }
+                        <Col lg="auto"
+                            className="d-flex align-items-center"
+                        >
+                            <Button type="button"
+                                variant="blank"
+                                className="px-0 py-0"
+                                OnClick={() => setIsHidden(!isHidden)}
+                            >
+                                <FontAwesomeIcon icon={isHidden ? faChevronDown : faChevronUp}
+                                    className="tc-primary"
+                                    size="lg"
+                                />
+                            </Button>
+                        </Col>
+                    </Row>
+
+                    {annotationFormFieldProperty.properties?.map(fieldProperty => {
+                        let fieldName = `${annotationFormFieldProperty.jsonPath.replaceAll('.', '_').replaceAll('][', '_').replaceAll('[', '').replaceAll(']', '')}`;
+
+                        /* If is instance of sub class, add sub class index to field name */
+                        if (annotationFormFieldProperty.subClassIndex) {
+                            fieldName = fieldName.concat(`[${annotationFormFieldProperty.subClassIndex}]`);
+                        }
+
+                        // console.log(fieldProperty);
+
+                        return (
+                            <Row key={fieldProperty.jsonPath}
+                                className={`${formFieldsDivClass} mb-2`}
+                            >
+                                <Col>
+                                    <p className="fs-4">
+                                        {fieldProperty.name}
+                                    </p>
+
+                                    <Field name={`annotationValues.${fieldName}.${fieldProperty.key}`}
+                                        value={formValues?.annotationValues?.[fieldName]?.[fieldProperty.key] ?? fieldProperty.currentValue ?? ''}
+                                        className="w-100 b-grey br-corner mt-1 py-1 px-2"
+                                    />
+                                </Col>
+                            </Row>
+                        );
+                    })}
+                </div>
+            );
+        case 'array':
+            /* Format field name for field array sub class */
+            const fieldName = `${annotationFormFieldProperty.jsonPath.replaceAll('.', '_').replaceAll('][', '_').replaceAll('[', '').replaceAll(']', '')}`;
+
+            return (
+                <div>
+                    <FieldArray name={`annotationValues.${fieldName}`}>
+                        {({ push, remove }) => (
+                            <>
+                                <div className="bgc-primary tc-white b-grey br-corner mb-3 px-3 py-2">
+                                    <Row className="py-1">
+                                        <Col className="d-flex align-items-center">
+                                            <p className="fw-bold">
+                                                {`${annotationFormFieldProperty.name}s`}
+                                            </p>
+                                        </Col>
+                                        <Col lg="auto"
+                                            className="d-flex align-items-center"
+                                        >
+                                            <Button type="button"
+                                                variant="blank"
+                                                className="px-0 py-0"
+                                                OnClick={() => push({})}
+                                            >
+                                                <FontAwesomeIcon icon={faPlus}
+                                                    size="lg"
+                                                />
+                                            </Button>
+                                        </Col>
+                                    </Row>
+                                </div>
+
+                                {/* For each sub class index, render a annotation form segment */}
+                                {formValues?.annotationValues?.[fieldName]?.map((_classObject: Dict, index: number) => {
+                                    /* Set sub class as object and render form segment */
+                                    const annotationFormFieldSubProperty: AnnotationFormProperty = { ...annotationFormFieldProperty };
+
+                                    annotationFormFieldSubProperty.type = 'object';
+                                    annotationFormFieldProperty.subClassIndex = index;
+
+                                    return (
+                                        <div key={fieldName}
+                                            className="ms-4"
+                                        >
+                                            <AnnotationFormSegment annotationFormFieldProperty={annotationFormFieldSubProperty}
+                                                formValues={formValues}
+                                                Remove={() => remove(index)}
+                                            />
+                                        </div>
+                                    );
+                                })}
+                            </>
+                        )}
+                    </FieldArray>
+                </div>
+            );
+    };
+};
+
+export default AnnotationFormSegment;

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -1,11 +1,153 @@
+/* Import Dependencies */
+import { useState } from 'react';
+import { Row, Col } from 'react-bootstrap';
+
+/* Import Utitlties */
+import { GenerateAnnotationFormFieldProperties, GetAnnotationMotivations } from "app/utilities/AnnotateUtilities";
+
+/* Import Hooks */
+import { useAppSelector, useTrigger } from "app/Hooks";
+
+/* Import Store */
+import { getAnnotationTarget } from "redux-store/AnnotateSlice";
+
+/* Import Types */
+import { DigitalSpecimen } from "app/types/DigitalSpecimen";
+import { DigitalMedia } from "app/types/DigitalMedia";
+import { AnnotationFormProperty, Dict, DropdownItem } from "app/Types";
+
+/* Import Components */
+import AnnotationFormSegment from './AnnotationFormSegment';
+import { Dropdown } from "components/elements/customUI/CustomUI";
+
+
+/* Props Type */
+type Props = {
+    schema: Dict,
+    superClass: DigitalSpecimen | DigitalMedia | Dict,
+    formValues?: Dict,
+    SetFieldValue?: Function
+};
+
+
 /**
- * 
+ * Component that renders the third and final step in the annotation wizard for defining the motivation and actual values
  * @returns JSX Component
  */
-const AnnotationFormStep = () => {
-    return (
-        <div>
+const AnnotationFormStep = (props: Props) => {
+    const { schema, superClass, formValues, SetFieldValue } = props;
 
+    /* Hooks */
+    const trigger = useTrigger();
+
+    /* Base variables */
+    const annotationTarget = useAppSelector(getAnnotationTarget);
+    const [annotationFormFieldProperties, setAnnotationFormFieldProperties] = useState<{ [propertyName: string]: AnnotationFormProperty }>();
+    const annotationMotivations = GetAnnotationMotivations();
+    let baseObjectFormFieldProperty: AnnotationFormProperty | undefined;
+
+    /* Construct annotation motivation dropdown items */
+    const annotationMotivationDropdownItems: DropdownItem[] = Object.entries(annotationMotivations).map(([value, label]) => ({
+        label,
+        value
+    }));
+
+    /* OnLoad, generate field properties for annotation form */
+    trigger.SetTrigger(() => {
+        if (formValues) {
+            GenerateAnnotationFormFieldProperties(formValues.jsonPath, superClass, schema.title).then(annotationFormFieldProperties => {
+                setAnnotationFormFieldProperties(annotationFormFieldProperties);
+            });
+        }
+    }, []);
+
+    /* OnChange of annotation form field properties, check for existing values within super class and append to annotation form */
+    // trigger.SetTrigger(() => {
+    //     const annotationValues: Dict = {};
+
+    //     /* For each class, add potential form values as placeholders, if possible with existing values */
+    //     annotationFormFieldProperties.forEach()
+
+    //     console.log(annotationFormFieldProperties);
+    // }, [annotationFormFieldProperties]);
+
+    /* From annotation form field properties, extract base object and its properties */
+    if (annotationFormFieldProperties && formValues) {
+        baseObjectFormFieldProperty = Object.values(annotationFormFieldProperties).find(annotationFormFieldProperty => annotationFormFieldProperty.jsonPath === formValues.jsonPath);
+    }
+
+    return (
+        <div className="h-100 d-flex flex-column">
+            {/* Annotation motivation, will be disabled if pre defined by instance selection */}
+            <Row>
+                <Col>
+                    <p>
+                        What motivates you to make this annotation?
+                    </p>
+
+                    <Row className="mt-3">
+                        <Col>
+                            <Dropdown items={annotationMotivationDropdownItems}
+                                selectedItem={formValues?.motivation && {
+                                    label: annotationMotivations[formValues.motivation as keyof typeof annotationMotivations],
+                                    value: formValues.motivation
+                                }}
+                                placeholder="Select a motivation"
+                                styles={{
+                                    background: '#ffffff',
+                                    border: true,
+                                    borderRadius: '8px'
+                                }}
+                                OnChange={(option: {
+                                    label: string,
+                                    value: string
+                                }) => {
+                                    SetFieldValue?.('motivation', option.value)
+                                }}
+                            />
+                        </Col>
+                    </Row>
+                </Col>
+            </Row>
+            {/* Annotation form properties */}
+            <Row className="mt-3">
+                <Col>
+                    <p>
+                        Specify which value(s) you want to annotate
+                    </p>
+                </Col>
+            </Row>
+            <Row className="flex-grow-1 mt-3 overflow-scroll">
+                <Col>
+                    {(annotationFormFieldProperties && formValues) ?
+                        <>
+                            {/* Render base class' form fields */}
+                            {baseObjectFormFieldProperty &&
+                                <AnnotationFormSegment annotationFormFieldProperty={baseObjectFormFieldProperty}
+                                    formValues={formValues}
+                                />
+                            }
+                            <p className="fs-4 fw-lightBold mb-2">
+                                {`Sub classes of ${baseObjectFormFieldProperty?.name}`}
+                            </p>
+                            {/* Render optional, additional sub classes' form fields */}
+                            {Object.values(annotationFormFieldProperties).filter(
+                                annotationFormFieldProperty => annotationFormFieldProperty.jsonPath !== formValues.jsonPath
+                            ).sort(
+                                (a) => a.type !== 'object' ? 1 : 0
+                            ).map(
+                                annotationFormFieldProperty => (
+                                    <AnnotationFormSegment key={annotationFormFieldProperty.jsonPath}
+                                        annotationFormFieldProperty={annotationFormFieldProperty}
+                                        formValues={formValues}
+                                    />
+                                )
+                            )}
+                        </>
+                        : <p>Loading</p>
+                    }
+                </Col>
+            </Row>
         </div>
     );
 };

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -7,10 +7,7 @@ import { Row, Col } from 'react-bootstrap';
 import { GenerateAnnotationFormFieldProperties, GetAnnotationMotivations } from "app/utilities/AnnotateUtilities";
 
 /* Import Hooks */
-import { useAppSelector, useTrigger } from "app/Hooks";
-
-/* Import Store */
-import { getAnnotationTarget } from "redux-store/AnnotateSlice";
+import { useTrigger } from "app/Hooks";
 
 /* Import Types */
 import { DigitalSpecimen } from "app/types/DigitalSpecimen";
@@ -19,7 +16,7 @@ import { AnnotationFormProperty, Dict, DropdownItem } from "app/Types";
 
 /* Import Components */
 import AnnotationFormSegment from './AnnotationFormSegment';
-import { Dropdown } from "components/elements/customUI/CustomUI";
+import { Dropdown, InputTextArea } from "components/elements/customUI/CustomUI";
 
 
 /* Props Type */
@@ -46,9 +43,8 @@ const AnnotationFormStep = (props: Props) => {
     const trigger = useTrigger();
 
     /* Base variables */
-    const annotationTarget = useAppSelector(getAnnotationTarget);
     const [annotationFormFieldProperties, setAnnotationFormFieldProperties] = useState<{ [propertyName: string]: AnnotationFormProperty }>();
-    const annotationMotivations = GetAnnotationMotivations();
+    const annotationMotivations = GetAnnotationMotivations(formValues?.motivation);
     let baseObjectFormFieldProperty: AnnotationFormProperty | undefined;
     let subClassObjectFormFieldProperties: AnnotationFormProperty[] = [];
 
@@ -104,6 +100,7 @@ const AnnotationFormStep = (props: Props) => {
                                     value: formValues.motivation
                                 }}
                                 placeholder="Select a motivation"
+                                disabled={formValues?.motivation === 'ods:adding'}
                                 styles={{
                                     background: '#ffffff',
                                     border: true,
@@ -124,13 +121,17 @@ const AnnotationFormStep = (props: Props) => {
             <Row className="mt-3">
                 <Col>
                     <p>
-                        Specify which value(s) you want to annotate
+                        {['ods:adding', 'oa:editing'].includes(formValues?.motivation) ?
+                            'Specify which value(s) you want to annotate'
+                            : 'Write your annotation value'
+                        }
                     </p>
                 </Col>
             </Row>
             <Row className="flex-grow-1 mt-3 overflow-scroll">
                 <Col>
-                    {(annotationFormFieldProperties && formValues) ?
+                    {/* If motivation is either adding or editing, render the complete digital object as a form, else a generic text area */}
+                    {(annotationFormFieldProperties && formValues && ['ods:adding', 'oa:editing'].includes(formValues.motivation)) ?
                         <>
                             {/* Render base class' form fields */}
                             {baseObjectFormFieldProperty &&
@@ -157,7 +158,7 @@ const AnnotationFormStep = (props: Props) => {
                                 </>
                             }
                         </>
-                        : <p>Loading</p>
+                        : <InputTextArea name="annotationValues.value" />
                     }
                 </Col>
             </Row>

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ExistingInstance.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ExistingInstance.tsx
@@ -123,7 +123,10 @@ const ExistingInstance = (props: Props) => {
                                 variant="primary"
                                 className="fs-5 py-1 px-3"
                                 disabled={selected}
-                                OnClick={() => SetFieldValue?.('jsonPath', jsonPath)}
+                                OnClick={() => {
+                                    SetFieldValue?.('motivation', 'oa:editing');
+                                    SetFieldValue?.('jsonPath', jsonPath);
+                                }}
                             >
                                 {!selected ? 'Select this instance' : 'Currently selected'}
                             </Button>

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
@@ -127,6 +127,7 @@ const NewInstance = (props: Props) => {
                                     OnClick={() => {
                                         const latestIndex: any = jp.query(superClass, annotationTarget.jsonPath)[0].length;
 
+                                        SetFieldValue?.('motivation', 'ods:adding');
                                         SetFieldValue?.('jsonPath', `${annotationTarget.jsonPath}[${latestIndex}]`);
                                     }}
                                 >

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
@@ -156,7 +156,7 @@ const ParentClassification = (props: Props) => {
                     }}
                 />
 
-                {(parentClasses.filter(parentClass => parentClass.name in formValues?.parentClassDropdownValues ?? {}).length === parentClasses.length && (index + 1) === parentClasses.length) &&
+                {(parentClasses.filter(parentClass => formValues && parentClass.name in formValues.parentClassDropdownValues).length === parentClasses.length && (index + 1) === parentClasses.length) &&
                     <Button type="button"
                         variant="primary"
                         disabled={formValues?.parentClassDropdownValues[parentClass.name] <= 0 && selected}

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
@@ -84,6 +84,7 @@ const ParentClassification = (props: Props) => {
                     OnClick={() => {
                         if (annotationTarget) {
                             /* Set field values in form to parent class */
+                            SetFieldValue?.('motivation', 'ods:adding');
                             SetFieldValue?.('jsonPath', `${parentClass.jsonPath}[0]`);
                             SetFieldValue?.('class', {
                                 label: MakeJsonPathReadableString(parentClass.jsonPath),
@@ -172,6 +173,7 @@ const ParentClassification = (props: Props) => {
                                 jsonPath = `${jsonPath}[${latestIndex}]`;
                             }
 
+                            SetFieldValue?.('motivation', 'ods:adding');
                             SetFieldValue?.('jsonPath', jsonPath);
                         }}
                     >

--- a/src/components/elements/customUI/CustomUI.tsx
+++ b/src/components/elements/customUI/CustomUI.tsx
@@ -4,6 +4,7 @@ import Button from "./button/Button";
 import DataTable from "./dataTable/DataTable";
 import Dropdown from "./dropdown/Dropdown";
 import InputField from "./inputField/InputField";
+import InputTextArea from "./inputTextArea/InputTextArea";
 import LoadingScreen from "./loadingScreen/LoadingScreen";
 import OpenStreetMap from "./openStreetMap/OpenStreetMap";
 import MultiSelect from "./multiSelect/MultiSelect";
@@ -21,6 +22,7 @@ export {
     DataTable,
     Dropdown,
     InputField,
+    InputTextArea,
     LoadingScreen,
     MultiSelect,
     OpenStreetMap,

--- a/src/components/elements/customUI/dropdown/Dropdown.tsx
+++ b/src/components/elements/customUI/dropdown/Dropdown.tsx
@@ -120,13 +120,12 @@ const Dropdown = (props: Props) => {
                 }),
                 singleValue: provided => ({
                     ...provided,
-                    color: styles?.textColor ?? '#333333',
+                    color: styles?.textColor ?? '#333333'
                 }),
                 valueContainer: provided => ({
                     ...provided,
                     width: 'max-content',
-                    padding: '0px',
-
+                    padding: '0px'
                 }),
                 clearIndicator: provided => ({
                     ...provided,

--- a/src/components/elements/customUI/inputTextArea/InputTextArea.tsx
+++ b/src/components/elements/customUI/inputTextArea/InputTextArea.tsx
@@ -1,0 +1,30 @@
+/* Import Dependencies */
+import { Field } from "formik";
+
+
+/* Props Type */
+type Props = {
+    name: string
+};
+
+
+/**
+ * Component that renders an automatically sized text area with Formik form field
+ * @param name The name of the form field
+ * @returns JSX Component
+ */
+const InputTextArea = (props: Props) => {
+    const { name } = props;
+
+    return (
+        <div>
+            <Field name={name}
+                as="textarea"
+                className="w-100"
+                rows="6"
+            />
+        </div>
+    );
+};
+
+export default InputTextArea;

--- a/src/components/elements/customUI/inputTextArea/inputTextArea.module.scss
+++ b/src/components/elements/customUI/inputTextArea/inputTextArea.module.scss
@@ -1,0 +1,14 @@
+/* Custom styling for the input text area component */
+.inputTextArea {
+    border: 1px solid #ccc;
+    font-family: inherit;
+    font-size: inherit;
+    padding: 1px 6px;
+
+    display: block;
+    width: 100%;
+    overflow: hidden;
+    resize: both;
+    min-height: 40px;
+    line-height: 20px;
+}


### PR DESCRIPTION
PR adds a third step to the annotation wizard for defining the annotation motivation and specifying the values that should form the body of the annotation.

Additions and modifications enable the user to provide values for the whole (or part of) digital object that is provided as the super class. All terms in the digital object, as well as sub classes and terms and sub classes within those will be rendered, so if a user targets a high level in the digital object, lots of different child classes can appear and be given values.
Annotations with the comment or assessment motivations will render a default text area.

Adding a new instance of a class or term will block all other motivations and always be an empty form (because it is a completely new one). A new instance of a class within an array will always be defined as the next index to appear in that array and be specified this way in the JSON path.

Existing instances of terms or classes can be modified, commented on or be assessed. Modifying instances will look up the existing values in the provided super class and render them inside the form.

This step represents the last real action a user has to do in terms of defining values for the annotation.