### PR TITLE
Nest sub classes in form

### DIFF
--- a/src/api/annotation/InsertAnnotation.ts
+++ b/src/api/annotation/InsertAnnotation.ts
@@ -49,7 +49,7 @@ const InsertAnnotation = async ({ newAnnotation }: { newAnnotation: AnnotationTe
         /* Set Annotation */
         annotation = data.data.attributes as Annotation;
     } catch (error: any) {
-        throw (PostException('Annotation', error.request.responseURL));
+        throw PostException('Annotation', error.request.responseURL);
     };
 
     return annotation;

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -257,7 +257,6 @@ const ProcessAnnotationValues = (baseJsonPath: string, annotationValues: {
         if (!isEmpty(annotationValue)) {
             /* Format field name into JSON path */
             const jsonPath = `${FormatJsonPathFromFieldName(fieldName).replaceAll('"', "'")}`;
-
             const localAnnotationValue = cloneDeep(annotationValue);
 
             /* Remove objects and arrays with objects from value */

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -1,6 +1,6 @@
 /* Import Dependencies */
 import jp from 'jsonpath';
-import { isEmpty } from 'lodash';
+import { isEmpty, cloneDeep } from 'lodash';
 
 /* Import Utilities */
 import { ExtractLowestLevelSchema, ExtractClassesAndTermsFromSchema, MakeJsonPathReadableString } from 'app/utilities/SchemaUtilities';
@@ -251,28 +251,32 @@ const ProcessAnnotationValues = (baseJsonPath: string, annotationValues: {
 }) => {
     let annotationObject: Dict = {};
 
-    Object.entries(annotationValues).forEach(([fieldName, annotationValue]) => {
-        /* Format field name into JSON path */
-        const jsonPath = `${FormatJsonPathFromFieldName(fieldName).replaceAll('"', "'")}`;
+    Object.entries(annotationValues).sort((a, b) =>
+        a[0].replace(/[^_]/g, "").length > b[0].replace(/[^_]/g, "").length ? 1 : 0
+    ).forEach(([fieldName, annotationValue]) => {
+        if (!isEmpty(annotationValue)) {
+            /* Format field name into JSON path */
+            const jsonPath = `${FormatJsonPathFromFieldName(fieldName).replaceAll('"', "'")}`;
 
-        const localAnnotationValue = { ...annotationValue };
+            const localAnnotationValue = cloneDeep(annotationValue);
 
-        /* Remove objects and arrays with objects from value */
-        Object.keys(annotationValue).forEach(key => {
-            if (key.includes('has')) {
-                delete localAnnotationValue[key];
+            /* Remove objects and arrays with objects from value */
+            Object.keys(annotationValue).forEach(key => {
+                if (key.includes('has')) {
+                    delete localAnnotationValue[key];
+                }
+            });
+
+            /* If value is present and path is root, append directly to root object, otherwise use JSON path minus base JSON path if value is present */
+            if (!isEmpty({ ...localAnnotationValue }) && jsonPath === baseJsonPath) {
+                annotationObject = {
+                    ...annotationObject,
+                    ...localAnnotationValue
+                }
+            } else if (!isEmpty({ ...localAnnotationValue })) {
+                /* Set provided value according to JSON path in object */
+                jp.value(annotationObject, `$${jsonPath.replace(baseJsonPath, '')}`, localAnnotationValue);
             }
-        });
-
-        /* If value is present and path is root, append directly to root object, otherwise use JSON path minus base JSON path if value is present */
-        if (!isEmpty(localAnnotationValue) && jsonPath === baseJsonPath) {
-            annotationObject = {
-                ...localAnnotationValue,
-                ...annotationObject
-            }
-        } else if (!isEmpty(localAnnotationValue)) {
-            /* Set provided value according to JSON path in object */
-            jp.value(annotationObject, `$${jsonPath.replace(baseJsonPath, '')}`, localAnnotationValue);
         }
     });
 

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -177,11 +177,13 @@ const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClas
     /* For each class, add it as a key property to the annotation form fields dictionary */
     classesList.forEach(classProperty => {
         if (!termValue) {
+            const localPath: string = jp.parse(classProperty.value).pop().expression.value;
+
             annotationFormFieldProperties[classProperty.label] = {
                 key: classProperty.key,
                 name: classProperty.label,
                 jsonPath: classProperty.value.replace(`$`, jsonPath),
-                type: classProperty.value.includes('has') ? 'array' : 'object',
+                type: localPath.includes('has') ? 'array' : 'object',
                 properties: []
             };
 

--- a/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
+++ b/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
@@ -112,7 +112,7 @@ const AnnotationSidePanel = (props: Props) => {
                                 setAnnotationWizardToggle(false);
                                 setLoading(false);
                             }}
-                            ToggleLoading={() => setLoading(!loading)}
+                            SetLoading={(loading: boolean) => setLoading(loading)}
                             SetFilterSortValues={setFilterSortValues}
                         />
                         : <AnnotationsOverview annotations={annotations}

--- a/src/components/elements/annotationSidePanel/components/AnnotationsOverview.tsx
+++ b/src/components/elements/annotationSidePanel/components/AnnotationsOverview.tsx
@@ -118,8 +118,8 @@ const AnnotationsOverview = (props: Props) => {
                         >
                             <Button type="button"
                                 variant="accent"
-                                disabled={!KeycloakService.IsLoggedIn()}
-                                OnClick={() => KeycloakService.IsLoggedIn() && StartAnnotationWizard()}
+                                // disabled={!KeycloakService.IsLoggedIn()}
+                                OnClick={() => /*KeycloakService.IsLoggedIn() &&*/ StartAnnotationWizard()}
                             >
                                 <p>
                                     <FontAwesomeIcon icon={faPenToSquare}

--- a/src/components/elements/annotationSidePanel/components/AnnotationsOverview.tsx
+++ b/src/components/elements/annotationSidePanel/components/AnnotationsOverview.tsx
@@ -37,7 +37,7 @@ type Props = {
  * @returns JSX Component
  */
 const AnnotationsOverview = (props: Props) => {
-    const { annotations, filterSortValues, SetFilterSortValues, StartAnnotationWizard } = props;;
+    const { annotations, filterSortValues, SetFilterSortValues, StartAnnotationWizard } = props;
 
     /**
      * Function to sort and filter annotations by the selected values
@@ -118,8 +118,8 @@ const AnnotationsOverview = (props: Props) => {
                         >
                             <Button type="button"
                                 variant="accent"
-                                disabled={!KeycloakService.IsLoggedIn()}
-                                OnClick={() => KeycloakService.IsLoggedIn() && StartAnnotationWizard()}
+                                disabled={!KeycloakService.IsLoggedIn() || !KeycloakService.GetParsedToken()?.orcid}
+                                OnClick={() => (KeycloakService.IsLoggedIn() && KeycloakService.GetParsedToken()?.orcid) && StartAnnotationWizard()}
                             >
                                 <p>
                                     <FontAwesomeIcon icon={faPenToSquare}

--- a/src/components/elements/annotationSidePanel/components/AnnotationsOverview.tsx
+++ b/src/components/elements/annotationSidePanel/components/AnnotationsOverview.tsx
@@ -118,8 +118,8 @@ const AnnotationsOverview = (props: Props) => {
                         >
                             <Button type="button"
                                 variant="accent"
-                                // disabled={!KeycloakService.IsLoggedIn()}
-                                OnClick={() => /*KeycloakService.IsLoggedIn() &&*/ StartAnnotationWizard()}
+                                disabled={!KeycloakService.IsLoggedIn()}
+                                OnClick={() => KeycloakService.IsLoggedIn() && StartAnnotationWizard()}
                             >
                                 <p>
                                     <FontAwesomeIcon icon={faPenToSquare}

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
@@ -207,29 +207,31 @@ const AnnotationWizard = (props: Props) => {
                                 annotationValues
                             });
 
-                            /* Try to post the new annotation */
-                            ToggleLoading();
+                            console.log(newAnnotation);
 
-                            const annotation = await InsertAnnotation({
-                                newAnnotation
-                            });
+                            /* Try to post the new annotation */
+                            // ToggleLoading();
+
+                            // const annotation = await InsertAnnotation({
+                            //     newAnnotation
+                            // });
 
                             /* If annotation object is not empty and thus the action succeeded, go back to overview and refresh, otherwise show error message */
-                            if (annotation) {
-                                StopAnnotationWizard();
+                            // if (annotation) {
+                            //     StopAnnotationWizard();
 
-                                /* Reset filter and sort values */
-                                SetFilterSortValues({
-                                    motivation: '',
-                                    sortBy: 'dateLatest'
-                                });
-                            } else {
-                                notification.Push({
-                                    key: `${superClass['@id']}-${Math.random()}`,
-                                    message: `Failed to add the annotation. Please try saving it again.`,
-                                    template: 'error'
-                                });
-                            }
+                            //     /* Reset filter and sort values */
+                            //     SetFilterSortValues({
+                            //         motivation: '',
+                            //         sortBy: 'dateLatest'
+                            //     });
+                            // } else {
+                            //     notification.Push({
+                            //         key: `${superClass['@id']}-${Math.random()}`,
+                            //         message: `Failed to add the annotation. Please try saving it again.`,
+                            //         template: 'error'
+                            //     });
+                            // }
                         }}
                     >
                         {({ values, setFieldValue, setValues }) => (

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
@@ -31,17 +31,22 @@ type Props = {
     schema: Dict,
     superClass: DigitalSpecimen | DigitalMedia | Dict,
     StopAnnotationWizard: Function,
-    ToggleLoading: Function,
+    SetLoading: Function,
     SetFilterSortValues: Function
 };
 
 
 /**
  * Component that renders the annotation wizard for adding annotations
+ * @param schema The base schema to build upon
+ * @param superClass The super class on which the annotation wizard should act
+ * @param StopAnnotationWizard Function to stop and shut down the annotation wizard
+ * @param SetLoading Function to set the loading state of the annotation side panel
+ * @param SetFilterSortValues Function to set the filter and sort values in the annotations overview
  * @returns JSX Component
  */
 const AnnotationWizard = (props: Props) => {
-    const { schema, superClass, StopAnnotationWizard, ToggleLoading, SetFilterSortValues } = props;
+    const { schema, superClass, StopAnnotationWizard, SetLoading, SetFilterSortValues } = props;
 
     /* Hooks */
     const dispatch = useAppDispatch();
@@ -207,31 +212,31 @@ const AnnotationWizard = (props: Props) => {
                                 annotationValues
                             });
 
-                            console.log(newAnnotation);
-
                             /* Try to post the new annotation */
-                            // ToggleLoading();
-
-                            // const annotation = await InsertAnnotation({
-                            //     newAnnotation
-                            // });
+                            SetLoading(true);
 
                             /* If annotation object is not empty and thus the action succeeded, go back to overview and refresh, otherwise show error message */
-                            // if (annotation) {
-                            //     StopAnnotationWizard();
+                            try {
+                                await InsertAnnotation({
+                                    newAnnotation
+                                });
 
-                            //     /* Reset filter and sort values */
-                            //     SetFilterSortValues({
-                            //         motivation: '',
-                            //         sortBy: 'dateLatest'
-                            //     });
-                            // } else {
-                            //     notification.Push({
-                            //         key: `${superClass['@id']}-${Math.random()}`,
-                            //         message: `Failed to add the annotation. Please try saving it again.`,
-                            //         template: 'error'
-                            //     });
-                            // }
+                                StopAnnotationWizard();
+
+                                /* Reset filter and sort values */
+                                SetFilterSortValues({
+                                    motivation: '',
+                                    sortBy: 'dateLatest'
+                                });
+                            } catch {
+                                notification.Push({
+                                    key: `${superClass['@id']}-${Math.random()}`,
+                                    message: `Failed to add the annotation. Please try saving it again.`,
+                                    template: 'error'
+                                });
+
+                                SetLoading(false);
+                            };
                         }}
                     >
                         {({ values, setFieldValue, setValues }) => (

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
@@ -43,6 +43,8 @@ const AnnotationFormSegment = (props: Props) => {
         'd-none': isHidden
     });
 
+    // console.log(annotationFormFieldProperty);
+
     /* Render form segment based on the type of the annotation form field property */
     switch (annotationFormFieldProperty.type) {
         case 'object': {
@@ -116,14 +118,22 @@ const AnnotationFormSegment = (props: Props) => {
                                 className={`${formFieldsDivClass} mb-2`}
                             >
                                 <Col>
-                                    <p className="fs-4">
-                                        {fieldProperty.name}
-                                    </p>
 
-                                    <Field name={`annotationValues.${fieldName}`}
-                                        value={fieldValue ?? ''}
-                                        className="w-100 b-grey br-corner mt-1 py-1 px-2"
-                                    />
+
+                                    {['object', 'array'].includes(fieldProperty.type) ?
+                                        <AnnotationFormSegment annotationFormFieldProperty={fieldProperty}
+                                            formValues={formValues}
+                                        />
+                                        : <>
+                                            <p className="fs-4">
+                                                {fieldProperty.name}
+                                            </p>
+                                            <Field name={`annotationValues.${fieldName}`}
+                                                value={fieldValue ?? ''}
+                                                className="w-100 b-grey br-corner mt-1 py-1 px-2"
+                                            />
+                                        </>
+                                    }
                                 </Col>
                             </Row>
                         );

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormSegment.tsx
@@ -118,11 +118,10 @@ const AnnotationFormSegment = (props: Props) => {
                                 className={`${formFieldsDivClass} mb-2`}
                             >
                                 <Col>
-
-
                                     {['object', 'array'].includes(fieldProperty.type) ?
                                         <AnnotationFormSegment annotationFormFieldProperty={fieldProperty}
                                             formValues={formValues}
+                                            index={index}
                                         />
                                         : <>
                                             <p className="fs-4">
@@ -142,7 +141,15 @@ const AnnotationFormSegment = (props: Props) => {
             );
         } case 'array': {
             /* Format field name for field array sub class */
-            const fieldName = `${annotationFormFieldProperty.jsonPath.replaceAll('.', '_').replaceAll('][', '_').replaceAll('[', '').replaceAll(']', '')}`;
+            let fieldName = `${annotationFormFieldProperty.jsonPath.replaceAll('.', '_').replaceAll('][', '_').replaceAll('[', '').replaceAll(']', '')}`;
+
+            /* If index is present, add it in between of the latest property and its parent class which is the array */
+            if (typeof (index) !== 'undefined') {
+                const fieldNameSplitPrefix = fieldName.split('_').slice(0, -1);
+                const fieldNameSplitSuffix = fieldName.split('_').slice(-1);
+
+                fieldName = `${fieldNameSplitPrefix.join('_')}_${index}_${fieldNameSplitSuffix[0]}`;
+            }
 
             return (
                 <div>
@@ -173,11 +180,28 @@ const AnnotationFormSegment = (props: Props) => {
                                 </div>
 
                                 {/* For each sub class index, render an annotation form segment */}
-                                {formValues?.annotationValues?.[fieldName]?.map((_classObject: Dict, index: number) => {
+                                {formValues?.annotationValues?.[fieldName]?.map((_classObject: Dict, localIndex: number) => {
                                     /* Set sub class as object and render form segment */
-                                    const key = `${fieldName}_${index}`;
+                                    const key = `${fieldName}_${localIndex}`;
+                                    let propertyFieldName: string = '$';
+
+                                    fieldName.replace('$', '').split('_').forEach(path => {
+                                        propertyFieldName = propertyFieldName.concat(`[${path}]`);
+                                    });
+
+                                    /* If index is present, add it in between of the latest property and its parent class which is the array */
+                                    // if (typeof (index) !== 'undefined') {
+                                    //     const propertyFieldNameSplitPrefix = propertyFieldName.split('_').slice(0, -1);
+                                    //     const propertyFieldNameSplitSuffix = propertyFieldName.split('_').slice(-1);
+
+                                    //     propertyFieldName= `${propertyFieldNameSplitPrefix.join('_')}_${index}_${propertyFieldNameSplitSuffix[0]}`;
+                                    // }
+
+
+
                                     const annotationFormFieldSubProperty: AnnotationFormProperty = {
                                         ...annotationFormFieldProperty,
+                                        jsonPath: propertyFieldName,
                                         type: 'object'
                                     };
 
@@ -187,8 +211,8 @@ const AnnotationFormSegment = (props: Props) => {
                                         >
                                             <AnnotationFormSegment annotationFormFieldProperty={annotationFormFieldSubProperty}
                                                 formValues={formValues}
-                                                index={index}
-                                                Remove={() => remove(index)}
+                                                index={localIndex}
+                                                Remove={() => remove(localIndex)}
                                             />
                                         </div>
                                     );

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -1,6 +1,6 @@
 /* Import Dependencies */
 import { isEmpty } from 'lodash';
-import jp, { parent, paths } from 'jsonpath';
+import jp from 'jsonpath';
 import { useState } from 'react';
 import { Row, Col } from 'react-bootstrap';
 

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -76,8 +76,6 @@ const AnnotationFormStep = (props: Props) => {
                 /* Set form values */
                 SetFormValues?.(newSetFormValues);
 
-                console.log(annotationFormFieldProperties);
-
                 /* Set annotation form field properties */
                 setAnnotationFormFieldProperties(annotationFormFieldProperties);
             });
@@ -100,10 +98,6 @@ const AnnotationFormStep = (props: Props) => {
            
             jp.parse(jsonPath).slice(1, -1).forEach(pathSegment => {
                 parentPath = parentPath.concat(`['${pathSegment.expression.value}']['properties']`);
-
-                // const propertiesValueLength: number = jp.value(subClassObjectFormFieldProperties, parentPath).length ?? 0;
-
-                // parentPath = parentPath.concat(`[${propertiesValueLength}]`);
             });
 
             if (parentPath.split('properties').length >= 3) {
@@ -118,11 +112,6 @@ const AnnotationFormStep = (props: Props) => {
                     if (path === 'properties') {
                         properties = true;
                     } else if (properties) {
-                        // console.log(localExtendedPath);
-                        // console.log(path)
-                        // console.log(subClassObjectFormFieldProperties);
-                        // console.log(jp.value(subClassObjectFormFieldProperties, localExtendedPath));
-
                         /* Find index of sub class in parent properties array */
                         index = jp.value(subClassObjectFormFieldProperties, localExtendedPath)?.findIndex((fieldProperty: AnnotationFormProperty) => 
                             jp.parse(fieldProperty.jsonPath).pop().expression.value === path
@@ -140,18 +129,8 @@ const AnnotationFormStep = (props: Props) => {
             }
 
             if (parentPath !== '$') {
-                // console.log(annotationFormFieldProperty);
-                // console.log(subClassObjectFormFieldProperties);
-                // console.log(jp.parse(jsonPath).pop().expression.value);
-                // console.log(parentPath);
-                // console.log(annotationFormFieldProperty);
-                // console.log(jp.value(subClassObjectFormFieldProperties, parentPath));
-
                 /* Remove last properties part from parent path and treat as local path */
                 const localPath: string = localExtendedPath ? localExtendedPath.split('[').slice(0, -1).join('[') : parentPath.split('[').slice(0, -1).join('[');
-
-                console.log(localPath);
-                console.log(parentPath);
 
                 jp.value(subClassObjectFormFieldProperties, localPath, {
                     ...jp.value(subClassObjectFormFieldProperties, localPath),
@@ -171,8 +150,6 @@ const AnnotationFormStep = (props: Props) => {
             }
         });
     }
-
-    console.log(subClassObjectFormFieldProperties);
 
     return (
         <div className="h-100 d-flex flex-column">

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -91,7 +91,6 @@ const AnnotationFormStep = (props: Props) => {
             annotationFormFieldProperty => annotationFormFieldProperty.jsonPath !== formValues.jsonPath
         ).forEach(annotationFormFieldProperty => {
             const jsonPath = `$${annotationFormFieldProperty.jsonPath.replace(baseObjectFormFieldProperty?.jsonPath ?? '', '')}`;
-            // const parentPath: string = jp.stringify(jp.parse(jsonPath).slice(0, -1));
 
             let parentPath: string = '$';
             let localExtendedPath: string = '';
@@ -101,7 +100,6 @@ const AnnotationFormStep = (props: Props) => {
             });
 
             if (parentPath.split('properties').length >= 3) {
-                // console.log(parentPath);
                 let properties: boolean = false;
 
                 jp.parse(parentPath).forEach(pathSegment => {


### PR DESCRIPTION
PR fixes the remaining issues within the annotation wizard form step, when defining actual values to be annotated.
Sub classes are now nested inside their parents, so the UI does not conflict with the way the data model is structured and thus does not allow the user for creating broken parent child links.

Fixes the issues with:
- Broken links being created due to child classes not being nested inside parent classes in the UI
- Local annotation value not being assigned correctly in the annotation values processing  (zero index issue)
- Child objects and terms of sub classes with arrays not appending the parent index, generating an invalid field name (path)