### PR TITLE
Add annotation summary step to annotation wizard

### DIFF
--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -72,7 +72,7 @@ const ExtractParentClasses = (params: {
  * @returns Formatted JSON path string replacing connections with lower dashes
  */
 const FormatFieldNameFromJsonPath = (jsonPath: string): string => {
-    return jsonPath.replaceAll('][', '_').replaceAll(/\[|\]/g, '');
+    return jsonPath.replaceAll('][', '_').replaceAll(/[\[\]]/g, '');
 };
 
 /**

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -81,15 +81,15 @@ const FormatFieldNameFromJsonPath = (jsonPath: string): string => {
  * @returns JSON path string
  */
 const FormatJsonPathFromFieldName = (fieldName: string): string => {
-    const splittedArray: (string | number)[] = fieldName.replaceAll("'", '').replaceAll('$', '').split('_');
+    const splitArray: (string | number)[] = fieldName.replaceAll(/['\$]/g, '').split('_');
 
-    splittedArray.forEach((value, index) => {
+    splitArray.forEach((value, index) => {
         if (!isNaN(value as number)) {
-            splittedArray[index] = Number(value);
+            splitArray[index] = Number(value);
         }
     });
 
-    return jp.stringify(splittedArray);
+    return jp.stringify(splitArray);
 };
 
 /**

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -72,7 +72,7 @@ const ExtractParentClasses = (params: {
  * @returns Formatted JSON path string replacing connections with lower dashes
  */
 const FormatFieldNameFromJsonPath = (jsonPath: string): string => {
-    return jsonPath.replaceAll('][', '_').replaceAll(/[\]\[]/g, '');
+    return jsonPath.replaceAll('][', '_').replaceAll(/[\][]/g, '');
 };
 
 /**

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -81,7 +81,7 @@ const FormatFieldNameFromJsonPath = (jsonPath: string): string => {
  * @returns JSON path string
  */
 const FormatJsonPathFromFieldName = (fieldName: string): string => {
-    const splitArray: (string | number)[] = fieldName.replaceAll(/['\$]/g, '').split('_');
+    const splitArray: (string | number)[] = fieldName.replaceAll(/['$]/g, '').split('_');
 
     splitArray.forEach((value, index) => {
         if (!isNaN(value as number)) {

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -72,7 +72,7 @@ const ExtractParentClasses = (params: {
  * @returns Formatted JSON path string replacing connections with lower dashes
  */
 const FormatFieldNameFromJsonPath = (jsonPath: string): string => {
-    return jsonPath.replaceAll('][', '_').replaceAll(/[\[\]]/g, '');
+    return jsonPath.replaceAll('][', '_').replaceAll(/[\]\[]/g, '');
 };
 
 /**

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -76,6 +76,21 @@ const FormatFieldNameFromJsonPath = (jsonPath: string) => {
 };
 
 /**
+ * 
+ */
+const FormatJsonPathFromFieldName = (fieldName: string) => {
+    const splittedArray: (string | number)[] = fieldName.replaceAll("'", '').replaceAll('$', '').split('_');
+
+    splittedArray.forEach((value, index) => {
+        if (!isNaN(value as number)) {
+            splittedArray[index] = Number(value);
+        }
+    });
+
+    return jp.stringify(splittedArray);
+};
+
+/**
  * Function to generate and return a dictionary containing all classes and terms of the schema adhering to the provided schema name; and their values
  * @param jsonPath The JSON path that leads to the schema to be used
  * @returns The annotation form field properties and their associated form values
@@ -114,9 +129,9 @@ const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClas
                     }
                 });
 
-                formValues[FormatFieldNameFromJsonPath(classProperty.value.replace(`$`, jsonPath))] = classFormValues;
+                formValues[FormatFieldNameFromJsonPath(classProperty.value.replace(`$`, jsonPath))] = classFormValues ?? {};
             } else {
-                formValues[FormatFieldNameFromJsonPath(classProperty.value.replace(`$`, jsonPath))] = classValues;
+                formValues[FormatFieldNameFromJsonPath(classProperty.value.replace(`$`, jsonPath))] = classValues ?? [];
             }
 
             /* For each term of class, add it to the properties array of the corresponding class in the annotation form fields dictionary */
@@ -169,6 +184,7 @@ const ProvideReadableMotivation = (motivation: 'ods:adding' | 'ods:deleting' | '
 
 export {
     ExtractParentClasses,
+    FormatJsonPathFromFieldName,
     GenerateAnnotationFormFieldProperties,
     GetAnnotationMotivations,
     ProvideReadableMotivation

--- a/src/app/utilities/SchemaUtilities.ts
+++ b/src/app/utilities/SchemaUtilities.ts
@@ -89,7 +89,7 @@ const ExtractFromSchema = async (schemaName: string): Promise<Dict> => {
  */
 const ExtractLowestLevelSchema = async (jsonPath: string): Promise<Dict | undefined> => {
     /* Base variables */
-    let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll(/[\]\[']/g, '');
+    let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll(/[\][']/g, '');
 
     if (classSeparatedString.at(-1) === '_') {
         classSeparatedString = classSeparatedString.slice(0, -1);

--- a/src/app/utilities/SchemaUtilities.ts
+++ b/src/app/utilities/SchemaUtilities.ts
@@ -89,7 +89,7 @@ const ExtractFromSchema = async (schemaName: string): Promise<Dict> => {
  */
 const ExtractLowestLevelSchema = async (jsonPath: string): Promise<Dict | undefined> => {
     /* Base variables */
-    let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll(/\[|\]|'/g, '');
+    let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll(/[\[\]']/g, '');
 
     if (classSeparatedString.at(-1) === '_') {
         classSeparatedString = classSeparatedString.slice(0, -1);

--- a/src/app/utilities/SchemaUtilities.ts
+++ b/src/app/utilities/SchemaUtilities.ts
@@ -89,7 +89,7 @@ const ExtractFromSchema = async (schemaName: string): Promise<Dict> => {
  */
 const ExtractLowestLevelSchema = async (jsonPath: string): Promise<Dict | undefined> => {
     /* Base variables */
-    let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll(/[\[\]']/g, '');
+    let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll(/[\]\[']/g, '');
 
     if (classSeparatedString.at(-1) === '_') {
         classSeparatedString = classSeparatedString.slice(0, -1);

--- a/src/app/utilities/SchemaUtilities.ts
+++ b/src/app/utilities/SchemaUtilities.ts
@@ -146,7 +146,7 @@ const IterateOverSchemaLayer = async (params: {
     const localTermsList: { key: string, label: string, value: string }[] = [];
 
     /* Iterate over schema layer properties and determine if it is a class or term by checking the ods:has pattern */
-    for (let i = 0; i < Object.keys(schema).length; i++) {
+    for (let i = 0; i < Object.keys(schema ?? {}).length; i++) {
         const key = Object.keys(schema)[i];
         const property = Object.values(schema)[i];
 

--- a/src/app/utilities/SchemaUtilities.ts
+++ b/src/app/utilities/SchemaUtilities.ts
@@ -76,7 +76,7 @@ const ExtractClassesAndTermsFromSchema = async (schema: Dict, jsonPath?: string)
  * @param schemaName The name of the schema to extract from
  * @returns Dictionary of the requested schema
  */
-const ExtractFromSchema = async (schemaName: string) => {
+const ExtractFromSchema = async (schemaName: string): Promise<Dict> => {
     const strippedSchemaName = StripSchemaString(schemaName);
 
     return await import(`../../sources/dataModel/${strippedSchemaName}.json`);
@@ -87,9 +87,9 @@ const ExtractFromSchema = async (schemaName: string) => {
  * @param schemaName The name of the schema to extract from 
  * @returns Dictionary of the requested schema
  */
-const ExtractLowestLevelSchema = async (jsonPath: string) => {
+const ExtractLowestLevelSchema = async (jsonPath: string): Promise<Dict | undefined> => {
     /* Base variables */
-    let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll('[', '').replaceAll(']', '').replaceAll("'", '');
+    let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll(/\[|\]|'/g, '');
 
     if (classSeparatedString.at(-1) === '_') {
         classSeparatedString = classSeparatedString.slice(0, -1);
@@ -215,10 +215,11 @@ const MakeJsonPathReadableString = (jsonPath: string): string => {
 
     /* Remove schema prefixes */
     readableString = readableString.replaceAll('@', '');
+    readableString = readableString.replaceAll('has', '');
     readableString = readableString.replaceAll('ods:', '');
     readableString = readableString.replaceAll('dwc:', '');
     readableString = readableString.replaceAll('dcterms:', '');
-    readableString = readableString.replaceAll('has', '');
+    
 
     /* Remove JSON path indications */
     readableString = readableString.replaceAll('[', '');

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
@@ -1,5 +1,6 @@
 /* Import Dependencies */
 import { Formik, Form } from 'formik';
+import { isEmpty } from 'lodash';
 import { useState } from 'react';
 import { Row, Col } from 'react-bootstrap';
 
@@ -15,7 +16,7 @@ import { DigitalMedia } from 'app/types/DigitalMedia';
 import { Dict, ProgressDot } from 'app/Types';
 
 /* Import Components */
-import { AnnotationFormStep, AnnotationSelectInstanceStep, AnnotationTargetStep } from './AnnotationWizardComponents';
+import { AnnotationFormStep, AnnotationSelectInstanceStep, AnnotationSummaryStep, AnnotationTargetStep } from './AnnotationWizardComponents';
 import { Button, ProgressDots, Tabs } from 'components/elements/customUI/CustomUI';
 
 
@@ -43,7 +44,8 @@ const AnnotationWizard = (props: Props) => {
         annotationSelectInstance: <AnnotationSelectInstanceStep superClass={superClass}
             schemaTitle={schema.title}
         />,
-        annotationForm: <AnnotationFormStep superClass={superClass} />
+        annotationForm: <AnnotationFormStep superClass={superClass} />,
+        annotationSummary: <AnnotationSummaryStep superClass={superClass} />
     };
 
     /* Base variables */
@@ -76,7 +78,7 @@ const AnnotationWizard = (props: Props) => {
         annotationValues: {
             [className: string]: {
                 [termName: string]: string
-            }
+            } | { value: string }
         }
     } = {
         class: undefined,
@@ -153,6 +155,12 @@ const AnnotationWizard = (props: Props) => {
                 break;
             case 1:
                 if ((formValues.class || formValues.term) && formValues.jsonPath) {
+                    forwardAllowed = true;
+                }
+
+                break;
+            case 2:
+                if (!isEmpty(formValues.annotationValues) && formValues.jsonPath) {
                     forwardAllowed = true;
                 }
 

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizardComponents.ts
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizardComponents.ts
@@ -1,6 +1,7 @@
 /* Import Components */
 import AnnotationFormStep from "./steps/AnnotationFormStep";
 import AnnotationSelectInstanceStep from "./steps/AnnotationSelectInstanceStep";
+import AnnotationSummaryStep from "./steps/AnnotationSummaryStep";
 import AnnotationTargetStep from "./steps/AnnotationTargetStep";
 
 
@@ -8,5 +9,6 @@ import AnnotationTargetStep from "./steps/AnnotationTargetStep";
 export {
     AnnotationFormStep,
     AnnotationSelectInstanceStep,
+    AnnotationSummaryStep,
     AnnotationTargetStep,
 };

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
@@ -166,9 +166,10 @@ const AnnotationFormSegment = (props: Props) => {
                                 {formValues?.annotationValues?.[fieldName]?.map((_classObject: Dict, index: number) => {
                                     /* Set sub class as object and render form segment */
                                     const key = `${fieldName}_${index}`;
-                                    const annotationFormFieldSubProperty: AnnotationFormProperty = { ...annotationFormFieldProperty };
-
-                                    annotationFormFieldSubProperty.type = 'object';
+                                    const annotationFormFieldSubProperty: AnnotationFormProperty = {
+                                        ...annotationFormFieldProperty,
+                                        type: 'object'
+                                    };
 
                                     return (
                                         <div key={key}

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -1,6 +1,5 @@
 /* Import Dependencies */
 import { isEmpty } from 'lodash';
-import jp from 'jsonpath';
 import { useState } from 'react';
 import { Row, Col } from 'react-bootstrap';
 

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -1,5 +1,6 @@
 /* Import Dependencies */
 import { isEmpty } from 'lodash';
+import jp from 'jsonpath';
 import { useState } from 'react';
 import { Row, Col } from 'react-bootstrap';
 
@@ -47,7 +48,7 @@ const AnnotationFormStep = (props: Props) => {
 
     /* Base variables */
     const annotationTarget = useAppSelector(getAnnotationTarget);
-    const [annotationFormFieldProperties, setAnnotationFormFieldProperties] = useState<{ [propertyName: string]: AnnotationFormProperty }>();
+    const [annotationFormFieldProperties, setAnnotationFormFieldProperties] = useState<{ [propertyName: string]: AnnotationFormProperty }>({});
     const annotationMotivations = GetAnnotationMotivations(formValues?.motivation);
     let baseObjectFormFieldProperty: AnnotationFormProperty | undefined;
     let subClassObjectFormFieldProperties: AnnotationFormProperty[] = [];
@@ -61,6 +62,7 @@ const AnnotationFormStep = (props: Props) => {
     /* OnLoad, generate field properties for annotation form */
     trigger.SetTrigger(() => {
         if (formValues) {
+            /* For selected class, get annotation form field properties and their values */
             GenerateAnnotationFormFieldProperties(formValues.jsonPath, superClass).then(({ annotationFormFieldProperties, newFormValues }) => {
                 /* Set form values state with current values, based upon annotation form field properties */
                 const newSetFormValues = {
@@ -81,7 +83,7 @@ const AnnotationFormStep = (props: Props) => {
     }, []);
 
     /* From annotation form field properties, extract base object and its properties */
-    if (annotationFormFieldProperties && formValues) {
+    if (!isEmpty(annotationFormFieldProperties) && formValues) {
         baseObjectFormFieldProperty = Object.values(annotationFormFieldProperties).find(annotationFormFieldProperty => annotationFormFieldProperty.jsonPath === formValues.jsonPath);
 
         /* From annotation form field properties, extract sub class objects and their properties */

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -7,7 +7,10 @@ import { Row, Col } from 'react-bootstrap';
 import { GenerateAnnotationFormFieldProperties, GetAnnotationMotivations } from "app/utilities/AnnotateUtilities";
 
 /* Import Hooks */
-import { useTrigger } from "app/Hooks";
+import { useAppSelector, useTrigger } from "app/Hooks";
+
+/* Import Store */
+import { getAnnotationTarget } from 'redux-store/AnnotateSlice';
 
 /* Import Types */
 import { DigitalSpecimen } from "app/types/DigitalSpecimen";
@@ -43,6 +46,7 @@ const AnnotationFormStep = (props: Props) => {
     const trigger = useTrigger();
 
     /* Base variables */
+    const annotationTarget = useAppSelector(getAnnotationTarget);
     const [annotationFormFieldProperties, setAnnotationFormFieldProperties] = useState<{ [propertyName: string]: AnnotationFormProperty }>();
     const annotationMotivations = GetAnnotationMotivations(formValues?.motivation);
     let baseObjectFormFieldProperty: AnnotationFormProperty | undefined;
@@ -61,7 +65,10 @@ const AnnotationFormStep = (props: Props) => {
                 /* Set form values state with current values, based upon annotation form field properties */
                 const newSetFormValues = {
                     ...formValues,
-                    annotationValues: newFormValues
+                    annotationValues: {
+                        ...newFormValues,
+                        ...formValues.annotationValues,
+                    }
                 };
 
                 /* Set form values */
@@ -121,7 +128,7 @@ const AnnotationFormStep = (props: Props) => {
             <Row className="mt-3">
                 <Col>
                     <p>
-                        {['ods:adding', 'oa:editing'].includes(formValues?.motivation) ?
+                        {(['ods:adding', 'oa:editing'].includes(formValues?.motivation) && annotationTarget?.type === 'class') ?
                             'Specify which value(s) you want to annotate'
                             : 'Write your annotation value'
                         }
@@ -131,7 +138,7 @@ const AnnotationFormStep = (props: Props) => {
             <Row className="flex-grow-1 mt-3 overflow-scroll">
                 <Col>
                     {/* If motivation is either adding or editing, render the complete digital object as a form, else a generic text area */}
-                    {(annotationFormFieldProperties && formValues && ['ods:adding', 'oa:editing'].includes(formValues.motivation)) ?
+                    {(annotationFormFieldProperties && formValues && ['ods:adding', 'oa:editing'].includes(formValues.motivation) && annotationTarget?.type === 'class') ?
                         <>
                             {/* Render base class' form fields */}
                             {baseObjectFormFieldProperty &&

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
@@ -17,6 +17,7 @@ import { DigitalMedia } from 'app/types/DigitalMedia';
 import { Dict } from 'app/Types';
 
 /* Import Components */
+import SummaryValueBlock from './SummaryValueBlock';
 import SummaryValuesBlock from './SummaryValuesBlock';
 import { Button } from 'components/elements/customUI/CustomUI';
 
@@ -106,18 +107,24 @@ const AnnotationSummaryStep = (props: Props) => {
                     {annotationTarget?.type === 'class' ?
                         <>
                             {Object.entries(formValues?.annotationValues).sort().map(([className, classValue]: [string, any]) => (
-                                <>
+                                <div key={className}>
                                     {Array.isArray(classValue) ?
                                         <>
-                                            {classValue.map((childValue, index) => (
-                                                <div className="mb-3">
-                                                    <SummaryValuesBlock superClass={superClass}
-                                                        className={className}
-                                                        values={childValue}
-                                                        index={index}
-                                                    />
-                                                </div>
-                                            ))}
+                                            {classValue.map((childValue, index) => {
+                                                const key = `${className}_${index}`;
+
+                                                return (
+                                                    <div key={key}
+                                                        className="mb-3"
+                                                    >
+                                                        <SummaryValuesBlock superClass={superClass}
+                                                            className={className}
+                                                            values={childValue}
+                                                            index={index}
+                                                        />
+                                                    </div>
+                                                );
+                                            })}
                                         </>
                                         : <div className="mb-3">
                                             <SummaryValuesBlock superClass={superClass}
@@ -126,12 +133,12 @@ const AnnotationSummaryStep = (props: Props) => {
                                             />
                                         </div>
                                     }
-                                </>
+                                </div>
                             ))}
                         </>
-                        : <Card>
-
-                        </Card>
+                        : <SummaryValueBlock termName={MakeJsonPathReadableString(annotationTarget?.jsonPath ?? '')}
+                            value={formValues?.annotationValues.value}
+                        />
                     }
                 </Col>
             </Row>

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
@@ -136,7 +136,8 @@ const AnnotationSummaryStep = (props: Props) => {
                                 </div>
                             ))}
                         </>
-                        : <SummaryValueBlock termName={MakeJsonPathReadableString(annotationTarget?.jsonPath ?? '')}
+                        : <SummaryValueBlock superClass={superClass}
+                            termName={MakeJsonPathReadableString(formValues?.jsonPath ?? '')}
                             value={formValues?.annotationValues.value}
                         />
                     }

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
@@ -1,0 +1,154 @@
+/* Import Dependencies */
+import { capitalize } from 'lodash';
+import { Row, Col, Card } from 'react-bootstrap';
+
+/* Import Utilities */
+import { MakeJsonPathReadableString } from 'app/utilities/SchemaUtilities';
+
+/* Import Hooks */
+import { useAppSelector } from 'app/Hooks';
+
+/* Import Store */
+import { getAnnotationTarget } from 'redux-store/AnnotateSlice';
+
+/* Import Types */
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
+import { DigitalMedia } from 'app/types/DigitalMedia';
+import { Dict } from 'app/Types';
+
+/* Import Components */
+import SummaryValuesBlock from './SummaryValuesBlock';
+import { Button } from 'components/elements/customUI/CustomUI';
+
+
+/* Props Type */
+type Props = {
+    superClass: DigitalSpecimen | DigitalMedia | Dict
+    formValues?: Dict
+};
+
+
+/**
+ * Component that renders the fourth and final step of the annotation wizard, presenting a summary of the annotation to the user
+ * @param superClass The selected super class
+ * @param formValues The current form values of the annotation form
+ * @returns JSX Component
+ */
+const AnnotationSummaryStep = (props: Props) => {
+    const { superClass, formValues } = props;
+
+    /* Base variables */
+    const annotationTarget = useAppSelector(getAnnotationTarget);
+    let motivationDescription: string;
+
+    /* Define motivation description based upon selected motivation, deleting is not part of this */
+    switch (formValues?.motivation) {
+        case 'ods:adding': {
+            motivationDescription = 'Annotation which will add a new instance of:';
+
+            break;
+        } case 'oa:editing': {
+            motivationDescription = 'Annotation which modifies this existing instance of:';
+
+            break;
+        } case 'oa:assessing': {
+            motivationDescription = 'Annotation which assesses this instance of:';
+
+            break;
+        } default: {
+            motivationDescription = 'Annotation which comments on this instance of:';
+        }
+    };
+
+    return (
+        <div className="h-100 d-flex flex-column">
+            {/* Title text */}
+            <Row>
+                <Col>
+                    <p>
+                        Please check to see if your annotation is satisfied. Then click on the save button to post and save it.
+                    </p>
+                </Col>
+            </Row>
+            {/* Motivation description and annotation target */}
+            <Row className="mt-4">
+                <Col>
+                    <Card className="px-3 py-2">
+                        <p className="fs-4 fw-bold">
+                            {motivationDescription}
+                        </p>
+                        <p>
+                            <span className="tc-primary fw-lightBold">
+                                {`${capitalize(annotationTarget?.type)}: `}
+                            </span>
+                            {MakeJsonPathReadableString(annotationTarget?.jsonPath ?? '')}
+                        </p>
+                    </Card>
+                </Col>
+            </Row>
+            {/* Annotation values */}
+            <Row className="mt-3">
+                <Col>
+                    <p>
+                        Values to be annotated:
+                    </p>
+                </Col>
+                <Col lg="auto"
+                    className="d-flex align-items-center"
+                >
+                    <p className="fs-5 tc-grey">
+                        (New or modified values are marked with blue)
+                    </p>
+                </Col>
+            </Row>
+            <Row className="flex-grow-1 overflow-scroll mt-2">
+                <Col>
+                    {annotationTarget?.type === 'class' ?
+                        <>
+                            {Object.entries(formValues?.annotationValues).sort().map(([className, classValue]: [string, any]) => (
+                                <>
+                                    {Array.isArray(classValue) ?
+                                        <>
+                                            {classValue.map((childValue, index) => (
+                                                <div className="mb-3">
+                                                    <SummaryValuesBlock superClass={superClass}
+                                                        className={className}
+                                                        values={childValue}
+                                                        index={index}
+                                                    />
+                                                </div>
+                                            ))}
+                                        </>
+                                        : <div className="mb-3">
+                                            <SummaryValuesBlock superClass={superClass}
+                                                className={className}
+                                                values={classValue}
+                                            />
+                                        </div>
+                                    }
+                                </>
+                            ))}
+                        </>
+                        : <Card>
+
+                        </Card>
+                    }
+                </Col>
+            </Row>
+            {/* Save annotation button */}
+            <Row className="flex-row-reverse mt-3">
+                <Col lg="auto">
+                    <Button type="button"
+                        variant="primary"
+                    >
+                        <p>
+                            Save Annotation
+                        </p>
+                    </Button>
+                </Col>
+            </Row>
+        </div >
+    );
+};
+
+export default AnnotationSummaryStep;

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
@@ -139,6 +139,7 @@ const AnnotationSummaryStep = (props: Props) => {
                         : <SummaryValueBlock superClass={superClass}
                             termName={MakeJsonPathReadableString(formValues?.jsonPath ?? '')}
                             value={formValues?.annotationValues.value}
+                            jsonPath={formValues?.jsonPath}
                         />
                     }
                 </Col>

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
@@ -106,7 +106,7 @@ const AnnotationSummaryStep = (props: Props) => {
                 <Col>
                     {annotationTarget?.type === 'class' ?
                         <>
-                            {Object.entries(formValues?.annotationValues).sort().map(([className, classValue]: [string, any]) => (
+                            {Object.entries(formValues?.annotationValues).sort((a, b) => a > b ? 1 : 0).map(([className, classValue]: [string, any]) => (
                                 <div key={className}>
                                     {Array.isArray(classValue) ?
                                         <>

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationTargetStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationTargetStep.tsx
@@ -7,7 +7,10 @@ import Select, { SingleValue } from 'react-select';
 import { ExtractClassesAndTermsFromSchema, MakeJsonPathReadableString } from 'app/utilities/SchemaUtilities';
 
 /* Import Hooks */
-import { useTrigger } from 'app/Hooks';
+import { useAppSelector, useTrigger } from 'app/Hooks';
+
+/* Import Store */
+import { getAnnotationTarget } from 'redux-store/AnnotateSlice';
 
 /* Import Types */
 import { Dict } from 'app/Types';
@@ -39,6 +42,7 @@ const AnnotationTargetStep = (props: Props) => {
     const trigger = useTrigger();
 
     /* Base variables */
+    const annotationTarget = useAppSelector(getAnnotationTarget);
     const [classesList, setClassesList] = useState<{ label: string, value: string }[]>([]);
     const [termsList, setTermsList] = useState<{ label: string, options: { label: string, value: string }[] }[]>([]);
 
@@ -174,10 +178,18 @@ const AnnotationTargetStep = (props: Props) => {
                             <Col lg>
                                 <Button type="button"
                                     variant="accent"
-                                    OnClick={() => SetAnnotationTarget?.({
-                                        label: formValues.class?.label,
-                                        value: formValues.class.value
-                                    }, 'class')}
+                                    OnClick={() => {
+                                        /* Make sure JSON path in form values is reset if it differs from annotation target */
+                                        if (formValues.class?.value !== annotationTarget?.jsonPath) {
+                                            SetFieldValue?.('jsonPath', undefined);
+                                        }
+
+                                        /* Set annotation target */
+                                        SetAnnotationTarget?.({
+                                            label: formValues.class?.label,
+                                            value: formValues.class.value
+                                        }, 'class');
+                                    }}
                                 >
                                     <p>{`Target class: ${formValues.class?.label}`}</p>
                                 </Button>
@@ -189,10 +201,18 @@ const AnnotationTargetStep = (props: Props) => {
                             <Col lg>
                                 <Button type="button"
                                     variant="accent"
-                                    OnClick={() => SetAnnotationTarget?.({
-                                        label: formValues.term?.label,
-                                        value: formValues.term?.value
-                                    }, 'term')}
+                                    OnClick={() => {
+                                        /* Make sure JSON path in form values is reset if it differs from annotation target */
+                                        if (formValues.term?.value !== annotationTarget?.jsonPath) {
+                                            SetFieldValue?.('jsonPath', undefined);
+                                        }
+
+                                        /* Set annotation target */
+                                        SetAnnotationTarget?.({
+                                            label: formValues.term?.label,
+                                            value: formValues.term?.value
+                                        }, 'term');
+                                    }}
                                 >
                                     <p>{`Target term: ${formValues.term?.label}`}</p>
                                 </Button>

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ExistingInstance.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ExistingInstance.tsx
@@ -124,7 +124,13 @@ const ExistingInstance = (props: Props) => {
                                 className="fs-5 py-1 px-3"
                                 disabled={selected}
                                 OnClick={() => {
+                                    /* Reset annotation values */
+                                    SetFieldValue?.('annotationValues', {});
+
+                                    /* Set motivation to editing */
                                     SetFieldValue?.('motivation', 'oa:editing');
+
+                                    /* Set JSON path */
                                     SetFieldValue?.('jsonPath', jsonPath);
                                 }}
                             >

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
@@ -97,7 +97,13 @@ const NewInstance = (props: Props) => {
                                     OnClick={() => {
                                         const latestIndex: any = jp.query(superClass, annotationTarget.jsonPath)[0].length;
 
+                                        /* Reset annotation values */
+                                        SetFieldValue?.('annotationValues', {});
+
+                                        /* Set motivation */
                                         SetFieldValue?.('motivation', 'ods:adding');
+
+                                        /* Set JSON path */
                                         SetFieldValue?.('jsonPath', `${annotationTarget.jsonPath}[${latestIndex}]`);
                                     }}
                                 >

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
@@ -116,7 +116,7 @@ const NewInstance = (props: Props) => {
                                 {parentClasses.map((parentClass, index) => {
                                     /* Key of parent class component */
                                     const key = `parentClass-${index}`;
-
+                                    
                                     return (
                                         <ParentClassification key={key}
                                             index={index}

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
@@ -158,7 +158,9 @@ const ParentClassification = (props: Props) => {
                     }}
                 />
 
-                {(parentClasses.filter(parentClass => formValues && parentClass.name in formValues.parentClassDropdownValues).length === parentClasses.length && (index + 1) === parentClasses.length) &&
+                {(parentClasses.filter(parentClass => formValues && parentClass.name in formValues.parentClassDropdownValues).length === parentClasses.length
+                    && (index + 1) === parentClasses.length
+                ) &&
                     <Button type="button"
                         variant="primary"
                         disabled={formValues?.parentClassDropdownValues[parentClass.name] <= 0 && selected}

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
@@ -167,15 +167,21 @@ const ParentClassification = (props: Props) => {
                         className="fs-5 mt-3 py-1 px-3"
                         OnClick={() => {
                             /* Set field value in annotation form */
-                            let jsonPath: string = annotationTarget?.jsonPath.replace(parentClass.jsonPath, `${parentClass.jsonPath}[${formValues?.parentClassDropdownValues[parentClass.name]}]`) ?? '';
+                            let jsonPath: string = annotationTarget?.jsonPath ?? '';
+                
+                            /* For values in form values parent classes, add indexes to JSON path */
+                            parentClasses.forEach((parentClass) => {
+                                const index: number = formValues?.parentClassDropdownValues[parentClass.name];
 
-                            /* Add latest index to JSON path if adding a new class instance to an array */
+                                jsonPath = jsonPath.replace(parentClass.jsonPath, `${parentClass.jsonPath}[${index}]`);
+                            });
+
                             if (jp.parse(jsonPath).slice(-1)[0].expression.value.includes('has')) {
                                 const latestIndex: any = jp.query(superClass, jsonPath)[0].length;
 
                                 jsonPath = `${jsonPath}[${latestIndex}]`;
                             }
-
+                       
                             SetFieldValue?.('annotationValues', {});
                             SetFieldValue?.('motivation', 'ods:adding');
                             SetFieldValue?.('jsonPath', jsonPath);

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ParentClassification.tsx
@@ -84,6 +84,7 @@ const ParentClassification = (props: Props) => {
                     OnClick={() => {
                         if (annotationTarget) {
                             /* Set field values in form to parent class */
+                            SetFieldValue?.('annotationValues', {});
                             SetFieldValue?.('motivation', 'ods:adding');
                             SetFieldValue?.('jsonPath', `${parentClass.jsonPath}[0]`);
                             SetFieldValue?.('class', {
@@ -173,6 +174,7 @@ const ParentClassification = (props: Props) => {
                                 jsonPath = `${jsonPath}[${latestIndex}]`;
                             }
 
+                            SetFieldValue?.('annotationValues', {});
                             SetFieldValue?.('motivation', 'ods:adding');
                             SetFieldValue?.('jsonPath', jsonPath);
                         }}

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValueBlock.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValueBlock.tsx
@@ -1,0 +1,34 @@
+/* Import Dependencies */
+import classNames from 'classnames';
+import { Card } from 'react-bootstrap';
+
+
+/* Props Type */
+type Props = {
+    termName: string,
+    value: string | number | boolean
+};
+
+
+/**
+ * Component that renders a block for holding values of one class or term and are displayed in the annotation wizard summary step
+ * @returns JSX Component
+ */
+const SummaryValueBlock = (props: Props) => {
+    const { termName, value } = props;
+    
+    return (
+        <div>
+            <Card className="px-3 py-2">
+                <p>
+                    <span className="fw-lightBold">
+                        {`${termName}: `}
+                    </span>
+                    {value}
+                </p>
+            </Card>
+        </div>
+    );
+};
+
+export default SummaryValueBlock;

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValueBlock.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValueBlock.tsx
@@ -2,9 +2,15 @@
 import classNames from 'classnames';
 import { Card } from 'react-bootstrap';
 
+/* Import Types */
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
+import { DigitalMedia } from 'app/types/DigitalMedia';
+import { Dict } from 'app/Types';
+
 
 /* Props Type */
 type Props = {
+    superClass: DigitalSpecimen | DigitalMedia | Dict,
     termName: string,
     value: string | number | boolean
 };
@@ -12,10 +18,20 @@ type Props = {
 
 /**
  * Component that renders a block for holding values of one class or term and are displayed in the annotation wizard summary step
+ * @param superClass The provided super class
+ * @param termName The name of the term being annotated
+ * @param value The value of the term being annotated
  * @returns JSX Component
  */
 const SummaryValueBlock = (props: Props) => {
-    const { termName, value } = props;
+    const { superClass, termName, value } = props;
+
+    console.log(termName);
+
+    /* Class Name */
+    // const termTitleClass = classNames({
+    //     'tc-accent': 
+    // });
     
     return (
         <div>

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValueBlock.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValueBlock.tsx
@@ -1,5 +1,6 @@
 /* Import Dependencies */
 import classNames from 'classnames';
+import jp from 'jsonpath';
 import { Card } from 'react-bootstrap';
 
 /* Import Types */
@@ -12,7 +13,8 @@ import { Dict } from 'app/Types';
 type Props = {
     superClass: DigitalSpecimen | DigitalMedia | Dict,
     termName: string,
-    value: string | number | boolean
+    value: string | number | boolean,
+    jsonPath: string
 };
 
 
@@ -24,20 +26,18 @@ type Props = {
  * @returns JSX Component
  */
 const SummaryValueBlock = (props: Props) => {
-    const { superClass, termName, value } = props;
-
-    console.log(termName);
+    const { superClass, termName, value, jsonPath } = props;
 
     /* Class Name */
-    // const termTitleClass = classNames({
-    //     'tc-accent': 
-    // });
+    const termTitleClass = classNames({
+        'tc-accent': jp.value(superClass, jsonPath) !== value
+    });
     
     return (
         <div>
             <Card className="px-3 py-2">
                 <p>
-                    <span className="fw-lightBold">
+                    <span className={`${termTitleClass} fw-lightBold`}>
                         {`${termName}: `}
                     </span>
                     {value}

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValuesBlock.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValuesBlock.tsx
@@ -1,0 +1,94 @@
+/* Import Dependencies */
+import classNames from 'classnames';
+import jp from 'jsonpath';
+import { isEmpty } from 'lodash';
+import { Row, Col, Card } from 'react-bootstrap';
+
+/* Import Utilities */
+import { FormatJsonPathFromFieldName } from 'app/utilities/AnnotateUtilities';
+import { MakeJsonPathReadableString } from 'app/utilities/SchemaUtilities';
+
+/* Import Types */
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
+import { DigitalMedia } from 'app/types/DigitalMedia';
+import { Dict } from 'app/Types';
+
+
+/* Props Type */
+type Props = {
+    superClass: DigitalSpecimen | DigitalMedia | Dict,
+    className: string,
+    values: Dict,
+    index?: number
+};
+
+
+/**
+ * Component that renders a block for holding values of one class or term and are displayed in the annotation wizard summary step
+ * @param superClass The selected super class
+ * @param className The name of the class of whose values are shown in the summary block
+ * @param values A dictionary of values which are assigned to the class
+ * @param index The index of the instance in the parent class array
+ * @returns JSX Component
+ */
+const SummaryValuesBlock = (props: Props) => {
+    const { superClass, className, values, index } = props;
+
+    /* Base variables */
+    const title: string = `${MakeJsonPathReadableString(className)}${typeof (index) !== 'undefined' ? ` #${index + 1}` : ''}`;
+    const classFieldPath: string = `${className}${typeof (index) !== 'undefined' ? `_${index}` : ''}`;
+    const classJsonPath: string = FormatJsonPathFromFieldName(classFieldPath);
+
+    /* Class Names */
+    const classTitleClass = classNames({
+        'tc-accent': !jp.value(superClass, classJsonPath)
+    });
+
+    return (
+        <div>
+            <Card key={className}
+                className="px-3 py-2"
+            >
+                <p className={`${classTitleClass} tc-primary fw-lightBold`}>
+                    {title}
+                </p>
+
+                {/* Class values */}
+                <div className="mt-1">
+                    {!isEmpty(values) ?
+                        <>
+                            {Object.entries(values).map(([key, value]) => {
+                                const termFieldPath: string = `${classFieldPath}_'${key}'`;
+                                const termJsonPath: string = FormatJsonPathFromFieldName(termFieldPath);
+                                const existingValue: string | number | boolean = jp.value(superClass, termJsonPath);
+
+                                /* Class Name */
+                                const termTitleClass = classNames({
+                                    'tc-accent': !existingValue || value !== existingValue
+                                });
+
+                                return (
+                                    <Row>
+                                        <Col>
+                                            <p>
+                                                <span className={`${termTitleClass} fw-lightBold`}>
+                                                    {`${MakeJsonPathReadableString(key)}: `}
+                                                </span>
+                                                {value}
+                                            </p>
+                                        </Col>
+                                    </Row>
+                                );
+                            })}
+                        </>
+                        : <p className="tc-grey fst-italic">
+                            Has no attached values
+                        </p>
+                    }
+                </div>
+            </Card>
+        </div>
+    );
+};
+
+export default SummaryValuesBlock;

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValuesBlock.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValuesBlock.tsx
@@ -35,8 +35,17 @@ const SummaryValuesBlock = (props: Props) => {
     const { superClass, className, values, index } = props;
 
     /* Base variables */
-    const title: string = `${MakeJsonPathReadableString(className)}${typeof (index) !== 'undefined' ? ` #${index + 1}` : ''}`;
-    const classFieldPath: string = `${className}${typeof (index) !== 'undefined' ? `_${index}` : ''}`;
+    // const indexTitle: string = typeof(index) !== 'undefined' ? ` #${index + 1}` : '';
+    let title: string = MakeJsonPathReadableString(className);
+    let classFieldPath: string = className;
+    
+
+    /* Add index to title and class field parh if present */
+    if (typeof(index) !== 'undefined') {
+        title = title.concat(` #${index + 1}`);
+        classFieldPath = classFieldPath.concat(`_${index}`);
+    }
+
     const classJsonPath: string = FormatJsonPathFromFieldName(classFieldPath);
 
     /* Class Names */
@@ -68,7 +77,7 @@ const SummaryValuesBlock = (props: Props) => {
                                 });
 
                                 return (
-                                    <Row>
+                                    <Row key={key}>
                                         <Col>
                                             <p>
                                                 <span className={`${termTitleClass} fw-lightBold`}>

--- a/src/components/elements/customUI/progressDots/ProgressDots.tsx
+++ b/src/components/elements/customUI/progressDots/ProgressDots.tsx
@@ -52,18 +52,11 @@ const ProgressDots = (props: Props) => {
     return (
         <div>
             <Row>
-                <Col className="position-relative">
-                    <Row>
+                <Col className={`${styles.progressDots} position-relative`}>
+                    <Row className="justify-content-between">
                         {progressDots.map((progressDot, index) => {
                             /* Validation function setup */
                             const Validate = () => ValidationFunction?.(index > 0 ? (index - 1) : 0);
-
-                            /* Class Names */
-                            const progressDotColClass = classNames({
-                                'justify-content-center': index !== 0 && index + 1 !== progressDots.length,
-                                'justify-content-start': index === 0,
-                                'justify-content-end': index + 1 === progressDots.length
-                            });
 
                             const progressDotClass = classNames({
                                 'tc-grey': index > selectedIndex && index > completedTill,
@@ -73,8 +66,7 @@ const ProgressDots = (props: Props) => {
 
                             return (
                                 <Col key={progressDot.label}
-                                    lg
-                                    className={`${progressDotColClass} d-flex`}
+                                    lg="auto"
                                 >
                                     <Button type="button"
                                         variant="blank"

--- a/src/components/elements/customUI/progressDots/progressDots.module.scss
+++ b/src/components/elements/customUI/progressDots/progressDots.module.scss
@@ -1,8 +1,4 @@
 /* Custom styling for progress dots component */
-.progressDots {
-    // height: 30px;
-}
-
 .progressBar {
     top: 50%;
     transform: translateY(-50%);

--- a/src/components/elements/customUI/progressDots/progressDots.module.scss
+++ b/src/components/elements/customUI/progressDots/progressDots.module.scss
@@ -1,4 +1,7 @@
 /* Custom styling for progress dots component */
+.progressDots {
+    // height: 30px;
+}
 
 .progressBar {
     top: 50%;


### PR DESCRIPTION
PR adds a fourth and final step to the annotation wizard that displays all of the values defined in the previous steps of the wizard like motivation, target and all of the annotation values. This step will allow the user to save the annotation, which will be implemented in the next PR.

Also includes a few fixes and optimizations for the annotation wizard.