### PR TITLE
Refactor search tour

### DIFF
--- a/src/app/Hooks.ts
+++ b/src/app/Hooks.ts
@@ -446,10 +446,24 @@ const useSearchFilters = () => {
         return searchParams.getAll(name).includes(value);
     };
 
+    /**
+     * Function to reset and remove all search filters
+     */
+    const ResetSearchFilters = () => {
+        [...searchParams.entries()].forEach(searchParam => {
+            console.log(searchParam);
+
+            searchParams.delete(searchParam[0]);
+        });
+
+        setSearchParams(searchParams);
+    };
+
     return {
         GetSearchFilters,
         SetSearchFilters,
-        CheckSearchFilter
+        CheckSearchFilter,
+        ResetSearchFilters
     };
 };
 

--- a/src/app/Types.ts
+++ b/src/app/Types.ts
@@ -194,3 +194,9 @@ export type ProgressDot = {
     label: string,
     OnClick: Function
 };
+
+/* Tour topic */
+export type TourTopic = {
+    name: string,
+    title: string
+};

--- a/src/components/elements/header/Header.tsx
+++ b/src/components/elements/header/Header.tsx
@@ -1,20 +1,17 @@
 /* Import Components */
 import classNames from 'classnames';
-import { useState } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 
 /* Import Utilities */
 import KeycloakService from 'app/Keycloak';
 
-/* Import Hooks */
-import { useAppDispatch } from 'app/Hooks';
-
-/* Import Store */
-import { setTourTopic } from 'redux-store/GlobalSlice';
+/* Import Types */
+import { TourTopic } from 'app/Types';
 
 /* Import Components */
 import Navigation from './Navigation';
+import TourTopicMenu from './TourTopicMenu';
 import UserMenu from './UserMenu';
 import { Button } from 'components/elements/customUI/CustomUI';
 
@@ -24,7 +21,7 @@ import { Button } from 'components/elements/customUI/CustomUI';
 type Props = {
     span?: number,
     offset?: number,
-    tourTopics?: string[]
+    tourTopics?: TourTopic[]
 };
 
 
@@ -38,19 +35,9 @@ type Props = {
 const Header = (props: Props) => {
     const { span, offset, tourTopics } = props;
 
-    /* Hooks */
-    const dispatch = useAppDispatch();
-
-    /* Base variables */
-    const [tourTopicMenuToggle, setTourTopicMenuToggle] = useState<boolean>(false);
-
     /* Class Names */
     const headerClass = classNames({
         'p-0': !span
-    });
-
-    const tourTopicMenuClass = classNames({
-        'd-none': !tourTopicMenuToggle
     });
 
     return (
@@ -75,31 +62,7 @@ const Header = (props: Props) => {
                             <Col lg="auto"
                                 className="position-relative tc-primary d-flex align-items-center"
                             >
-                                <Button type="button"
-                                    variant="blank"
-                                    className="fw-lightBold"
-                                    OnClick={() => {
-                                        if (tourTopics && tourTopics.length > 1) {
-                                            setTourTopicMenuToggle(!tourTopicMenuToggle);
-                                        } else {
-                                            dispatch(setTourTopic(tourTopics[0]));
-                                        }
-                                    }}
-                                >
-                                    Take a tour
-                                </Button>
-
-                                <div className={`${tourTopicMenuClass} position-absolute bottom-0`}>
-                                    {tourTopics?.map(tourTopic => (
-                                        <Row key={tourTopic}>
-                                            <Col>
-                                                <p className="fs-4">
-                                                    {tourTopic}
-                                                </p>
-                                            </Col>
-                                        </Row>
-                                    ))}
-                                </div>
+                                <TourTopicMenu tourTopics={tourTopics} />
                             </Col>
                         }
                         <Col lg="auto"

--- a/src/components/elements/header/Header.tsx
+++ b/src/components/elements/header/Header.tsx
@@ -71,35 +71,37 @@ const Header = (props: Props) => {
                             <Navigation />
                         </Col>
                         {/* Take a tour button */}
-                        <Col lg="auto"
-                            className="position-relative tc-primary d-flex align-items-center"
-                        >
-                            <Button type="button"
-                                variant="blank"
-                                className="fw-lightBold"
-                                OnClick={() => {
-                                    if (tourTopics?.length === 1) {
-                                        dispatch(setTourTopic('home'))
-                                    } else if (tourTopics && tourTopics.length > 1) {
-                                        setTourTopicMenuToggle(!tourTopicMenuToggle)
-                                    }
-                                }}
+                        {tourTopics?.length &&
+                            <Col lg="auto"
+                                className="position-relative tc-primary d-flex align-items-center"
                             >
-                                Take a tour
-                            </Button>
+                                <Button type="button"
+                                    variant="blank"
+                                    className="fw-lightBold"
+                                    OnClick={() => {
+                                        if (tourTopics && tourTopics.length > 1) {
+                                            setTourTopicMenuToggle(!tourTopicMenuToggle);
+                                        } else {
+                                            dispatch(setTourTopic(tourTopics[0]));
+                                        }
+                                    }}
+                                >
+                                    Take a tour
+                                </Button>
 
-                            <div className={`${tourTopicMenuClass} position-absolute bottom-0`}>
-                                {tourTopics?.map(tourTopic => (
-                                    <Row key={tourTopic}>
-                                        <Col>
-                                            <p className="fs-4">
-                                                {tourTopic}
-                                            </p>
-                                        </Col>
-                                    </Row>
-                                ))}
-                            </div>
-                        </Col>
+                                <div className={`${tourTopicMenuClass} position-absolute bottom-0`}>
+                                    {tourTopics?.map(tourTopic => (
+                                        <Row key={tourTopic}>
+                                            <Col>
+                                                <p className="fs-4">
+                                                    {tourTopic}
+                                                </p>
+                                            </Col>
+                                        </Row>
+                                    ))}
+                                </div>
+                            </Col>
+                        }
                         <Col lg="auto"
                             className="d-flex align-items-center"
                         >

--- a/src/components/elements/header/TourTopicMenu.tsx
+++ b/src/components/elements/header/TourTopicMenu.tsx
@@ -1,0 +1,98 @@
+/* Import Dependencies */
+import classNames from "classnames";
+import { useRef, useState } from 'react';
+import { Row, Col } from "react-bootstrap";
+
+/* Import Hooks */
+import { useAppDispatch, useFocus } from "app/Hooks";
+
+/* Import Store */
+import { setTourTopic } from 'redux-store/GlobalSlice';
+
+/* Import Types */
+import { TourTopic } from "app/Types";
+
+/* Import Styles */
+import styles from './header.module.scss';
+
+/* Import Components */
+import { Button } from "../customUI/CustomUI";
+
+
+/* Props Type */
+type Props = {
+    tourTopics: TourTopic[]
+};
+
+
+/**
+ * Component that renders the tour topic menu in the header
+ * @param tourTopics Tour topics that can activated for the rendered page
+ * @returns JSX Component
+ */
+const TourTopicMenu = (props: Props) => {
+    const { tourTopics } = props;
+
+    /* Hooks */
+    const dispatch = useAppDispatch();
+    const tourSelectMenuRef = useRef<HTMLDivElement>(null);
+
+    /* Base variables */
+    const [tourTopicMenuToggle, setTourTopicMenuToggle] = useState<boolean>(false);
+
+    /* Set focus on tour select menu */
+    useFocus({
+        ref: tourSelectMenuRef,
+        OnFocusLose: () => setTourTopicMenuToggle(false)
+    });
+
+    /* Class Names */
+    const tourTopicMenuClass = classNames({
+        'd-none': !tourTopicMenuToggle
+    });
+
+    return (
+        <div>
+            <Button type="button"
+                variant="blank"
+                className="fw-lightBold"
+                OnClick={() => {
+                    if (tourTopics && tourTopics.length > 1) {
+                        setTourTopicMenuToggle(!tourTopicMenuToggle);
+                    } else {
+                        dispatch(setTourTopic(tourTopics[0].name));
+                    }
+                }}
+            >
+                <p>
+                    Take a tour
+                </p>
+            </Button>
+
+            <div ref={tourSelectMenuRef}
+                className={`${styles.tourTopicMenu} ${tourTopicMenuClass} position-absolute ms-4 top-100 bgc-white b-primary br-corner overflow-hidden z-2`}
+            >
+                {tourTopics?.map(tourTopic => (
+                    <Row key={tourTopic.name}>
+                        <Col>
+                            <Button type="button"
+                                variant="blank"
+                                className="px-0 py-0 w-100 fw-lightBold text-start px-3 py-1 br-none hover-grey"
+                                OnClick={() => {
+                                    setTourTopicMenuToggle(false);
+                                    dispatch(setTourTopic(tourTopic.name));
+                                }}
+                            >
+                                <p className="fs-4">
+                                    {tourTopic.title}
+                                </p>
+                            </Button>
+                        </Col>
+                    </Row>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default TourTopicMenu;

--- a/src/components/elements/header/header.module.scss
+++ b/src/components/elements/header/header.module.scss
@@ -20,3 +20,8 @@
 .navItem:hover:after {
     transform: scaleX(1);
 }
+
+/* Tour select menu */
+.tourTopicMenu {
+    min-width: 17.5rem;
+}

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useFetch } from 'app/Hooks';
 
 /* Import Types */
-import { Dict } from 'app/Types';
+import { TourTopic, Dict } from 'app/Types';
 
 /* Import API */
 import GetDigitalSpecimenDisciplines from 'api/digitalSpecimen/GetDigitalSpecimenDisciplines';
@@ -47,7 +47,10 @@ const Home = () => {
         query: '',
         topicDisciplines: []
     };
-    const tourTopics: string[] = ['home'];
+    const tourTopics: TourTopic[] = [{
+        name: 'home',
+        title: 'About this page'
+    }];
 
     /* OnLoad: fetch digital specimen disciplines */
     fetch.Fetch({

--- a/src/components/home/TourSteps.tsx
+++ b/src/components/home/TourSteps.tsx
@@ -9,7 +9,7 @@ import { useAppSelector, useAppDispatch } from 'app/Hooks';
 import { getTourTopic, setTourTopic } from 'redux-store/GlobalSlice';
 
 /* Import Sources */
-import HomeIntro from 'sources/tourText/home.json';
+import HomeTourStepsText from 'sources/tourText/home.json';
 
 
 /* Props Type */
@@ -31,20 +31,16 @@ const TourSteps = (props: Props) => {
 
     /* Base variables */
     const tourTopic = useAppSelector(getTourTopic);
-    const homeSteps = HomeIntro.home;
+    const homeSteps = HomeTourStepsText.home;
     const { options } = StepsConfig();
     let steps: {
-        [tourSection: string]: {
-            intro: string,
-            element?: string
-        }[]
-    } = {
-        home: []
-    };
+        intro: string,
+        element?: string
+    }[] = [];
 
     /* Construct Intro.js steps for Homepage */
     homeSteps.forEach((step, index) => {
-        steps.home.push({
+        steps.push({
             intro: step,
             element: `#tourHome${index + 1}`
         });
@@ -52,7 +48,7 @@ const TourSteps = (props: Props) => {
 
     return (
         <Steps enabled={tourTopic === 'home'}
-            steps={steps.home}
+            steps={steps}
             initialStep={0}
             onBeforeChange={(nextIndex) => {
                 return new Promise((resolve) => {

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -15,6 +15,7 @@ import GetDigitalSpecimens from 'api/digitalSpecimen/GetDigitalSpecimens';
 import styles from './Search.module.scss';
 
 /* Import Components */
+import SearchTourSteps from './tourSteps/SearchTourSteps';
 import { CompareDigitalSpecimenMenu, IdCard, SearchFiltersMenu, SearchResults, TopBar } from './components/SearchComponents';
 import { BreadCrumbs, Footer, Header } from "components/elements/Elements";
 
@@ -27,6 +28,7 @@ const Search = () => {
     /* Base variables */
     const searchDigitalSpecimen = useAppSelector(getSearchDigitalSpecimen);
     const compareDigitalSpecimen = useAppSelector(getCompareDigitalSpecimen);
+    const tourTopics: string[] = ['search'];
 
     /* OnLoad: setup pagination */
     const pagination = usePagination({
@@ -51,6 +53,7 @@ const Search = () => {
             {/* Render header*/}
             <Header span={10}
                 offset={1}
+                tourTopics={tourTopics}
             />
 
             {/* Search page body */}
@@ -75,17 +78,17 @@ const Search = () => {
                         <Row className="flex-grow-1 position-relative overflow-y-hidden mt-3">
                             {/* Search filters menu */}
                             <Col lg={{ span: 3 }}
-                                className="h-100 position-absolute"
+                                className="tourSearch5 tourSearch6 h-100 position-absolute"
                             >
                                 <SearchFiltersMenu />
                             </Col>
                             {/* Search results table */}
-                            <Col className={`${searchResultsClass} h-100 tr-smooth z-1 bgc-default`}>
+                            <Col className={`tourSearch3 ${searchResultsClass} h-100 tr-smooth z-1 bgc-default`}>
                                 <SearchResults pagination={pagination} />
                             </Col>
                             {/* ID card */}
                             <Col lg={{ span: 6, offset: 6 }}
-                                className={`${styles.idCard} h-100 position-absolute`}
+                                className={`tourSearch4 ${styles.idCard} h-100 position-absolute`}
                             >
                                 <IdCard />
                             </Col>
@@ -109,6 +112,9 @@ const Search = () => {
             <Footer span={10}
                 offset={1}
             />
+
+            {/* Tour steps */}
+            <SearchTourSteps pagination={pagination} />
         </div>
     );
 };

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -8,6 +8,9 @@ import { useAppSelector, usePagination } from 'app/Hooks';
 /* Import Store */
 import { getSearchDigitalSpecimen, getCompareDigitalSpecimen } from 'redux-store/SearchSlice';
 
+/* Import Types */
+import { TourTopic } from 'app/Types';
+
 /* Import API */
 import GetDigitalSpecimens from 'api/digitalSpecimen/GetDigitalSpecimens';
 
@@ -16,6 +19,7 @@ import styles from './Search.module.scss';
 
 /* Import Components */
 import SearchTourSteps from './tourSteps/SearchTourSteps';
+import CompareTourSteps from './tourSteps/CompareTourSteps';
 import { CompareDigitalSpecimenMenu, IdCard, SearchFiltersMenu, SearchResults, TopBar } from './components/SearchComponents';
 import { BreadCrumbs, Footer, Header } from "components/elements/Elements";
 
@@ -28,7 +32,13 @@ const Search = () => {
     /* Base variables */
     const searchDigitalSpecimen = useAppSelector(getSearchDigitalSpecimen);
     const compareDigitalSpecimen = useAppSelector(getCompareDigitalSpecimen);
-    const tourTopics: string[] = ['search'];
+    const tourTopics: TourTopic[] = [{
+        name: 'search',
+        title: 'About this page'
+    }, {
+        name: 'compare',
+        title: 'Comparing specimens'
+    }];
 
     /* OnLoad: setup pagination */
     const pagination = usePagination({
@@ -83,7 +93,7 @@ const Search = () => {
                                 <SearchFiltersMenu />
                             </Col>
                             {/* Search results table */}
-                            <Col className={`tourSearch3 ${searchResultsClass} h-100 tr-smooth z-1 bgc-default`}>
+                            <Col className={`tourSearch3 tourCompare3 tourCompare4 tourCompare5 ${searchResultsClass} h-100 tr-smooth z-1 bgc-default`}>
                                 <SearchResults pagination={pagination} />
                             </Col>
                             {/* ID card */}
@@ -96,9 +106,7 @@ const Search = () => {
                     </Col>
 
                     {/* Compare digital specimens menu */}
-                    <div 
-                        className={`${compareDigitalSpecimenMenuClass} position-absolute w-25 end-0 bottom-0 z-1`}
-                    >
+                    <div className={`tourCompare6 ${compareDigitalSpecimenMenuClass} position-absolute w-25 end-0 bottom-0 z-1`}>
                         <Row>
                             <Col lg={{ span: 10 }}>
                                 <CompareDigitalSpecimenMenu />
@@ -115,6 +123,7 @@ const Search = () => {
 
             {/* Tour steps */}
             <SearchTourSteps pagination={pagination} />
+            <CompareTourSteps pagination={pagination} />
         </div>
     );
 };

--- a/src/components/search/components/topBar/TopBar.tsx
+++ b/src/components/search/components/topBar/TopBar.tsx
@@ -75,6 +75,7 @@ const TopBar = () => {
                         <Col className="d-flex justify-content-end">
                             <Button type="button"
                                 variant="secondary"
+                                className="tourCompare2"
                                 OnClick={() => {
                                     dispatch(setSearchDigitalSpecimen(undefined));
                                     dispatch(setCompareDigitalSpecimen(compareDigitalSpecimen ? undefined : []))

--- a/src/components/search/components/topBar/TopBar.tsx
+++ b/src/components/search/components/topBar/TopBar.tsx
@@ -33,6 +33,7 @@ const TopBar = () => {
     return (
         <div>
             <Formik initialValues={initialFormValues}
+                enableReinitialize
                 onSubmit={async (values) => {
                     await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -50,7 +51,9 @@ const TopBar = () => {
                 <Form>
                     <Row>
                         {/* Search bar */}
-                        <Col lg={{ span: 3 }}>
+                        <Col lg={{ span: 3 }}
+                            className="tourSearch2"
+                        >
                             <Row>
                                 <Col className="pe-0">
                                     <InputField name="query"
@@ -74,7 +77,8 @@ const TopBar = () => {
                                 variant="secondary"
                                 OnClick={() => {
                                     dispatch(setSearchDigitalSpecimen(undefined));
-                                    dispatch(setCompareDigitalSpecimen(compareDigitalSpecimen ? undefined : []))}
+                                    dispatch(setCompareDigitalSpecimen(compareDigitalSpecimen ? undefined : []))
+                                }
                                 }
                             >
                                 {!compareDigitalSpecimen ? 'Compare' : 'Cancel Compare'}

--- a/src/components/search/tourSteps/CompareTourSteps.tsx
+++ b/src/components/search/tourSteps/CompareTourSteps.tsx
@@ -1,0 +1,122 @@
+/* Import Dependencies */
+import { Steps } from 'intro.js-react';
+
+/* Import Config */
+import StepsConfig from 'app/config/StepsConfig';
+
+/* Import Hooks */
+import { useAppSelector, useAppDispatch, useSearchFilters } from 'app/Hooks';
+
+/* Import Store */
+import { getTourTopic, setTourTopic } from 'redux-store/GlobalSlice';
+import { getCompareDigitalSpecimen, setCompareDigitalSpecimen } from 'redux-store/SearchSlice';
+
+/* Import Types */
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
+import { PaginationObject } from 'app/Types';
+
+/* Import Sources */
+import SearchTourStepsText from 'sources/tourText/search.json';
+
+
+/* Props Type */
+type Props = {
+    pagination: PaginationObject
+};
+
+
+/**
+ * Component that renders the tour steps for the homepage
+ * @param pagination The pagination object used to index the digital specimen results
+ * @returns JSX Component
+ */
+const CompareTourSteps = (props: Props) => {
+    const { pagination } = props;
+
+    /* Hooks */
+    const dispatch = useAppDispatch();
+    const searchFilters = useSearchFilters();
+
+    /* Base variables */
+    const tourTopic = useAppSelector(getTourTopic);
+    const compareDigitalSpecimen = useAppSelector(getCompareDigitalSpecimen);
+    const compareSteps = SearchTourStepsText.compare;
+    const { options } = StepsConfig();
+    let steps: {
+        intro: string,
+        element?: string
+    }[] = [];
+
+    /* Construct Intro.js steps for Homepage */
+    compareSteps.forEach((step, index) => {
+        steps.push({
+            intro: step,
+            element: `.tourCompare${index + 1}`
+        });
+    });
+
+    return (
+        <Steps enabled={tourTopic === 'compare'}
+            steps={steps}
+            initialStep={0}
+            onBeforeChange={(nextIndex) => {
+                return new Promise((resolve) => {
+                    if ([0, 1].includes(nextIndex)) {
+                        dispatch(setCompareDigitalSpecimen(undefined));
+
+                        resolve();
+                    } else if (nextIndex === 2) {
+                        /* On step 3: set search query to 'bellis perennis' and enable comparison mode */
+                        searchFilters.SetSearchFilters({
+                            q: 'bellis perennis'
+                        });
+
+                        dispatch(setCompareDigitalSpecimen([]));
+
+                        resolve();
+                    } else if (nextIndex === 3) {
+                        /* On step 4: simulate selecting specimen for comparison */
+                        if (!compareDigitalSpecimen?.length) {
+                            dispatch(setCompareDigitalSpecimen([pagination.records[0] as DigitalSpecimen]));
+
+                            resolve();
+                        } else if (compareDigitalSpecimen.length) {
+                            const localCompareDigitalSpecimen = [...compareDigitalSpecimen];
+                            localCompareDigitalSpecimen.pop();
+
+                            dispatch(setCompareDigitalSpecimen([...localCompareDigitalSpecimen]));
+
+                            resolve();
+                        } else {
+                            resolve();
+                        }
+                    } else if ([4, 5].includes(nextIndex)) {
+                        /* On step 5: simulate selecting of second specimen for comparison */
+                        const compareDigitalSpecimen: DigitalSpecimen[] = [];
+
+                        compareDigitalSpecimen.push(pagination.records[0] as DigitalSpecimen);
+                        compareDigitalSpecimen.push(pagination.records[1] as DigitalSpecimen);
+
+                        dispatch(setCompareDigitalSpecimen(compareDigitalSpecimen));
+
+
+
+                        resolve();
+                    } else {
+                        resolve();
+                    }
+                });
+            }}
+            onStart={() => {
+                searchFilters.ResetSearchFilters();
+                dispatch(setCompareDigitalSpecimen(undefined));
+            }}
+            onExit={() => {
+                dispatch(setTourTopic(undefined));
+            }}
+            options={options}
+        />
+    );
+};
+
+export default CompareTourSteps;

--- a/src/components/search/tourSteps/SearchTourSteps.tsx
+++ b/src/components/search/tourSteps/SearchTourSteps.tsx
@@ -1,0 +1,108 @@
+/* Import Dependencies */
+import { Steps } from 'intro.js-react';
+
+/* Import Config */
+import StepsConfig from 'app/config/StepsConfig';
+
+/* Import Hooks */
+import { useAppSelector, useAppDispatch, useSearchFilters } from 'app/Hooks';
+
+/* Import Store */
+import { getTourTopic, setTourTopic } from 'redux-store/GlobalSlice';
+import { setSearchDigitalSpecimen } from 'redux-store/SearchSlice';
+
+/* Import Types */
+import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
+import { PaginationObject } from 'app/Types';
+
+/* Import Sources */
+import SearchTourStepsText from 'sources/tourText/search.json';
+
+
+/* Props Type */
+type Props = {
+    pagination: PaginationObject
+};
+
+
+/**
+ * Component that renders the tour steps for the homepage
+ * @param pagination The pagination object used to index the digital specimen results
+ * @returns JSX Component
+ */
+const SearchTourSteps = (props: Props) => {
+    const { pagination } = props;
+
+    /* Hooks */
+    const dispatch = useAppDispatch();
+    const searchFilters = useSearchFilters();
+
+    /* Base variables */
+    const tourTopic = useAppSelector(getTourTopic);
+    const searchSteps = SearchTourStepsText.search;
+    const { options } = StepsConfig();
+    let steps: {
+        intro: string,
+        element?: string
+    }[] = [];
+
+    /* Construct Intro.js steps for Homepage */
+    searchSteps.forEach((step, index) => {
+        steps.push({
+            intro: step,
+            element: `.tourSearch${index + 1}`
+        });
+    });
+
+    return (
+        <Steps enabled={tourTopic === 'search'}
+            steps={steps}
+            initialStep={0}
+            onBeforeChange={(nextIndex) => {
+                return new Promise((resolve) => {
+                    if (nextIndex === 2) {
+                        /* On step 2: Set search query to: 'bellis perennis' */
+                        searchFilters.SetSearchFilters({
+                            q: 'bellis perennis'
+                        });
+
+                        dispatch(setSearchDigitalSpecimen(undefined));
+
+                        resolve();
+                    } else if (nextIndex === 3) {
+                        /* On step 3: Set search result to second index of search results of 'bellis perennis' query */
+                        dispatch(setSearchDigitalSpecimen(pagination.records[1] as DigitalSpecimen));
+
+                        setTimeout(() => {
+                            resolve();
+                        }, 500);
+                    } else if (nextIndex === 4) {
+                        /* On step 4: Remove search result and reopen filters */
+                        dispatch(setSearchDigitalSpecimen(undefined));
+
+                        searchFilters.SetSearchFilters({
+                            topicDiscipline: ''
+                        });
+
+                        resolve();
+                    } else if (nextIndex === 5) {
+                        /* On step 5: Set Topic Discipline filter to 'Botany' */
+                        searchFilters.SetSearchFilters({
+                            topicDiscipline: 'Botany'
+                        });
+
+                        resolve();
+                    } else {
+                        resolve();
+                    }
+                });
+            }}
+            onExit={() => {
+                dispatch(setTourTopic(undefined));
+            }}
+            options={options}
+        />
+    );
+};
+
+export default SearchTourSteps;

--- a/src/sources/tourText/search.json
+++ b/src/sources/tourText/search.json
@@ -12,6 +12,7 @@
         "To start comparing, first click on the ‘compare’ button on the top right of the results table.",
         "Pressing this button will trigger ‘compare mode’. Note the checkboxes added to the table rows? You can select them to include those specific specimens in the comparison.",
         "Selecting the checkbox of a specimen will add it to the compare list, which can be found in the window in the right bottom corner. This also mentions how many specimens you still need or are able to select to use compare mode.",
+        "Select at least two specimen to be able to compare.",
         "When selecting the specimens is done, click on ‘compare’ to initiate the comparison."
     ]
 }

--- a/src/sources/tourText/search.json
+++ b/src/sources/tourText/search.json
@@ -1,0 +1,17 @@
+{
+    "search": [
+        "This is the search page. It allows you to define a search for specimens and displays the results in a table. Using the search capabilities of this page, is a powerful method for searching specific specimens. It also acts as a landing page for when you decided to use the search functionalities of the Homepage. In that case, the results of the search from the Homepage will be shown.",
+        "The easiest method for searching is by using the free text search. Type in any kind of search term you would like to see if any specimen record complies. For example: you can search on ‘Bellis Perennis’ as a species name.",
+        "If we start the search on this query, the results will be displayed in the results table. The table can contain up to 400 pages of results and shows some minimal information about the specimen.",
+        "When we select a row in the table, it opens up a new panel called the ID Card. This ID Card gives a much better representation of the specimen, including details about the organisation, location and digital media attached to it if present. You can easily switch between specimen ID Cards by selecting another specimen from the table.",
+        "To refine our search even more, we can make use of the filters on the left. These filters offer more specific options to define like: taxonomy, location, organisation and the MIDS level (Minimum Information about a Digital Specimen). Having selected some filters, breaks down our search results even more in the results table.",
+        "Activated filters will always be shown in the filters panel and can be removed upon clicking on the ‘x’ icon."
+    ],
+    "compare": [
+        "The search page allows you to compare specimens with each other in order to seek out differences, or to determine which specimen to look further on. With this method you can compare up to three specimens.",
+        "To start comparing, first click on the ‘compare’ button on the top right of the results table.",
+        "Pressing this button will trigger ‘compare mode’. Note the checkboxes added to the table rows? You can select them to include those specific specimens in the comparison.",
+        "Selecting the checkbox of a specimen will add it to the compare list, which can be found in the window in the right bottom corner. This also mentions how many specimens you still need or are able to select to use compare mode.",
+        "When selecting the specimens is done, click on ‘compare’ to initiate the comparison."
+    ]
+}


### PR DESCRIPTION
PR refactors the tours on the search page, including one about the page itself and one about comparing specimens.
Also reintroduces the selection menu for multiple tours on the same page and streamlines the process a bit.
Targets of the tour will now be specified with classes as there is no possibility to have multiple identifiers on HTML elements.

Introduces a new method in the useSearchFilters hook for resetting all search filters simultaneously.