### PR TITLE
Super class only allow comments and assessments

### DIFF
--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -162,16 +162,17 @@ const FormatJsonPathFromFieldName = (fieldName: string): string => {
  * Function to generate and return a dictionary containing all classes and terms of the schema adhering to the provided schema name; and their values
  * @param jsonPath The JSON path that leads to the schema to be used
  * @param superClass The provided super class
+ * @param schemaName The name of the base schema
  * @returns The annotation form field properties and their associated form values
  */
-const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClass: DigitalSpecimen | DigitalMedia | Dict) => {
+const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClass: DigitalSpecimen | DigitalMedia | Dict, schemaName: string) => {
     const annotationFormFieldProperties: {
         [propertyName: string]: AnnotationFormProperty
     } = {};
     const formValues: Dict = {};
 
     /* Extract main schema */
-    const schema: Dict | undefined = await ExtractLowestLevelSchema(jsonPath);
+    const schema: Dict | undefined = await ExtractLowestLevelSchema(jsonPath, schemaName);
     const { classesList, termsList, termValue } = await ExtractClassesAndTermsFromSchema(schema ?? {}, jsonPath);
 
     /* For each class, add it as a key property to the annotation form fields dictionary */
@@ -235,7 +236,7 @@ const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClas
 const GetAnnotationMotivations = (givenMotivation?: string, targetType?: string) => ({
     ...((givenMotivation === 'ods:adding' || givenMotivation === '*') && { 'ods:adding': 'Addition' }),
     'oa:assessing': 'Assessment',
-    ...((targetType && targetType !== 'superClass') && { 'oa:editing': "Modification" }),
+    ...((targetType !== 'superClass') && { 'oa:editing': "Modification" }),
     'oa:commenting': "Comment",
     ...(givenMotivation === '*' && { 'ods:deleting': "Deletion" })
 });

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -232,10 +232,10 @@ const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClas
  * Function that returns all of the annotation motivations as options (excluding deletion as this is handled systematically)
  * @param givenMotivation An already selected motivation that impacts the choice in motivation
  */
-const GetAnnotationMotivations = (givenMotivation?: string) => ({
+const GetAnnotationMotivations = (givenMotivation?: string, targetType?: string) => ({
     ...((givenMotivation === 'ods:adding' || givenMotivation === '*') && { 'ods:adding': 'Addition' }),
     'oa:assessing': 'Assessment',
-    'oa:editing': "Modification",
+    ...((targetType && targetType !== 'superClass') && { 'oa:editing': "Modification" }),
     'oa:commenting': "Comment",
     ...(givenMotivation === '*' && { 'ods:deleting': "Deletion" })
 });

--- a/src/app/utilities/SchemaUtilities.ts
+++ b/src/app/utilities/SchemaUtilities.ts
@@ -89,15 +89,21 @@ const ExtractFromSchema = async (schemaName: string): Promise<Dict> => {
 
 /**
  * Function to extract the data from a lowest level generated schema of the data model
- * @param schemaName The name of the schema to extract from 
+ * @param jsonPath The JSON path of the provided property
+ * @param schemaName The name of the base schema 
  * @returns Dictionary of the requested schema
  */
-const ExtractLowestLevelSchema = async (jsonPath: string): Promise<Dict | undefined> => {
+const ExtractLowestLevelSchema = async (jsonPath: string, schemaName: string): Promise<Dict | undefined> => {
     /* Base variables */
     let classSeparatedString: string = jsonPath.replaceAll(/\[(\d+)\]/g, '_').replaceAll('$', '').replaceAll('][', '_').replaceAll(/[\][']/g, '');
 
     if (classSeparatedString.at(-1) === '_') {
         classSeparatedString = classSeparatedString.slice(0, -1);
+    }
+
+    /* Check for top level term, if so add base schema name to class separated string */
+    if (!classSeparatedString.includes('has')) {
+        classSeparatedString = `${schemaName}_${classSeparatedString}`;
     }
 
     const strippedSchemaName = lowerFirst(StripSchemaString(classSeparatedString).split('_').at(-1));

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
@@ -58,7 +58,9 @@ const AnnotationWizard = (props: Props) => {
         annotationSelectInstance: <AnnotationSelectInstanceStep superClass={superClass}
             schemaTitle={schema.title}
         />,
-        annotationForm: <AnnotationFormStep superClass={superClass} />,
+        annotationForm: <AnnotationFormStep superClass={superClass}
+            schemaName={schema.title}
+        />,
         annotationSummary: <AnnotationSummaryStep superClass={superClass} />
     };
 

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -26,6 +26,7 @@ import { Dropdown, InputTextArea } from "components/elements/customUI/CustomUI";
 /* Props Type */
 type Props = {
     superClass: DigitalSpecimen | DigitalMedia | Dict,
+    schemaName: string,
     formValues?: Dict,
     SetFieldValue?: Function,
     SetFormValues?: Function
@@ -35,13 +36,14 @@ type Props = {
 /**
  * Component that renders the third and final step in the annotation wizard for defining the motivation and actual values
  * @param superClass The selected digital object
+ * @param schemaName The name of the 
  * @param formValues The values of the annotation form
  * @param SetFieldValue Funtion to set a value to a single field in the form
  * @param SetFormValues Function to set all of the values in the form
  * @returns JSX Component
  */
 const AnnotationFormStep = (props: Props) => {
-    const { superClass, formValues, SetFieldValue, SetFormValues } = props;
+    const { superClass, schemaName, formValues, SetFieldValue, SetFormValues } = props;
 
     /* Hooks */
     const trigger = useTrigger();
@@ -58,12 +60,12 @@ const AnnotationFormStep = (props: Props) => {
         label,
         value
     }));
-
+    
     /* OnLoad, generate field properties for annotation form */
     trigger.SetTrigger(() => {
-        if (formValues && annotationTarget?.type === 'class') {
+        if (formValues) {
             /* For selected class, get annotation form field properties and their values */
-            GenerateAnnotationFormFieldProperties(formValues.jsonPath, superClass).then(({ annotationFormFieldProperties, newFormValues }) => {
+            GenerateAnnotationFormFieldProperties(formValues.jsonPath, superClass, schemaName).then(({ annotationFormFieldProperties, newFormValues }) => {
                 /* Set form values state with current values, based upon annotation form field properties */
                 const newSetFormValues = {
                     ...formValues,

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -1,6 +1,6 @@
 /* Import Dependencies */
 import { isEmpty } from 'lodash';
-import jp, { parent, paths } from 'jsonpath';
+import jp from 'jsonpath';
 import { useState } from 'react';
 import { Row, Col } from 'react-bootstrap';
 
@@ -61,7 +61,7 @@ const AnnotationFormStep = (props: Props) => {
 
     /* OnLoad, generate field properties for annotation form */
     trigger.SetTrigger(() => {
-        if (formValues) {
+        if (formValues && annotationTarget?.type === 'class') {
             /* For selected class, get annotation form field properties and their values */
             GenerateAnnotationFormFieldProperties(formValues.jsonPath, superClass).then(({ annotationFormFieldProperties, newFormValues }) => {
                 /* Set form values state with current values, based upon annotation form field properties */
@@ -205,24 +205,6 @@ const AnnotationFormStep = (props: Props) => {
                                     formValues={formValues}
                                 />
                             }
-                            {/* {!isEmpty(subClassObjectFormFieldProperties) &&
-                                <>
-                                    <p className="fs-4 fw-lightBold mb-2">
-                                        {`Sub classes of ${baseObjectFormFieldProperty?.name}`}
-                                    </p> */}
-                            {/* Render optional, additional sub classes' form fields, if present */}
-                            {/* {subClassObjectFormFieldProperties.sort(
-                                        (a) => a.type !== 'object' ? 1 : 0
-                                    ).map(
-                                        annotationFormFieldProperty => (
-                                            <AnnotationFormSegment key={annotationFormFieldProperty.jsonPath}
-                                                annotationFormFieldProperty={annotationFormFieldProperty}
-                                                formValues={formValues}
-                                            />
-                                        )
-                                    )}
-                                </>
-                            } */}
                             {!isEmpty(subClassObjectFormFieldProperties) &&
                                 <>
                                     <p className="fs-4 fw-lightBold mb-2">

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ExistingInstance.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/ExistingInstance.tsx
@@ -128,7 +128,7 @@ const ExistingInstance = (props: Props) => {
                                     SetFieldValue?.('annotationValues', {});
 
                                     /* Set motivation to editing */
-                                    SetFieldValue?.('motivation', 'oa:editing');
+                                    SetFieldValue?.('motivation', jsonPath === '$' ? 'oa:commenting' : 'oa:editing');
 
                                     /* Set JSON path */
                                     SetFieldValue?.('jsonPath', jsonPath);

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
@@ -86,7 +86,7 @@ const NewInstance = (props: Props) => {
                             </p>
                         </Col>
                     </Row>
-                    {/* Render content based upon parent class check or just the set json path button if there are not any and the target is a class with an array */}
+                    {/* Render content based upon parent class check or just the set JSON path button if there are not any and the target is a class with an array */}
                     {(!parentClasses.length && annotationTarget && (annotationTarget.type !== 'term' && jp.parse(annotationTarget.jsonPath).slice(-1)[0].expression.value.includes('has'))) ?
                         <Row>
                             <Col>
@@ -113,24 +113,45 @@ const NewInstance = (props: Props) => {
                         </Row>
                         : <Row>
                             <Col>
-                                {parentClasses.map((parentClass, index) => {
-                                    /* Key of parent class component */
-                                    const key = `parentClass-${index}`;
-                                    
-                                    return (
-                                        <ParentClassification key={key}
-                                            index={index}
-                                            parentClass={parentClass}
-                                            selected={selected}
-                                            parentClasses={parentClasses}
-                                            annotationTarget={annotationTarget}
-                                            formValues={formValues}
-                                            superClass={superClass}
-                                            SetFieldValue={SetFieldValue}
-                                            SetParentClasses={setParentClasses}
-                                        />
-                                    );
-                                })}
+                                {parentClasses.length ?
+                                    <>
+                                        {parentClasses.map((parentClass, index) => {
+                                            /* Key of parent class component */
+                                            const key = `parentClass-${index}`;
+
+                                            return (
+                                                <ParentClassification key={key}
+                                                    index={index}
+                                                    parentClass={parentClass}
+                                                    selected={selected}
+                                                    parentClasses={parentClasses}
+                                                    annotationTarget={annotationTarget}
+                                                    formValues={formValues}
+                                                    superClass={superClass}
+                                                    SetFieldValue={SetFieldValue}
+                                                    SetParentClasses={setParentClasses}
+                                                />
+                                            );
+                                        })}
+                                    </>
+                                    : <Button type="button"
+                                        variant="primary"
+                                        disabled={selected}
+                                        className="fs-5 mt-3 py-1 px-3"
+                                        OnClick={() => {
+                                            /* Reset annotation values */
+                                            SetFieldValue?.('annotationValues', {});
+
+                                            /* Set motivation */
+                                            SetFieldValue?.('motivation', 'ods:adding');
+
+                                            /* Set JSON path */
+                                            SetFieldValue?.('jsonPath', annotationTarget?.jsonPath);
+                                        }}
+                                    >
+                                        {!selected ? `Add instance of ${MakeJsonPathReadableString(annotationTarget?.jsonPath ?? '')}` : 'Currently selected'}
+                                    </Button>
+                                }
                             </Col>
                         </Row>
                     }


### PR DESCRIPTION
PR applies the logic to only allow comments and assessment motivated annotations for super classes.
Also fixes two issues with annotating top level terms:
- Not being able to add one when one does not exist
- Having their default values (when editing) in the form field