### PR TITLE
Process and Submit Annotations

### DIFF
--- a/src/api/annotation/InsertAnnotation.ts
+++ b/src/api/annotation/InsertAnnotation.ts
@@ -1,0 +1,58 @@
+/* Import Dependencies */
+import axios from 'axios';
+import KeycloakService from 'app/Keycloak';
+
+/* Import Types */
+import { Annotation } from 'app/types/Annotation';
+import { AnnotationTemplate, JSONResult } from 'app/Types';
+
+/* Import Exceptions */
+import { PostException } from 'app/Exceptions';
+
+
+/**
+ * Function for posting a new annotation
+ * @param newAnnotation The annotation to post
+ * @returns Object of Digital Specimen
+ */
+const InsertAnnotation = async ({ newAnnotation }: { newAnnotation: AnnotationTemplate }): Promise<Annotation | undefined> => {
+    let annotation: Annotation | undefined;
+
+    /* Construct post structure for annotation */
+    const postAnnotation: {
+        data: {
+            type: 'ods:Annotation',
+            attributes: AnnotationTemplate
+        }
+    } = {
+        data: {
+            type: 'ods:Annotation',
+            attributes: newAnnotation
+        }
+    };
+
+    try {
+        const result = await axios({
+            method: 'post',
+            url: 'annotation',
+            responseType: 'json',
+            data: postAnnotation,
+            headers: {
+                'Content-type': 'application/json',
+                'Authorization': `Bearer ${KeycloakService.GetToken()}`
+            }
+        });
+
+        /* Get result data from JSON */
+        const data: JSONResult = result.data;
+
+        /* Set Annotation */
+        annotation = data.data.attributes as Annotation;
+    } catch (error: any) {
+        throw (PostException('Annotation', error.request.responseURL));
+    };
+
+    return annotation;
+};
+
+export default InsertAnnotation;

--- a/src/app/Exceptions.ts
+++ b/src/app/Exceptions.ts
@@ -1,7 +1,7 @@
 /* Exceptions for error logging */
 
 /**
- * Function for returning a: default exception, activated for uknown response codes
+ * Function for returning a default exception, activated for uknown response codes
  * @param objectType The type of the object that was requested
  * @param requestUrl The url that was requested
  * @returns Error message
@@ -11,7 +11,7 @@ const DefaultException = (objectName: string, requestUrl: string) => {
 };
 
 /**
- * Function for returning a: not found exception, activated by response code 404
+ * Function for returning a not found exception, activated by response code 404
  * @param objectType The type of the object that was requested
  * @param requestUrl The url that was requested
  * @returns Error message
@@ -21,7 +21,7 @@ const NotFoundException = (objectName: string, requestUrl: string) => {
 };
 
 /**
- * Function for returning a: no search results found exception, activated by an empty result array when a response code 200 occurs
+ * Function for returning a no search results found exception, activated by an empty result array when a response code 200 occurs
  * @param objectType The type of the object that was requested
  * @param requestUrl The url that was requested
  * @returns Error message
@@ -30,8 +30,19 @@ const NoSearchResults = (objectName: string, requestUrl: string) => {
     return `No search results were found for object type: ${objectName}' with these search parameters. Request: ${requestUrl}`;
 };
 
+/**
+ * Function for returning a post exception that is thrown when an error occurs during the post request
+* @param objectType The type of the object that was requested
+ * @param requestUrl The url that was requested
+ * @returns Error message
+ */
+const PostException = (objectName: string, requestUrl: string) => {
+    return `Post request for object type: ${objectName} failed. Request: ${requestUrl}`;
+};
+
 export {
     DefaultException,
     NotFoundException,
-    NoSearchResults
+    NoSearchResults,
+    PostException
 };

--- a/src/app/Keycloak.ts
+++ b/src/app/Keycloak.ts
@@ -18,7 +18,7 @@ const InitKeyCloak = (callback?: Callback, token?: string) => {
         onLoad: "check-sso",
         silentCheckSsoRedirectUri: window.location.origin + "/silent-check-sso.html",
         pkceMethod: "S256",
-        scope: 'roles profile email',
+        scope: 'roles profile email orcid',
         token: token,
         refreshToken: token
     })

--- a/src/app/Types.ts
+++ b/src/app/Types.ts
@@ -94,6 +94,34 @@ export type AnnotationTarget = {
     jsonPath: string
 };
 
+/* Annotation template */
+export type AnnotationTemplate = {
+    "oa:motivation": "ods:adding" | "ods:deleting" | "oa:assessing" | "oa:editing" | "oa:commenting",
+    "oa:motivatedBy": string,
+    "oa:hasTarget": {
+        "@id": string,
+        "@type": string,
+        "ods:ID": string,
+        "ods:type": string,
+        "oa:hasSelector": {
+            "ods:field"?: string
+        } | {
+            "ods:class"?: string
+        } | {
+            "ac:hasROI"?: {
+                "ac:xFrac": number,
+                "ac:yFrac": number,
+                "ac:widthFrac": number,
+                "ac:heightFrac": number
+            },
+            "dcterms:conformsTo": "https://ac.tdwg.org/termlist/#711-region-of-interest-vocabulary"
+        }
+    },
+    "oa:hasBody": {
+        "oa:value": (string | Dict)[]
+    }
+};
+
 /* Parent class */
 export type ParentClass = {
     jsonPath: string,

--- a/src/components/digitalSpecimen/DigitalSpecimen.tsx
+++ b/src/components/digitalSpecimen/DigitalSpecimen.tsx
@@ -93,7 +93,7 @@ const DigitalSpecimen = () => {
     return (
         <div className="h-100 d-flex flex-column">
             {/* Main container, acting as the body for the digital specimen page and additionally, the annotation side panel */}
-            <Container fluid className="h-100 overflow-y-hidden">
+            <Container fluid className="h-100 overflow-hidden">
                 <Row className="h-100">
                     <Col className={`${digitalSpecimenBodyClass} h-100 tr-smooth`}>
                         <div className={`${digitalSpecimenContentClass} h-100 d-flex flex-column tr-smooth`}>

--- a/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
+++ b/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
@@ -17,6 +17,7 @@ import styles from './annotationSidePanel.module.scss';
 
 /* Import Components */
 import { AnnotationsOverview, AnnotationPolicyText, AnnotationWizard, TopBar } from './AnnotationSidePanelComponents';
+import { LoadingScreen } from '../customUI/CustomUI';
 
 
 /* Props Type */
@@ -46,13 +47,14 @@ const AnnotationSidePanel = (props: Props) => {
     const [annotations, setAnnotations] = useState<Annotation[]>([]);
     const [annotationWizardToggle, setAnnotationWizardToggle] = useState<boolean>(false);
     const [policyTextToggle, setPolicyTextToggle] = useState<boolean>(false);
+    const [loading, setLoading] = useState<boolean>(false);
 
     /* OnLoad: fetch annotations of super class with provided method */
     fetch.Fetch({
         params: {
             handle: superClass?.['ods:ID'].replace(import.meta.env.VITE_DOI_URL, '')
         },
-        triggers: [superClass],
+        triggers: [superClass, annotationWizardToggle],
         Method: GetAnnotations,
         Handler: (annotations: Annotation[]) => {
             setAnnotations(annotations)
@@ -62,6 +64,10 @@ const AnnotationSidePanel = (props: Props) => {
     /* Class Names */
     const policyTextClass = classNames({
         'd-none': !policyTextToggle
+    });
+
+    const loadingScreenClass = classNames({
+        'z-2': loading
     });
 
     return (
@@ -80,7 +86,11 @@ const AnnotationSidePanel = (props: Props) => {
                     {(annotationWizardToggle && superClass) ?
                         <AnnotationWizard schema={schema}
                             superClass={superClass}
-                            StopAnnotationWizard={() => setAnnotationWizardToggle(false)}
+                            StopAnnotationWizard={() => {
+                                setAnnotationWizardToggle(false);
+                                setLoading(false);
+                            }}
+                            ToggleLoading={() => setLoading(!loading)}
                         />
                         : <AnnotationsOverview annotations={annotations}
                             StartAnnotationWizard={() => setAnnotationWizardToggle(true)}
@@ -92,6 +102,11 @@ const AnnotationSidePanel = (props: Props) => {
             <div className={`${policyTextClass} position-absolute top-0 start-0 h-100 w-100 bgc-dark-opacity z-2`}>
                 <AnnotationPolicyText HidePolicyText={() => setPolicyTextToggle(false)} />
             </div>
+            {/* Loading screen */}
+            <LoadingScreen visible={loading}
+                displaySpinner={true}
+                className={`${loadingScreenClass} position-absolute top-0 start-0 h-100 w-100`}
+            />
         </div>
     );
 };

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
@@ -1,5 +1,5 @@
 /* Import Dependencies */
-import { capitalize } from 'lodash';
+import { capitalize, isEmpty } from 'lodash';
 import { Row, Col, Card } from 'react-bootstrap';
 
 /* Import Utilities */
@@ -106,7 +106,7 @@ const AnnotationSummaryStep = (props: Props) => {
                 <Col>
                     {annotationTarget?.type === 'class' ?
                         <>
-                            {Object.entries(formValues?.annotationValues).sort().map(([className, classValue]: [string, any]) => (
+                            {Object.entries(formValues?.annotationValues).filter(([_, classValue]) => !isEmpty(classValue)).sort().map(([className, classValue]: [string, any]) => (
                                 <div key={className}>
                                     {Array.isArray(classValue) ?
                                         <>
@@ -147,7 +147,7 @@ const AnnotationSummaryStep = (props: Props) => {
             {/* Save annotation button */}
             <Row className="flex-row-reverse mt-3">
                 <Col lg="auto">
-                    <Button type="button"
+                    <Button type="submit"
                         variant="primary"
                     >
                         <p>

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValuesBlock.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/SummaryValuesBlock.tsx
@@ -38,10 +38,10 @@ const SummaryValuesBlock = (props: Props) => {
     // const indexTitle: string = typeof(index) !== 'undefined' ? ` #${index + 1}` : '';
     let title: string = MakeJsonPathReadableString(className);
     let classFieldPath: string = className;
-    
+
 
     /* Add index to title and class field parh if present */
-    if (typeof(index) !== 'undefined') {
+    if (typeof (index) !== 'undefined') {
         title = title.concat(` #${index + 1}`);
         classFieldPath = classFieldPath.concat(`_${index}`);
     }
@@ -67,27 +67,29 @@ const SummaryValuesBlock = (props: Props) => {
                     {!isEmpty(values) ?
                         <>
                             {Object.entries(values).map(([key, value]) => {
-                                const termFieldPath: string = `${classFieldPath}_'${key}'`;
-                                const termJsonPath: string = FormatJsonPathFromFieldName(termFieldPath);
-                                const existingValue: string | number | boolean = jp.value(superClass, termJsonPath);
+                                if (value) {
+                                    const termFieldPath: string = `${classFieldPath}_'${key}'`;
+                                    const termJsonPath: string = FormatJsonPathFromFieldName(termFieldPath);
+                                    const existingValue: string | number | boolean = jp.value(superClass, termJsonPath);
 
-                                /* Class Name */
-                                const termTitleClass = classNames({
-                                    'tc-accent': !existingValue || value !== existingValue
-                                });
+                                    /* Class Name */
+                                    const termTitleClass = classNames({
+                                        'tc-accent': !existingValue || value !== existingValue
+                                    });
 
-                                return (
-                                    <Row key={key}>
-                                        <Col>
-                                            <p>
-                                                <span className={`${termTitleClass} fw-lightBold`}>
-                                                    {`${MakeJsonPathReadableString(key)}: `}
-                                                </span>
-                                                {value}
-                                            </p>
-                                        </Col>
-                                    </Row>
-                                );
+                                    return (
+                                        <Row key={key}>
+                                            <Col>
+                                                <p>
+                                                    <span className={`${termTitleClass} fw-lightBold`}>
+                                                        {`${MakeJsonPathReadableString(key)}: `}
+                                                    </span>
+                                                    {value}
+                                                </p>
+                                            </Col>
+                                        </Row>
+                                    );
+                                }
                             })}
                         </>
                         : <p className="tc-grey fst-italic">


### PR DESCRIPTION
PR adds the functionality to process and submit annotations to the API when a user clicks on the 'save' button at the end of the annotation wizard. The processing and creation of the annotation object are handled as utility functions. The form submit function posts the annotation towards the API and catches the result, going back to the annotation overview with the newly added annotation, or displays an error message when an error occurs during the connection with the API. A new exception has been added for failing POST requests.