### PR TITLE
Add annotation mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -71,6 +71,13 @@ p {
   padding: 0 !important;
 }
 
+button {
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+
 /* Font sizes, default is 16px */
 .fs-title {
   font-size: 3rem !important;

--- a/src/app/Types.ts
+++ b/src/app/Types.ts
@@ -97,6 +97,7 @@ export type SuperClass = DigitalSpecimenType | DigitalMediaType | Dict;
 export type AnnotationTarget = {
     type: 'superClass' | 'class' | 'term',
     jsonPath: string,
+    directPath?: boolean,
     annotation?: {
         id: string,
         motivation: string,

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -206,7 +206,7 @@ const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClas
 
             /* Add class values to form values */
             const classValues: Dict | Dict[] = jp.value(superClass, classProperty.value.replace(`$`, jsonPath));
-            const classFormValues: Dict = { ...classValues };      
+            const classFormValues: Dict = { ...classValues };
 
             if (!Array.isArray(classValues) && classValues) {
                 Object.entries(classValues).forEach(([key, value]) => {

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -165,8 +165,6 @@ const FormatFieldNameFromJsonPath = (jsonPath: string): string => {
 const FormatJsonPathFromFieldName = (fieldName: string): string => {
     const splitArray: (string | number)[] = fieldName.replaceAll(/['$]/g, '').split('_');
 
-    console.log(fieldName);
-
     splitArray.forEach((value, index) => {
         if (!isNaN(value as number)) {
             splitArray[index] = Number(value);
@@ -223,14 +221,16 @@ const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClas
 
                 if (!classValues) {
                     const parentFieldName: string = classProperty.value.replace(`$`, jsonPath).split('[').slice(0, -1).join('[');
-
                     const parentValues: Dict | undefined = jp.value(superClass, parentFieldName);
-
                     const childFieldName: string = classProperty.value.split('[').pop()?.replace(']', '').replaceAll("'", '') ?? '';
 
-                    parentValues?.filter((parentValue: Dict) => parentValue[childFieldName]).forEach((parentValue: Dict) => {
-                        localClassValues.push(parentValue[childFieldName]);
-                    });
+                    if (Array.isArray(parentValues)) {
+                        parentValues?.filter((parentValue: Dict) => parentValue[childFieldName]).forEach((parentValue: Dict) => {
+                            localClassValues.push(parentValue[childFieldName]);
+                        });
+                    } else if (parentValues?.[childFieldName]) {
+                        localClassValues.push(parentValues[childFieldName]);
+                    }
                 }
 
                 formValues[FormatFieldNameFromJsonPath(classProperty.value.replace(`$`, jsonPath))] = classValues ?? localClassValues ?? [];

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -165,6 +165,8 @@ const FormatFieldNameFromJsonPath = (jsonPath: string): string => {
 const FormatJsonPathFromFieldName = (fieldName: string): string => {
     const splitArray: (string | number)[] = fieldName.replaceAll(/['$]/g, '').split('_');
 
+    console.log(fieldName);
+
     splitArray.forEach((value, index) => {
         if (!isNaN(value as number)) {
             splitArray[index] = Number(value);
@@ -249,7 +251,7 @@ const GenerateAnnotationFormFieldProperties = async (jsonPath: string, superClas
             });
         } else {
             /* Treat upper parent as term and set annotation form value */
-            formValues.value = jp.value(superClass, termValue.value);
+            formValues.value = jp.value(superClass, termValue.value) ?? '';
         }
     });
 
@@ -384,6 +386,7 @@ const ReformatToAnnotoriousAnnotation = (annotation: Annotation, mediaUrl: strin
 export {
     ConstructAnnotationObject,
     ExtractParentClasses,
+    FormatFieldNameFromJsonPath,
     FormatJsonPathFromFieldName,
     GenerateAnnotationFormFieldProperties,
     GetAnnotationMotivations,

--- a/src/components/digitalMedia/DigitalMedia.tsx
+++ b/src/components/digitalMedia/DigitalMedia.tsx
@@ -9,6 +9,7 @@ import { useAppSelector, useAppDispatch, useFetch } from "app/Hooks";
 
 /* Import Store */
 import { getDigitalMedia, setDigitalMedia } from "redux-store/DigitalMediaSlice";
+import { setAnnotationTarget } from "redux-store/AnnotateSlice";
 
 /* Import Types */
 import { DigitalMedia as DigitalMediaType } from "app/types/DigitalMedia";
@@ -57,6 +58,19 @@ const DigitalMedia = () => {
         Handler: (digitalMedia: DigitalMediaType) => dispatch(setDigitalMedia(digitalMedia))
     });
 
+    /**
+     * Function to set the annotation target state
+     * @param annotationTargetType The type of the annotation target, either class or term
+     * @param jsonPath The JSON path that targets the class or term
+     */
+    const SetAnnotationTarget = (annotationTargetType: 'class' | 'term', jsonPath: string) => {
+        dispatch(setAnnotationTarget({
+            type: annotationTargetType,
+            jsonPath,
+            directPath: true
+        }));
+    };
+
     /* Class Names */
     const digitalMediaBodyClass = classNames({
         'col-lg-12': !annotationMode,
@@ -104,7 +118,7 @@ const DigitalMedia = () => {
                                                             annotationMode={annotationMode}
                                                             annotoriousMode={annotoriousMode}
                                                             selectedTabIndex={selectedTabIndex}
-                                                            ToggleAnnotationSidePanel={() => setAnnotationMode(!annotationMode)}
+                                                            ToggleAnnotationMode={() => setAnnotationMode(!annotationMode)}
                                                             SetAnnotoriousMode={(mode: string) => setAnnotoriousMode(mode)}
                                                         />
                                                     </Col>
@@ -124,6 +138,8 @@ const DigitalMedia = () => {
                                                         <ContentBlock digitalMedia={digitalMedia}
                                                             annotoriousMode={annotoriousMode}
                                                             selectedTabIndex={selectedTabIndex}
+                                                            annotationMode={annotationMode}
+                                                            SetAnnotationTarget={SetAnnotationTarget}
                                                             SetAnnotoriousMode={(mode: string) => setAnnotoriousMode(mode)}
                                                             SetSelectedTabIndex={setSelectedTabIndex}
                                                         />

--- a/src/components/digitalMedia/components/contentBlock/ContentBlock.tsx
+++ b/src/components/digitalMedia/components/contentBlock/ContentBlock.tsx
@@ -12,6 +12,8 @@ type Props = {
     digitalMedia: DigitalMedia,
     annotoriousMode: string,
     selectedTabIndex: number,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function,
     SetAnnotoriousMode: Function,
     SetSelectedTabIndex: Function
 };
@@ -21,13 +23,15 @@ type Props = {
  * Component that renders the content block on the digital media page
  * @param digitalMedia The selected digital media
  * @param annotoriousMode The currently selected Annotorious mode
- * @param selectedTabIndex The selected index for the digital specime
+ * @param selectedTabIndex The selected index for the digital specimen
+ * @param annotationMode Boolean indicating if the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
  * @param SetAnnotoriousMode Function to set the Annotorious mode
  * @param SetSelectedTabIndex Function to set the selected tab index
  * @returns JSX Component
  */
 const ContentBlock = (props: Props) => {
-    const { digitalMedia, annotoriousMode, selectedTabIndex, SetAnnotoriousMode, SetSelectedTabIndex } = props;
+    const { digitalMedia, annotoriousMode, selectedTabIndex, annotationMode, SetAnnotationTarget, SetAnnotoriousMode, SetSelectedTabIndex } = props;
 
     /* Base variables */
     const tabs = {
@@ -35,10 +39,15 @@ const ContentBlock = (props: Props) => {
             annotoriousMode={annotoriousMode}
             SetAnnotoriousMode={SetAnnotoriousMode}
         />,
-        'metadata': <DigitalMediaMetadata digitalMedia={digitalMedia} />,
+        'metadata': <DigitalMediaMetadata digitalMedia={digitalMedia}
+            annotationMode={annotationMode}
+            SetAnnotationTarget={SetAnnotationTarget}
+        />,
         'entityRelationships': <EntityRelationships digitalObjectId={digitalMedia["@id"]}
             digitalObjectName={digitalMedia["dcterms:title"]}
             digitalObjectEntityRelationships={digitalMedia["ods:hasEntityRelationships"]}
+            annotationMode={annotationMode}
+            SetAnnotationTarget={SetAnnotationTarget}
         />
     };
 

--- a/src/components/digitalMedia/components/contentBlock/components/DigitalMediaMetadata.tsx
+++ b/src/components/digitalMedia/components/contentBlock/components/DigitalMediaMetadata.tsx
@@ -8,22 +8,32 @@ import { ClassProperties } from "components/elements/Elements";
 
 /* Props Type */
 type Props = {
-    digitalMedia: DigitalMedia
+    digitalMedia: DigitalMedia,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
 /**
  * Component that renders the digital media metadata content block on the digital media page
+ * @param digitalMedia The selected digital media item
+ * @param annotationMode Boolean indicating if the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
  * @returns JSX Component
  */
 const DigitalMediaMetadata = (props: Props) => {
-    const { digitalMedia } = props;
+    const { digitalMedia, annotationMode, SetAnnotationTarget } = props;
 
     /* Base variables */
     const metadata: {
         mainProperties: Dict
     } = {
         mainProperties: {}
+    };
+    const jsonPaths: {
+        [propertySection: string]: string
+    } = {
+        mainProperties: "$"
     };
 
     /* Construct table properties */
@@ -36,6 +46,9 @@ const DigitalMediaMetadata = (props: Props) => {
             <ClassProperties key={metadata.mainProperties['@id']}
                 title="Metadata"
                 properties={metadata}
+                jsonPaths={jsonPaths}
+                annotationMode={annotationMode}
+                SetAnnotationTarget={SetAnnotationTarget}
             />
         </div>
     );

--- a/src/components/digitalMedia/components/topBar/TopBar.tsx
+++ b/src/components/digitalMedia/components/topBar/TopBar.tsx
@@ -25,7 +25,7 @@ type Props = {
     annotationMode: boolean,
     annotoriousMode: string,
     selectedTabIndex: number,
-    ToggleAnnotationSidePanel: Function,
+    ToggleAnnotationMode: Function,
     SetAnnotoriousMode: Function
 };
 
@@ -36,12 +36,12 @@ type Props = {
  * @param annotationMode Boolean that indicates if the annotation mode is toggled
  * @param annotoriousMode String indicating the Annotorious mode
  * @param selectedTabIndex The index of the selected content block tab
- * @param ToggleAnnotationSidePanel Function to toggle the annotation side panel
+ * @param ToggleAnnotationMode Function to toggle the annotation mode
  * @param SetAnnotoriousMode Function to set the Annotorious mode
  * @returns JSX Component
  */
 const TopBar = (props: Props) => {
-    const { digitalMedia, annotationMode, annotoriousMode, selectedTabIndex, ToggleAnnotationSidePanel, SetAnnotoriousMode } = props;
+    const { digitalMedia, annotationMode, annotoriousMode, selectedTabIndex, ToggleAnnotationMode, SetAnnotoriousMode } = props;
 
     /* Hooks */
     const navigate = useNavigate();
@@ -157,7 +157,7 @@ const TopBar = (props: Props) => {
                 <Col lg={(KeycloakService.IsLoggedIn() && !selectedTabIndex) && 'auto'}>
                     <TopBarActions actionDropdownItems={actionDropdownItems}
                         annotationMode={annotationMode}
-                        ToggleAnnotationSidePanel={ToggleAnnotationSidePanel}
+                        ToggleAnnotationMode={ToggleAnnotationMode}
                     />
                 </Col>
             </Row>

--- a/src/components/digitalSpecimen/DigitalSpecimen.tsx
+++ b/src/components/digitalSpecimen/DigitalSpecimen.tsx
@@ -1,6 +1,5 @@
 /* Import Dependencies */
 import classNames from 'classnames';
-import jp from 'jsonpath';
 import { useState } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';

--- a/src/components/digitalSpecimen/DigitalSpecimen.tsx
+++ b/src/components/digitalSpecimen/DigitalSpecimen.tsx
@@ -9,6 +9,7 @@ import { useAppSelector, useAppDispatch, useFetch } from 'app/Hooks';
 
 /* Import Store */
 import { getDigitalSpecimen, setDigitalSpecimen } from 'redux-store/DigitalSpecimenSlice';
+import { setAnnotationTarget } from 'redux-store/AnnotateSlice';
 
 /* Import Types */
 import { DigitalMedia } from 'app/types/DigitalMedia';
@@ -99,6 +100,18 @@ const DigitalSpecimen = () => {
         }
     });
 
+    /**
+     * Function to set the annotation target state
+     * @param annotationTargetType The type of the annotation target, either class or term
+     * @param jsonPath The JSON path that targets the class or term
+     */
+    const SetAnnotationTarget = (annotationTargetType: 'class' | 'term', jsonPath: string) => {
+       dispatch(setAnnotationTarget({
+            type: annotationTargetType,
+            jsonPath
+       }));
+    };
+
     /* Class Names */
     const digitalSpecimenBodyClass = classNames({
         'col-lg-12': !annotationMode,
@@ -144,7 +157,7 @@ const DigitalSpecimen = () => {
                                                     <Col>
                                                         <TopBar digitalSpecimen={digitalSpecimen}
                                                             annotationMode={annotationMode}
-                                                            ToggleAnnotationSidePanel={() => setAnnotationMode(!annotationMode)}
+                                                            ToggleAnnotationMode={() => setAnnotationMode(!annotationMode)}
                                                         />
                                                     </Col>
                                                 </Row>
@@ -156,6 +169,8 @@ const DigitalSpecimen = () => {
                                                     >
                                                         <IdCard digitalSpecimen={digitalSpecimen}
                                                             digitalSpecimenDigitalMedia={digitalSpecimenDigitalMedia}
+                                                            annotationMode={annotationMode}
+                                                            SetAnnotationTarget={SetAnnotationTarget}
                                                         />
                                                     </Col>
                                                     {/* Content block */}

--- a/src/components/digitalSpecimen/DigitalSpecimen.tsx
+++ b/src/components/digitalSpecimen/DigitalSpecimen.tsx
@@ -106,10 +106,11 @@ const DigitalSpecimen = () => {
      * @param jsonPath The JSON path that targets the class or term
      */
     const SetAnnotationTarget = (annotationTargetType: 'class' | 'term', jsonPath: string) => {
-       dispatch(setAnnotationTarget({
+        dispatch(setAnnotationTarget({
             type: annotationTargetType,
-            jsonPath
-       }));
+            jsonPath,
+            directPath: true
+        }));
     };
 
     /* Class Names */

--- a/src/components/digitalSpecimen/DigitalSpecimen.tsx
+++ b/src/components/digitalSpecimen/DigitalSpecimen.tsx
@@ -1,5 +1,6 @@
 /* Import Dependencies */
 import classNames from 'classnames';
+import jp from 'jsonpath';
 import { useState } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
@@ -26,7 +27,7 @@ import GetDigitalSpecimenDigitalMedia from 'api/digitalSpecimen/GetDigitalSpecim
 import GetDigitalSpecimenAnnotations from 'api/digitalSpecimen/GetDigitalSpecimenAnnotations';
 import GetDigitalSpecimenMas from 'api/digitalSpecimen/GetDigitalSpecimenMas';
 import GetDigitalSpecimenMasJobRecords from 'api/digitalSpecimen/GetDigitalSpecimenMasJobRecords';
-import ScheduleDigitalSpecimenMas from "api/digitalSpecimen/ScheduleDigitalSpecimenMas";
+import ScheduleDigitalSpecimenMas from 'api/digitalSpecimen/ScheduleDigitalSpecimenMas';
 
 /* Import Components */
 import AnnotateTourSteps from './tourSteps/AnnotateTourSteps';
@@ -182,6 +183,8 @@ const DigitalSpecimen = () => {
                                                         <ContentBlock digitalSpecimen={digitalSpecimen}
                                                             digitalSpecimenDigitalMedia={digitalSpecimenDigitalMedia}
                                                             selectedTabIndex={selectedTabIndex}
+                                                            annotationMode={annotationMode}
+                                                            SetAnnotationTarget={SetAnnotationTarget}
                                                             SetSelectedTabIndex={setSelectedTabIndex}
                                                         />
                                                     </Col>

--- a/src/components/digitalSpecimen/components/contentBlock/ContentBlock.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/ContentBlock.tsx
@@ -16,6 +16,8 @@ type Props = {
     digitalSpecimen: DigitalSpecimen,
     digitalSpecimenDigitalMedia: DigitalMedia[] | undefined,
     selectedTabIndex: number,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function,
     SetSelectedTabIndex: Function
 };
 
@@ -25,26 +27,42 @@ type Props = {
  * @param digitalSpecimen The selected digital specimen
  * @param digitalSpecimenDigitalMedia The digital media attached to the digital specimen
  * @param selectedTabIndex The selected index for the digital specimen tabs
+ * @param annotationMode Boolean indicating if the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
  * @param SetSelectedTabIndex Function to set the selected tab index
  * @returns JSX Component
  */
 const ContentBlock = (props: Props) => {
-    const { digitalSpecimen, digitalSpecimenDigitalMedia, selectedTabIndex, SetSelectedTabIndex } = props;
+    const { digitalSpecimen, digitalSpecimenDigitalMedia, selectedTabIndex, annotationMode, SetAnnotationTarget, SetSelectedTabIndex } = props;
 
     /* Base variables */
     const tabs = {
-        'digitalSpecimen': <DigitalSpecimenOverview digitalSpecimen={digitalSpecimen} />,
+        'digitalSpecimen': <DigitalSpecimenOverview digitalSpecimen={digitalSpecimen}
+            annotationMode={annotationMode}
+            SetAnnotationTarget={SetAnnotationTarget}
+        />,
         ...(digitalSpecimenDigitalMedia && !isEmpty(digitalSpecimenDigitalMedia) && {
             'digitalMedia': <DigitalSpecimenDigitalMedia digitalSpecimenDigitalMedia={digitalSpecimenDigitalMedia} />
         }),
-        'events': <Events digitalSpecimen={digitalSpecimen} />,
-        'identifications': <Identifications digitalSpecimen={digitalSpecimen} />,
+        'events': <Events digitalSpecimen={digitalSpecimen}
+            annotationMode={annotationMode}
+            SetAnnotationTarget={SetAnnotationTarget}
+        />,
+        'identifications': <Identifications digitalSpecimen={digitalSpecimen}
+            annotationMode={annotationMode}
+            SetAnnotationTarget={SetAnnotationTarget}
+        />,
         'entityRelationships': <EntityRelationships digitalObjectId={digitalSpecimen['@id']}
             digitalObjectName={digitalSpecimen['ods:specimenName']}
             digitalObjectEntityRelationships={digitalSpecimen['ods:hasEntityRelationships']}
+            annotationMode={annotationMode}
+            SetAnnotationTarget={SetAnnotationTarget}
         />,
         ...(!isEmpty(digitalSpecimen['ods:hasAssertions']) && {
-            'assertions': <Assertions digitalSpecimen={digitalSpecimen} />
+            'assertions': <Assertions digitalSpecimen={digitalSpecimen}
+                annotationMode={annotationMode}
+                SetAnnotationTarget={SetAnnotationTarget}
+            />
         })
     };
 

--- a/src/components/digitalSpecimen/components/contentBlock/components/Assertions.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/Assertions.tsx
@@ -7,16 +7,28 @@ import { ClassProperties } from "components/elements/Elements";
 
 /* Props Type */
 type Props = {
-    digitalSpecimen: DigitalSpecimen
+    digitalSpecimen: DigitalSpecimen,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
 /**
- * Component that renders 
- * @returns 
+ * Component that renders
+ * @param digitalSpecimen The selected digital specimen
+ * @param annotationMode Boolean indicating ig the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
+ * @returns JSX Component
  */
 const Assertions = (props: Props) => {
-    const { digitalSpecimen } = props;
+    const { digitalSpecimen, annotationMode, SetAnnotationTarget } = props;
+
+    /* Base variables */
+    const jsonPaths: {
+        [propertySection: string]: string
+    } = {
+        mainProperties: "$['ods:hasAssertions'][index]",
+    };
 
     return (
         <div className="h-100">
@@ -25,6 +37,9 @@ const Assertions = (props: Props) => {
                     index={index}
                     title="assertion"
                     properties={assertion}
+                    jsonPaths={jsonPaths}
+                    annotationMode={annotationMode}
+                    SetAnnotationTarget={SetAnnotationTarget}
                 />
             ))}
         </div>

--- a/src/components/digitalSpecimen/components/contentBlock/components/DigitalSpecimenOverview.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/DigitalSpecimenOverview.tsx
@@ -1,5 +1,6 @@
 /* Import Dependencies */
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classNames from 'classnames';
 import { useState } from 'react';
 import { Row, Col, Card } from 'react-bootstrap';
 
@@ -20,23 +21,29 @@ import { Button, OpenStreetMap, Tooltip } from 'components/elements/customUI/Cus
 
 /* Props Type */
 type Props = {
-    digitalSpecimen: DigitalSpecimen
+    digitalSpecimen: DigitalSpecimen,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
 /**
  * Component that renders the digital specimen overview content block on the digital specimen page
  * @param digitalSpecimen The selected digital specimen
+ * @param annotationMode Boolean indicating if the annotation mode is enabled
+ * @param SetAnnotationTarget Function to set the annotation target
  * @returns JSX Component
  */
 const DigitalSpecimenOverview = (props: Props) => {
-    const { digitalSpecimen } = props;
+    const { digitalSpecimen, annotationMode, SetAnnotationTarget } = props;
 
     /* Base variables */
     const [copyMessage, setCopyMessage] = useState<string>('Copy');
     const acceptedIdentification = digitalSpecimen['ods:hasIdentifications']?.find(identification => identification['ods:isVerifiedIdentification']);
+    const acceptedIdentificationIndex: number | undefined = digitalSpecimen['ods:hasIdentifications']?.findIndex(identification => identification['ods:isVerifiedIdentification']);
     const collectors: string[] = [];
     const collectionEvent: Event | undefined = digitalSpecimen['ods:hasEvents']?.find(event => event['dwc:eventType'] === 'Collecting Event');
+    const collectionEventIndex: number | undefined = digitalSpecimen['ods:hasEvents']?.findIndex(event => event['dwc:eventType'] === 'Collecting Event');
     const topicDisciplinesWithIdentifications: string[] = [
         'Anthropology',
         'Botany',
@@ -66,6 +73,13 @@ const DigitalSpecimenOverview = (props: Props) => {
     const CraftCitation = () => {
         return `Distributed System of Scientific Collections (${new Date().getFullYear()}). ${digitalSpecimen['ods:specimenName']} [Dataset]. ${digitalSpecimen['@id']}`;
     };
+
+    /* Class Names */
+    const overviewItemButtonClass = classNames({
+        'tr-fast': true,
+        'hover-grey mc-pointer': annotationMode,
+        'mc-default': !annotationMode
+    });
 
     return (
         <div className="h-100">
@@ -102,28 +116,49 @@ const DigitalSpecimenOverview = (props: Props) => {
                                 {/* Collection date */}
                                 <Row className="mt-1">
                                     <Col>
-                                        <p className="fs-4 textOverflow">
-                                            <span className="fw-lightBold">Collection date: </span>
-                                            {collectionEvent?.['dwc:eventDate']}
-                                        </p>
+                                        <button type="button"
+                                            className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                            onClick={() => (annotationMode && collectionEvent) &&
+                                                SetAnnotationTarget('term', `$['ods:hasEvents'][${collectionEventIndex}]['dwc:eventDate']`)
+                                            }
+                                        >
+                                            <p className="fs-4 textOverflow">
+                                                <span className="fw-lightBold">Collection date: </span>
+                                                {collectionEvent?.['dwc:eventDate']}
+                                            </p>
+                                        </button>
                                     </Col>
                                 </Row>
                                 {/* Country */}
                                 <Row className="mt-1">
                                     <Col>
-                                        <p className="fs-4 textOverflow">
-                                            <span className="fw-lightBold">Country: </span>
-                                            {collectionEvent?.['ods:hasLocation']?.['dwc:country']}
-                                        </p>
+                                        <button type="button"
+                                            className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                            onClick={() => (annotationMode && collectionEvent) &&
+                                                SetAnnotationTarget('term', `$['ods:hasEvents'][${collectionEventIndex}]['ods:hasLocation']['dwc:country']`)
+                                            }
+                                        >
+                                            <p className="fs-4 textOverflow">
+                                                <span className="fw-lightBold">Country: </span>
+                                                {collectionEvent?.['ods:hasLocation']?.['dwc:country']}
+                                            </p>
+                                        </button>
                                     </Col>
                                 </Row>
                                 {/* Locality */}
                                 <Row className="mt-1">
                                     <Col>
-                                        <p className="fs-4 textOverflow">
-                                            <span className="fw-lightBold">Locality: </span>
-                                            {collectionEvent?.['ods:hasLocation']?.['dwc:locality']}
-                                        </p>
+                                        <button type="button"
+                                            className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                            onClick={() => (annotationMode && collectionEvent) &&
+                                                SetAnnotationTarget('term', `$['ods:hasEvents'][${collectionEventIndex}]['ods:hasLocation']['dwc:locality']`)
+                                            }
+                                        >
+                                            <p className="fs-4 textOverflow">
+                                                <span className="fw-lightBold">Locality: </span>
+                                                {collectionEvent?.['ods:hasLocation']?.['dwc:locality']}
+                                            </p>
+                                        </button>
                                     </Col>
                                 </Row>
                             </Col>
@@ -165,7 +200,10 @@ const DigitalSpecimenOverview = (props: Props) => {
                             <Row className="flex-grow-1 overflow-hidden mt-2">
                                 <Col>
                                     <AcceptedIdentification acceptedIdentification={acceptedIdentification}
+                                        acceptedIdentificationIndex={acceptedIdentificationIndex}
                                         digitalSpecimenName={digitalSpecimen['ods:specimenName'] ?? ''}
+                                        annotationMode={annotationMode}
+                                        SetAnnotationTarget={SetAnnotationTarget}
                                     />
                                 </Col>
                             </Row>
@@ -186,25 +224,39 @@ const DigitalSpecimenOverview = (props: Props) => {
                                 {/* Name */}
                                 <Row>
                                     <Col>
-                                        <p className="fs-4 textOverflow">
-                                            <span className="fw-lightBold">Name: </span>
-                                            <a href={digitalSpecimen['ods:organisationID']}
-                                                target="_blank"
-                                                rel="noreferer"
-                                                className="tc-accent"
-                                            >
-                                                {digitalSpecimen['ods:organisationName']}
-                                            </a>
-                                        </p>
+                                        <button type="button"
+                                            className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                            onClick={() => annotationMode &&
+                                                SetAnnotationTarget('term', `$['ods:organisationName']`)
+                                            }
+                                        >
+                                            <p className="fs-4 textOverflow">
+                                                <span className="fw-lightBold">Name: </span>
+                                                <a href={digitalSpecimen['ods:organisationID']}
+                                                    target="_blank"
+                                                    rel="noreferer"
+                                                    className="tc-accent"
+                                                >
+                                                    {digitalSpecimen['ods:organisationName']}
+                                                </a>
+                                            </p>
+                                        </button>
                                     </Col>
                                 </Row>
                                 {/* Collection */}
                                 <Row className="mt-1">
                                     <Col>
-                                        <p className="fs-4 textOverflow">
-                                            <span className="fw-lightBold">Collection: </span>
-                                            {digitalSpecimen['dwc:collectionCode']}
-                                        </p>
+                                        <button type="button"
+                                            className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                            onClick={() => annotationMode &&
+                                                SetAnnotationTarget('term', `$['dwc:collectionCode']`)
+                                            }
+                                        >
+                                            <p className="fs-4 textOverflow">
+                                                <span className="fw-lightBold">Collection: </span>
+                                                {digitalSpecimen['dwc:collectionCode']}
+                                            </p>
+                                        </button>
                                     </Col>
                                 </Row>
                             </Col>

--- a/src/components/digitalSpecimen/components/contentBlock/components/Events.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/Events.tsx
@@ -11,17 +11,21 @@ import { ClassProperties } from 'components/elements/Elements';
 
 /* Props Type */
 type Props = {
-    digitalSpecimen: DigitalSpecimen
+    digitalSpecimen: DigitalSpecimen,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
 /**
  * Component that renders the events content block on the digital specimen page
  * @param digitalSpecimen The selected digital specimen
+ * @param annotationMode Boolean indicating ig the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
  * @returns JSX Component
  */
 const Events = (props: Props) => {
-    const { digitalSpecimen } = props;
+    const { digitalSpecimen, annotationMode, SetAnnotationTarget } = props;
 
     /* Base variables */
     const events: {
@@ -31,6 +35,15 @@ const Events = (props: Props) => {
         geologicalContext?: Dict,
         assertions?: Dict
     }[] = [];
+    const jsonPaths: {
+       [propertySection: string]: string
+    } = {
+        mainProperties: "$['ods:hasEvents'][index]",
+        location: "$['ods:hasEvents'][index]['ods:hasLocation']",
+        georeference: "$['ods:hasEvents'][index]['ods:hasLocation']['ods:hasGeoreference']",
+        geologicalContext: "$['ods:hasEvents'][index]['ods:hasLocation']['ods:hasGeologicalContext']",
+        assertions: "$['ods:hasEvents'][index]['ods:hasAssertions']"
+    };
 
     /* Craft events dictionary to iterate over */
     digitalSpecimen['ods:hasEvents']?.forEach((event, index) => {
@@ -79,6 +92,9 @@ const Events = (props: Props) => {
                     index={index}
                     title="event"
                     properties={event}
+                    jsonPaths={jsonPaths}
+                    annotationMode={annotationMode}
+                    SetAnnotationTarget={SetAnnotationTarget}
                 />
             ))}
         </div>

--- a/src/components/digitalSpecimen/components/contentBlock/components/Identifications.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/Identifications.tsx
@@ -11,23 +11,33 @@ import { ClassProperties } from "components/elements/Elements";
 
 /* Props Type */
 type Props = {
-    digitalSpecimen: DigitalSpecimen
+    digitalSpecimen: DigitalSpecimen,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
 /**
  * Component that renders the identifications content block on the digital specimen page
  * @param digitalSpecimen The selected digital specimen
+ * @param annotationMode Boolean indicating ig the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
  * @returns JSX Component
  */
 const Identifications = (props: Props) => {
-    const { digitalSpecimen } = props;
+    const { digitalSpecimen, annotationMode, SetAnnotationTarget } = props;
 
     /* Base variables */
     const identifications: {
         mainProperties: Dict,
         [taxonIdentifications: string]: Dict
     }[] = [];
+    const jsonPaths: {
+        [propertySection: string]: string
+    } = {
+        mainProperties: "$['ods:hasIdentifications'][index]",
+        taxonIdentifications: "$['ods:hasIdentifications'][index]['ods:hasTaxonIdentifications'][subIndex]"
+    };
 
     /* Craft identifications dictionary to iterate over */
     digitalSpecimen["ods:hasIdentifications"]?.forEach((identification, index) => {
@@ -60,6 +70,9 @@ const Identifications = (props: Props) => {
                     index={index}
                     title="identification"
                     properties={identification}
+                    jsonPaths={jsonPaths}
+                    annotationMode={annotationMode}
+                    SetAnnotationTarget={SetAnnotationTarget}
                 />
             ))}
         </div>

--- a/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.tsx
@@ -1,4 +1,5 @@
 /* Import Dependencies */
+import classNames from "classnames";
 import { Row, Col } from "react-bootstrap";
 
 /* Import Types */
@@ -11,18 +12,31 @@ import styles from './digitalSpecimenOverview.module.scss';
 /* Props Type */
 type Props = {
     acceptedIdentification: Identification,
-    digitalSpecimenName: string
+    acceptedIdentificationIndex?: number,
+    digitalSpecimenName: string,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
 /**
  * Component that renders the accepted identification in the digital specimen overview on the digital specimen page
  * @param acceptedIdentification The accepted identification to display
+ * @param acceptedIdentificationIndex The index of the accepted identification in the identifications array
  * @param digitalSpecimenName The name of the selected digital specimen
+ * @param annotationMode Boolean indicating if the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
  * @returns JSX Component
  */
 const AcceptedIdentification = (props: Props) => {
-    const { acceptedIdentification, digitalSpecimenName } = props;
+    const { acceptedIdentification, acceptedIdentificationIndex, digitalSpecimenName, annotationMode, SetAnnotationTarget } = props;
+
+    /* Class Names */
+    const overviewItemButtonClass = classNames({
+        'tr-fast': true,
+        'hover-grey mc-pointer': annotationMode,
+        'mc-default': !annotationMode
+    });
 
     return (
         <div className="h-100 d-flex flex-column">
@@ -30,7 +44,7 @@ const AcceptedIdentification = (props: Props) => {
                 <Col>
                     {/* Scientific Name */}
                     <p className="fs-4 fw-lightBold textOverflow"
-                        dangerouslySetInnerHTML={{ __html: acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["ods:scientificNameHTMLLabel"] ?? digitalSpecimenName} }
+                        dangerouslySetInnerHTML={{ __html: acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["ods:scientificNameHTMLLabel"] ?? digitalSpecimenName }}
                     />
                 </Col>
             </Row>
@@ -59,55 +73,97 @@ const AcceptedIdentification = (props: Props) => {
                         {/* Kingdom */}
                         <Row>
                             <Col>
-                                <p className="fs-4 textOverflow">
-                                    <span className="fw-lightBold">Kingdom: </span>
-                                    {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:kingdom"]}
-                                </p>
+                                <button type="button"
+                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                    onClick={() => annotationMode &&
+                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:kingdom']`)
+                                    }
+                                >
+                                    <p className="fs-4 textOverflow">
+                                        <span className="fw-lightBold">Kingdom: </span>
+                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:kingdom"]}
+                                    </p>
+                                </button>
                             </Col>
                         </Row>
                         {/* Phylum */}
                         <Row>
                             <Col>
-                                <p className="fs-4 textOverflow">
-                                    <span className="fw-lightBold">Phylum: </span>
-                                    {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:phylum"]}
-                                </p>
+                                <button type="button"
+                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                    onClick={() => annotationMode &&
+                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:phylum']`)
+                                    }
+                                >
+                                    <p className="fs-4 textOverflow">
+                                        <span className="fw-lightBold">Phylum: </span>
+                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:phylum"]}
+                                    </p>
+                                </button>
                             </Col>
                         </Row>
                         {/* Class */}
                         <Row>
                             <Col>
-                                <p className="fs-4 textOverflow">
-                                    <span className="fw-lightBold">Class: </span>
-                                    {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:class"]}
-                                </p>
+                                <button type="button"
+                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                    onClick={() => annotationMode &&
+                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:class']`)
+                                    }
+                                >
+                                    <p className="fs-4 textOverflow">
+                                        <span className="fw-lightBold">Class: </span>
+                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:class"]}
+                                    </p>
+                                </button>
                             </Col>
                         </Row>
                         {/* Order */}
                         <Row>
                             <Col>
-                                <p className="fs-4 textOverflow">
-                                    <span className="fw-lightBold">Order: </span>
-                                    {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:order"]}
-                                </p>
+                                <button type="button"
+                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                    onClick={() => annotationMode &&
+                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:order']`)
+                                    }
+                                >
+                                    <p className="fs-4 textOverflow">
+                                        <span className="fw-lightBold">Order: </span>
+                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:order"]}
+                                    </p>
+                                </button>
                             </Col>
                         </Row>
                         {/* Family */}
                         <Row>
                             <Col>
-                                <p className="fs-4 textOverflow">
-                                    <span className="fw-lightBold">Family: </span>
-                                    {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:family"]}
-                                </p>
+                                <button type="button"
+                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                    onClick={() => annotationMode &&
+                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:family']`)
+                                    }
+                                >
+                                    <p className="fs-4 textOverflow">
+                                        <span className="fw-lightBold">Family: </span>
+                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:family"]}
+                                    </p>
+                                </button>
                             </Col>
                         </Row>
                         {/* Genus */}
                         <Row>
                             <Col>
-                                <p className="fs-4 textOverflow">
-                                    <span className="fw-lightBold">Genus: </span>
-                                    <span className="fst-italic">{acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:genus"]}</span>
-                                </p>
+                                <button type="button"
+                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                    onClick={() => annotationMode &&
+                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:genus']`)
+                                    }
+                                >
+                                    <p className="fs-4 textOverflow">
+                                        <span className="fw-lightBold">Genus: </span>
+                                        <span className="fst-italic">{acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:genus"]}</span>
+                                    </p>
+                                </button>
                             </Col>
                         </Row>
                     </div>

--- a/src/components/digitalSpecimen/components/idCard/IdCard.tsx
+++ b/src/components/digitalSpecimen/components/idCard/IdCard.tsx
@@ -1,4 +1,5 @@
 /* Import Dependencies */
+import classNames from 'classnames';
 import jp from 'jsonpath';
 import { useState, createElement, DetailedReactHTMLElement, HTMLAttributes } from 'react';
 import { Row, Col, Card } from 'react-bootstrap';
@@ -18,7 +19,9 @@ import { Identification } from 'app/types/Identification';
 /* Props Type */
 type Props = {
     digitalSpecimen: DigitalSpecimen,
-    digitalSpecimenDigitalMedia: DigitalMedia[] | undefined
+    digitalSpecimenDigitalMedia: DigitalMedia[] | undefined,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
@@ -26,10 +29,12 @@ type Props = {
  * Component that renders the ID card on the digital specimen page
  * @param digitalSpecimen The selected digital specimen
  * @param digitalSpecimenDigitalMedia The digital media belonging to the digital specimen
+ * @param annotationMode Boolean indicating if the annotation mode is enabled
+ * @param SetAnnotationTarget Function to set the annotation target
  * @returns JSX Component
  */
 const IdCard = (props: Props) => {
-    const { digitalSpecimen, digitalSpecimenDigitalMedia } = props;
+    const { digitalSpecimen, digitalSpecimenDigitalMedia, annotationMode, SetAnnotationTarget } = props;
 
     /* Hooks */
     const trigger = useTrigger();
@@ -76,6 +81,11 @@ const IdCard = (props: Props) => {
         }
     };
 
+    /* Class Names */
+    const idCardItemClass = classNames({
+        'hover-grey mc-pointer': annotationMode
+    });
+
     return (
         <div className="h-100 d-flex flex-column">
             {/* First digital media image of digital specimen, if present */}
@@ -90,16 +100,21 @@ const IdCard = (props: Props) => {
             }
             {/* ID card items*/}
             <Row className="flex-grow-1 overflow-hidden">
-                <Col>
+                <Col className="h-100">
                     <Card className="h-100 bgc-white px-3 py-3">
                         <div className="h-100 d-flex flex-column justify-content-between">
                             {/* Nomenclatural name (HTML label) */}
                             <Row>
-                                <Col className="fs-4">
-                                    <p className="fw-lightBold">Specimen Name</p>
-                                    <p className="textOverflow"
-                                        dangerouslySetInnerHTML={{ __html: GetSpecimenNameHTMLLabel() }}
-                                    />
+                                <Col className={`${idCardItemClass} fs-4 tr-fast`}>
+                                    <button type="button"
+                                        className="button-no-style textOverflow px-0 py-0 overflow-hidden"
+                                        onClick={() => SetAnnotationTarget('term', "$['ods:specimenName']")}
+                                    >
+                                        <p className="fw-lightBold">Specimen Name</p>
+                                        <p className="textOverflow"
+                                            dangerouslySetInnerHTML={{ __html: GetSpecimenNameHTMLLabel() }}
+                                        />
+                                    </button>
                                 </Col>
                             </Row>
                             {/* ID card properties */}
@@ -107,10 +122,15 @@ const IdCard = (props: Props) => {
                                 return (
                                     <Row key={idCardField.label}>
                                         {/* ID card item */}
-                                        <Col className="fs-4">
-                                            {/* Item label */}
-                                            <p className="fw-lightBold">{idCardField.label}</p>
-                                            <p className="textOverflow">{jp.query(digitalSpecimen, idCardField.jsonPath)}</p>
+                                        <Col className={`${idCardItemClass} fs-4 tr-fast overflow-hidden`}>
+                                            <button type="button"
+                                                className="button-no-style textOverflow px-0 py-0 overflow-hidden"
+                                                onClick={() => SetAnnotationTarget('term', idCardField.jsonPath)}
+                                            >
+                                                {/* Item label */}
+                                                <p className="fw-lightBold">{idCardField.label}</p>
+                                                <p className="textOverflow">{jp.query(digitalSpecimen, idCardField.jsonPath)}</p>
+                                            </button>
                                         </Col>
                                     </Row>
                                 );

--- a/src/components/digitalSpecimen/components/idCard/IdCard.tsx
+++ b/src/components/digitalSpecimen/components/idCard/IdCard.tsx
@@ -86,6 +86,10 @@ const IdCard = (props: Props) => {
         'hover-grey mc-pointer': annotationMode
     });
 
+    const idCardItemButtonClass = classNames({
+        'mc-default': !annotationMode
+    });
+
     return (
         <div className="h-100 d-flex flex-column">
             {/* First digital media image of digital specimen, if present */}
@@ -107,8 +111,8 @@ const IdCard = (props: Props) => {
                             <Row>
                                 <Col className={`${idCardItemClass} fs-4 tr-fast`}>
                                     <button type="button"
-                                        className="button-no-style textOverflow px-0 py-0 overflow-hidden"
-                                        onClick={() => SetAnnotationTarget('term', "$['ods:specimenName']")}
+                                        className={`${idCardItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                        onClick={() => annotationMode && SetAnnotationTarget('term', "$['ods:specimenName']")}
                                     >
                                         <p className="fw-lightBold">Specimen Name</p>
                                         <p className="textOverflow"
@@ -124,8 +128,8 @@ const IdCard = (props: Props) => {
                                         {/* ID card item */}
                                         <Col className={`${idCardItemClass} fs-4 tr-fast overflow-hidden`}>
                                             <button type="button"
-                                                className="button-no-style textOverflow px-0 py-0 overflow-hidden"
-                                                onClick={() => SetAnnotationTarget('term', idCardField.jsonPath)}
+                                                className={`${idCardItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                                                onClick={() => annotationMode && SetAnnotationTarget('term', idCardField.jsonPath)}
                                             >
                                                 {/* Item label */}
                                                 <p className="fw-lightBold">{idCardField.label}</p>

--- a/src/components/digitalSpecimen/components/topBar/TopBar.tsx
+++ b/src/components/digitalSpecimen/components/topBar/TopBar.tsx
@@ -26,7 +26,7 @@ import { Dropdown, Tooltip } from "components/elements/customUI/CustomUI";
 type Props = {
     digitalSpecimen: DigitalSpecimen,
     annotationMode: boolean,
-    ToggleAnnotationSidePanel: Function
+    ToggleAnnotationMode: Function
 };
 
 
@@ -34,11 +34,11 @@ type Props = {
  * Component that renders the top bar on the digital specimen page
  * @param digitalSpecimen The selected digital specimen
  * @param annotationMode Boolean that indicates if the annotation mode is toggled
- * @param ToggleAnnotationSidePanel Function to toggle the annotation side panel
+ * @param ToggleAnnotationMode Function to toggle the annotation mode
  * @returns JSX Component
  */
 const TopBar = (props: Props) => {
-    const { digitalSpecimen, annotationMode, ToggleAnnotationSidePanel } = props;
+    const { digitalSpecimen, annotationMode, ToggleAnnotationMode } = props;
 
     /* Hooks */
     const navigate = useNavigate();
@@ -156,7 +156,7 @@ const TopBar = (props: Props) => {
                 <Col className="tourDigitalSpecimen4">
                     <TopBarActions actionDropdownItems={actionDropdownItems}
                         annotationMode={annotationMode}
-                        ToggleAnnotationSidePanel={ToggleAnnotationSidePanel}
+                        ToggleAnnotationMode={ToggleAnnotationMode}
                     />
                 </Col>
             </Row>

--- a/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
+++ b/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
@@ -133,10 +133,7 @@ const AnnotationSidePanel = (props: Props) => {
                             annotationCases={annotationCases}
                             StopAnnotationWizard={() => {
                                 setAnnotationWizardToggle(false);
-                                dispatch(setAnnotationTarget(annotationTarget ? {
-                                    ...annotationTarget,
-                                    annotation: undefined
-                                } : undefined));
+                                dispatch(setAnnotationTarget(undefined));
                                 setLoading(false);
                             }}
                             SetLoading={(loading: boolean) => setLoading(loading)}
@@ -151,6 +148,7 @@ const AnnotationSidePanel = (props: Props) => {
                                 ScheduleMas={ScheduleMas}
                             />
                                 : <AnnotationsOverview annotations={annotations}
+                                    annotationTarget={annotationTarget}
                                     filterSortValues={filterSortValues}
                                     schemaTitle={schema.title}
                                     SetFilterSortValues={setFilterSortValues}

--- a/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
+++ b/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
@@ -133,8 +133,14 @@ const AnnotationSidePanel = (props: Props) => {
                             annotationCases={annotationCases}
                             StopAnnotationWizard={() => {
                                 setAnnotationWizardToggle(false);
-                                dispatch(setAnnotationTarget(undefined));
                                 setLoading(false);
+
+                                if (annotationTarget?.annotation) {
+                                    dispatch(setAnnotationTarget({
+                                        ...annotationTarget,
+                                        annotation: undefined
+                                    }));
+                                }
                             }}
                             SetLoading={(loading: boolean) => setLoading(loading)}
                             SetFilterSortValues={setFilterSortValues}

--- a/src/components/elements/annotationSidePanel/components/AnnotationCard.tsx
+++ b/src/components/elements/annotationSidePanel/components/AnnotationCard.tsx
@@ -126,7 +126,7 @@ const AnnotationCard = (props: Props) => {
                     <Col>
                         {/* Render annotation content based on target type */}
                         {annotation['oa:hasTarget']['oa:hasSelector']?.['@type'] === 'ods:TermSelector' &&
-                            <p>
+                            <p className="fs-4">
                                 {annotation['oa:hasBody']['oa:value']}
                             </p>
                         }

--- a/src/components/elements/annotationSidePanel/components/TopBar.tsx
+++ b/src/components/elements/annotationSidePanel/components/TopBar.tsx
@@ -2,6 +2,12 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Row, Col } from 'react-bootstrap';
 
+/* Import Hooks */
+import { useAppDispatch } from 'app/Hooks';
+
+/* Import Store */
+import { setAnnotationTarget } from 'redux-store/AnnotateSlice';
+
 /* Import Icons */
 import { faChevronLeft, faClosedCaptioning, faFileContract, faRotate } from '@fortawesome/free-solid-svg-icons';
 
@@ -27,6 +33,9 @@ type Props = {
 const TopBar = (props: Props) => {
     const { HideAnnotationSidePanel, RefreshAnnotations, ShowPolicyText } = props;
 
+    /* Hooks */
+    const dispatch = useAppDispatch();
+
     return (
         <div>
             <Row>
@@ -37,7 +46,10 @@ const TopBar = (props: Props) => {
                     <Button type="button"
                         variant="blank"
                         className="px-0 py-0"
-                        OnClick={() => HideAnnotationSidePanel()}
+                        OnClick={() => {
+                            HideAnnotationSidePanel();
+                            dispatch(setAnnotationTarget(undefined));
+                        }}
                     >
                         <FontAwesomeIcon icon={faChevronLeft}
                             className="tc-primary"

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
@@ -7,14 +7,13 @@ import { Row, Col } from 'react-bootstrap';
 
 /* Import Utilities */
 import { ConstructAnnotationObject, ProcessAnnotationValues } from 'app/utilities/AnnotateUtilities';
-import { MakeJsonPathReadableString } from 'app/utilities/SchemaUtilities';
 
 /* Import Hooks */
 import { useAppSelector, useAppDispatch, useNotification, useTrigger } from 'app/Hooks';
 
 /* Import Store */
 import { getAnnotationTarget, setAnnotationTarget } from 'redux-store/AnnotateSlice';
-import { getAnnotationWizardSelectedIndex, setAnnotationWizardToggle } from 'redux-store/TourSlice';
+import { getAnnotationWizardSelectedIndex } from 'redux-store/TourSlice';
 
 /* Import Types */
 import { AnnotationTarget, Dict, ProgressDot, SuperClass } from 'app/Types';

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
@@ -105,43 +105,9 @@ const AnnotationWizard = (props: Props) => {
         if (localAnnotationTarget?.annotation) {
             /* When changing the annotation target when editing an annotation, disable the annotation wizard */
             StopAnnotationWizard();
-
-            // setLocalAnnotationTarget(annotationTarget);
         } else if (annotationTarget?.directPath) {
             GoToStep(2);
-            // console.log(annotationTarget);
-
-            // let parentJsonPath: string = '$';
-
-            // if (FormatFieldNameFromJsonPath(annotationTarget.jsonPath).split('_').length > 1) {
-            //     parentJsonPath = FormatJsonPathFromFieldName(FormatFieldNameFromJsonPath(annotationTarget.jsonPath).split('_').slice(0, -1).join('_'));
-            // }
-
-            // // console.log(parentJsonPath);
-
-            // setInitialFormValues({
-            //     class: annotationTarget?.type === 'class' ? {
-            //         label: MakeJsonPathReadableString(annotationTarget.jsonPath),
-            //         value: annotationTarget?.jsonPath
-            //     } : {
-            //         label: parentJsonPath === '$' ? schema.title : MakeJsonPathReadableString(parentJsonPath),
-            //         value: parentJsonPath
-            //     },
-            //     term: annotationTarget?.type === 'term' ? {
-            //         label: MakeJsonPathReadableString(annotationTarget.jsonPath ?? ''),
-            //         value: annotationTarget?.jsonPath
-            //     } : undefined,
-            //     jsonPath: undefined,
-            //     motivation: ((annotationTarget?.jsonPath && jp.value(superClass, annotationTarget?.jsonPath)) && 'oa:editing')
-            //         ?? (annotationTarget?.jsonPath && 'ods:adding') ?? undefined,
-            //     parentClassDropdownValues: initialFormValues?.parentClassDropdownValues ?? {},
-            //     annotationValues: {}
-            // });
-
-            // console.log(initialFormValues);
         }
-
-        
     }, [annotationTarget]);
 
     /* Define wizard step components using tabs */
@@ -318,16 +284,14 @@ const AnnotationWizard = (props: Props) => {
                                 try {
                                     /* If annotation record is present in annotation target, patch annotation, otherwise insert annotation */
                                     if (annotationTarget?.annotation) {
-                                        // await PatchAnnotation({
-                                        //     annotationId: annotationTarget.annotation.id,
-                                        //     updatedAnnotation: newAnnotation
-                                        // });
-                                        console.log('edit', newAnnotation);
+                                        await PatchAnnotation({
+                                            annotationId: annotationTarget.annotation.id,
+                                            updatedAnnotation: newAnnotation
+                                        });
                                     } else {
-                                        // await InsertAnnotation({
-                                        //     newAnnotation
-                                        // });
-                                        console.log('new', newAnnotation);
+                                        await InsertAnnotation({
+                                            newAnnotation
+                                        });
                                     }
 
                                     StopAnnotationWizard();

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/AnnotationWizard.tsx
@@ -1,6 +1,7 @@
 /* Import Dependencies */
 import { Formik, Form } from 'formik';
 import { isEmpty } from 'lodash';
+import jp from 'jsonpath';
 import { useState } from 'react';
 import { Row, Col } from 'react-bootstrap';
 
@@ -60,43 +61,12 @@ const AnnotationWizard = (props: Props) => {
     const notification = useNotification();
     const trigger = useTrigger();
 
-    /* Define wizard step components using tabs */
+    /* Base variables */
     const annotationTarget = useAppSelector(getAnnotationTarget);
     const tourAnnotationWizardSelectedIndex = useAppSelector(getAnnotationWizardSelectedIndex);
-    const tabs: { [name: string]: JSX.Element } = {
-        ...(!annotationTarget?.annotation && {
-            annotationTarget: <AnnotationTargetStep schema={schema}
-                annotationCases={annotationCases}
-            />
-        }),
-        ...(!annotationTarget?.annotation && {
-            annotationSelectInstance: <AnnotationSelectInstanceStep superClass={superClass}
-                schemaTitle={schema.title}
-            />
-        }),
-        annotationForm: <AnnotationFormStep superClass={superClass}
-            schemaName={schema.title}
-        />,
-        annotationSummary: <AnnotationSummaryStep superClass={superClass}
-            schemaTitle={schema.title}
-        />
-    };
-
-    /* Base variables */
-    const [tabStates, setTabStates] = useState<{
-        checked: boolean,
-        active: boolean
-    }[]>(
-        Object.keys(tabs).map((_key, index) => ({
-            checked: !index,
-            active: !index
-        }))
-    );
-
     const progressDots: ProgressDot[] = [];
-    const selectedIndex: number = tabStates.findIndex(tabState => tabState.active);
-    const completedTill: number = tabStates.findLastIndex(tabState => tabState.checked);
-    const initialFormValues: {
+    const [localAnnotationTargetJsonPath, setLocalAnnotationTargetJsonpath] = useState<string | undefined>();
+    const [initialFormValues, setInitialFormValues] = useState<{
         class: {
             label: string,
             value: string
@@ -115,18 +85,57 @@ const AnnotationWizard = (props: Props) => {
                 [termName: string]: string
             } | { value: string }
         }
-    } = {
-        class: undefined,
-        term: undefined,
-        jsonPath: undefined,
-        parentClassDropdownValues: {},
-        motivation: undefined,
-        annotationValues: {}
+    } | undefined>(undefined);
+
+    /* OnLoad: define initial form values */
+    trigger.SetTrigger(() => {
+        setInitialFormValues({
+            class: undefined,
+            term: undefined,
+            jsonPath: annotationTarget?.jsonPath ?? undefined,
+            parentClassDropdownValues: {},
+            motivation: ((annotationTarget?.jsonPath && jp.value(superClass, annotationTarget?.jsonPath)) && 'oa:editing')
+                ?? (annotationTarget?.jsonPath && 'ods:adding') ?? undefined,
+            annotationValues: {}
+        });
+    }, []);
+
+    /* Define wizard step components using tabs */
+    const tabs: { [name: string]: JSX.Element } = {
+        /* Do not render the target step if editing an annotation or if the annotation target is predefined */
+        ...((!annotationTarget?.annotation && !initialFormValues?.jsonPath) && {
+            annotationTarget: <AnnotationTargetStep schema={schema}
+                annotationCases={annotationCases}
+            />
+        }),
+        /* Do not render the select instance step if editing an annotation or if the annotation target is predefined */
+        ...((!annotationTarget?.annotation && !initialFormValues?.jsonPath) && {
+            annotationSelectInstance: <AnnotationSelectInstanceStep superClass={superClass}
+                schemaTitle={schema.title}
+            />
+        }),
+        annotationForm: <AnnotationFormStep superClass={superClass}
+            schemaName={schema.title}
+        />,
+        annotationSummary: <AnnotationSummaryStep superClass={superClass}
+            schemaTitle={schema.title}
+        />
     };
+    const [tabStates, setTabStates] = useState<{
+        checked: boolean,
+        active: boolean
+    }[]>(
+        Object.keys(tabs).map((_key, index) => ({
+            checked: !index,
+            active: !index
+        }))
+    );
+    const selectedIndex: number = tabStates.findIndex(tabState => tabState.active);
+    const completedTill: number = tabStates.findLastIndex(tabState => tabState.checked);
 
     /* Onchange of tour annotation wizard selected index, update local state */
     trigger.SetTrigger(() => {
-        if (typeof(tourAnnotationWizardSelectedIndex) !== 'undefined') {
+        if (typeof (tourAnnotationWizardSelectedIndex) !== 'undefined') {
             setTabStates([
                 {
                     checked: true, active: tourAnnotationWizardSelectedIndex === 0
@@ -203,7 +212,7 @@ const AnnotationWizard = (props: Props) => {
 
         switch (stepIndex) {
             case 0:
-                if (formValues.class || formValues.term || annotationTarget?.annotation) {
+                if (formValues.class || formValues.term || annotationTarget?.annotation || initialFormValues?.jsonPath) {
                     forwardAllowed = true;
                 }
 
@@ -230,138 +239,145 @@ const AnnotationWizard = (props: Props) => {
             {/* Annotation wizard main body */}
             <Row className="flex-grow-1 overflow-hidden">
                 <Col className="h-100">
-                    <Formik initialValues={initialFormValues}
-                        onSubmit={async (values) => {
-                            await new Promise((resolve) => setTimeout(resolve, 100));
+                    {initialFormValues &&
+                        <Formik initialValues={initialFormValues}
+                            onSubmit={async (values) => {
+                                await new Promise((resolve) => setTimeout(resolve, 100));
 
-                            /* Extract and format annotation values from form values */
-                            const annotationValues: (string | Dict)[] = [];
+                                /* Extract and format annotation values from form values */
+                                const annotationValues: (string | Dict)[] = [];
 
-                            if (!('value' in values.annotationValues)) {
-                                annotationValues.push(JSON.stringify(ProcessAnnotationValues(values.jsonPath as string, values.annotationValues)));
-                            } else {
-                                annotationValues.push(values.annotationValues.value);
-                            }
-
-                            /* Construct annotation object */
-                            const newAnnotation = ConstructAnnotationObject({
-                                digitalObjectId: superClass['@id'],
-                                digitalObjectType: superClass['@type'],
-                                motivation: values.motivation ?? 'oa:commenting',
-                                annotationTargetType: values.annotationValues.value ? 'term' : 'class',
-                                jsonPath: values.jsonPath as string,
-                                annotationValues
-                            });
-
-                            /* Try to post the new annotation */
-                            SetLoading(true);
-
-                            /* If annotation object is not empty and thus the action succeeded, go back to overview and refresh, otherwise show error message */
-                            try {
-                                /* If annotation record is present in annotation target, patch annotation, otherwise insert annotation */
-                                if (annotationTarget?.annotation) {
-                                    await PatchAnnotation({
-                                        annotationId: annotationTarget.annotation.id,
-                                        updatedAnnotation: newAnnotation
-                                    });
+                                if (!('value' in values.annotationValues)) {
+                                    annotationValues.push(JSON.stringify(ProcessAnnotationValues(values.jsonPath as string, values.annotationValues)));
                                 } else {
-                                    await InsertAnnotation({
-                                        newAnnotation
-                                    });
+                                    annotationValues.push(values.annotationValues.value);
                                 }
 
-                                StopAnnotationWizard();
-
-                                /* Reset filter and sort values */
-                                SetFilterSortValues({
-                                    motivation: '',
-                                    sortBy: 'dateLatest'
-                                });
-                            } catch {
-                                notification.Push({
-                                    key: `${superClass['@id']}-${Math.random()}`,
-                                    message: `Failed to ${annotationTarget?.annotation ? 'update' : 'add'} the annotation. Please try saving it again.`,
-                                    template: 'error'
+                                /* Construct annotation object */
+                                const newAnnotation = ConstructAnnotationObject({
+                                    digitalObjectId: superClass['@id'],
+                                    digitalObjectType: superClass['@type'],
+                                    motivation: values.motivation ?? 'oa:commenting',
+                                    annotationTargetType: values.annotationValues.value ? 'term' : 'class',
+                                    jsonPath: values.jsonPath as string,
+                                    annotationValues
                                 });
 
-                                SetLoading(false);
-                            };
-                        }}
-                    >
-                        {({ values, setFieldValue, setValues }) => (
-                            <Form className="h-100 d-flex flex-column overflow-none">
-                                {/* Previous and next step buttons */}
-                                <Row>
-                                    <Col lg="auto">
-                                        <Button type="button"
-                                            variant="blank"
-                                            className="px-0 py-0 tc-primary fw-lightBold"
-                                            OnClick={() => StopAnnotationWizard()}
-                                        >
-                                            <p>
-                                                Exit
-                                            </p>
-                                        </Button>
-                                    </Col>
-                                    {!!selectedIndex &&
-                                        <Col lg>
+                                /* Try to post the new annotation */
+                                SetLoading(true);
+
+                                /* If annotation object is not empty and thus the action succeeded, go back to overview and refresh, otherwise show error message */
+                                try {
+                                    /* If annotation record is present in annotation target, patch annotation, otherwise insert annotation */
+                                    if (annotationTarget?.annotation) {
+                                        // await PatchAnnotation({
+                                        //     annotationId: annotationTarget.annotation.id,
+                                        //     updatedAnnotation: newAnnotation
+                                        // });
+                                        console.log('edit', newAnnotation);
+                                    } else {
+                                        // await InsertAnnotation({
+                                        //     newAnnotation
+                                        // });
+                                        console.log('new', newAnnotation);
+                                    }
+
+                                    StopAnnotationWizard();
+
+                                    /* Reset filter and sort values */
+                                    SetFilterSortValues({
+                                        motivation: '',
+                                        sortBy: 'dateLatest'
+                                    });
+                                } catch {
+                                    notification.Push({
+                                        key: `${superClass['@id']}-${Math.random()}`,
+                                        message: `Failed to ${annotationTarget?.annotation ? 'update' : 'add'} the annotation. Please try saving it again.`,
+                                        template: 'error'
+                                    });
+
+                                    SetLoading(false);
+                                };
+                            }}
+                        >
+                            {({ values, setFieldValue, setValues }) => (
+                                <Form className="h-100 d-flex flex-column overflow-none">
+                                    {/* Previous and next step buttons */}
+                                    <Row>
+                                        <Col lg="auto">
                                             <Button type="button"
                                                 variant="blank"
                                                 className="px-0 py-0 tc-primary fw-lightBold"
-                                                OnClick={() => GoToStep(selectedIndex - 1)}
+                                                OnClick={() => {
+                                                    StopAnnotationWizard();
+                                                    dispatch(setAnnotationTarget(undefined));
+                                                }}
                                             >
-                                                {`< Previous step`}
+                                                <p>
+                                                    Exit
+                                                </p>
                                             </Button>
                                         </Col>
-                                    }
-                                    {CheckForwardCriteria(selectedIndex, values) &&
-                                        <Col lg
-                                            className="d-flex justify-content-end"
-                                        >
-                                            <Button type="button"
-                                                variant="blank"
-                                                className="tourAnnotate12 tourAnnotate16 px-0 py-0 tc-primary fw-lightBold"
-                                                OnClick={() => GoToStep(selectedIndex + 1)}
+                                        {!!selectedIndex &&
+                                            <Col lg>
+                                                <Button type="button"
+                                                    variant="blank"
+                                                    className="px-0 py-0 tc-primary fw-lightBold"
+                                                    OnClick={() => GoToStep(selectedIndex - 1)}
+                                                >
+                                                    {`< Previous step`}
+                                                </Button>
+                                            </Col>
+                                        }
+                                        {CheckForwardCriteria(selectedIndex, values) &&
+                                            <Col lg
+                                                className="d-flex justify-content-end"
                                             >
-                                                {`Next step >`}
-                                            </Button>
+                                                <Button type="button"
+                                                    variant="blank"
+                                                    className="tourAnnotate12 tourAnnotate16 px-0 py-0 tc-primary fw-lightBold"
+                                                    OnClick={() => GoToStep(selectedIndex + 1)}
+                                                >
+                                                    {`Next step >`}
+                                                </Button>
+                                            </Col>
+                                        }
+                                    </Row>
+
+                                    {/* Wizard steps display */}
+                                    <Row className="flex-grow-1 overflow-hidden">
+                                        <Col className="h-100">
+                                            <Tabs tabs={tabs}
+                                                selectedIndex={selectedIndex}
+                                                tabClassName='d-none'
+                                                tabPanelClassName="flex-grow-1 overflow-hidden"
+                                                tabProps={{
+                                                    formValues: values,
+                                                    SetFieldValue: setFieldValue,
+                                                    SetFormValues: setValues,
+                                                    SetAnnotationTarget,
+                                                    GoToStep: GoToStep
+                                                }}
+                                                SetSelectedIndex={GoToStep}
+                                            />
                                         </Col>
-                                    }
-                                </Row>
-
-                                {/* Wizard steps display */}
-                                <Row className="flex-grow-1 overflow-hidden">
-                                    <Col className="h-100">
-                                        <Tabs tabs={tabs}
-                                            selectedIndex={selectedIndex}
-                                            tabClassName='d-none'
-                                            tabPanelClassName="flex-grow-1 overflow-hidden"
-                                            tabProps={{
-                                                formValues: values,
-                                                SetFieldValue: setFieldValue,
-                                                SetFormValues: setValues,
-                                                SetAnnotationTarget,
-                                                GoToStep: GoToStep
-                                            }}
-                                            SetSelectedIndex={GoToStep}
-                                        />
-                                    </Col>
-                                </Row>
+                                    </Row>
 
 
-                                {/* Progress dots adhering to the wizard */}
-                                <Row className="mt-3">
-                                    <Col>
-                                        <ProgressDots progressDots={progressDots}
-                                            selectedIndex={selectedIndex}
-                                            completedTill={completedTill}
-                                            ValidationFunction={(index: number) => CheckForwardCriteria(index, values)}
-                                        />
-                                    </Col>
-                                </Row>
-                            </Form>
-                        )}
-                    </Formik>
+                                    {/* Progress dots adhering to the wizard */}
+                                    <Row className="mt-3">
+                                        <Col>
+                                            <ProgressDots progressDots={progressDots}
+                                                selectedIndex={selectedIndex}
+                                                completedTill={completedTill}
+                                                ValidationFunction={(index: number) => CheckForwardCriteria(index, values)}
+                                            />
+                                        </Col>
+                                    </Row>
+                                </Form>
+                            )}
+                        </Formik>
+                    }
                 </Col>
             </Row>
         </div>

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -21,6 +21,7 @@ import { AnnotationFormProperty, AnnotationTarget, Dict, DropdownItem, SuperClas
 /* Import Components */
 import AnnotationFormSegment from './AnnotationFormSegment';
 import { Dropdown, InputTextArea } from "components/elements/customUI/CustomUI";
+import { MakeJsonPathReadableString } from 'app/utilities/SchemaUtilities';
 
 
 /* Props Type */
@@ -93,11 +94,11 @@ const AnnotationFormStep = (props: Props) => {
 
         /* For selected class, get annotation form field properties and their values */
         GenerateAnnotationFormFieldProperties(jsonPath, localSuperClass, schemaName).then(({ annotationFormFieldProperties, newFormValues }) => {
-            // let parentJsonPath: string = '$';
+            let parentJsonPath: string = '$';
 
-            // if (FormatFieldNameFromJsonPath(annotationTarget.jsonPath).split('_').length > 1) {
-            //     parentJsonPath = FormatJsonPathFromFieldName(FormatFieldNameFromJsonPath(annotationTarget.jsonPath).split('_').slice(0, -1).join('_'));
-            // }
+            if (annotationTarget?.jsonPath && FormatFieldNameFromJsonPath(annotationTarget.jsonPath).split('_').length > 1) {
+                parentJsonPath = FormatJsonPathFromFieldName(FormatFieldNameFromJsonPath(annotationTarget.jsonPath).split('_').slice(0, -1).join('_'));
+            }
 
             /* Set form values state with current values, based upon annotation form field properties */
             const newSetFormValues = {
@@ -105,7 +106,7 @@ const AnnotationFormStep = (props: Props) => {
                 annotationValues: {
                     ...newFormValues,
                     ...formValues?.annotationValues,
-                    value: (localAnnotationTarget?.jsonPath !== annotationTarget?.jsonPath) ? newFormValues.value : formValues?.annotationValues.value
+                    value: (localAnnotationTarget?.jsonPath !== annotationTarget?.jsonPath) ? newFormValues.value : formValues?.annotationValues.value ?? newFormValues.value
                 },
                 /* Set JSON path and motivation from this checkpoint if editing an annotation */
                 ...(annotationTarget?.annotation && {
@@ -114,6 +115,22 @@ const AnnotationFormStep = (props: Props) => {
                 }),
                 /* Set JSON path from this checkpoint if annotation target is a direct target */
                 ...(annotationTarget?.directPath && {
+                    ...(annotationTarget.type === 'term' ? {
+                        class: {
+                            label: MakeJsonPathReadableString((parentJsonPath !== '$' ? parentJsonPath : schemaName).replace(/\[\d+\]/g, ' ')),
+                            value: parentJsonPath.replace(/\[\d+\]/g, '')
+                        },
+                        value: {
+                            label: MakeJsonPathReadableString(annotationTarget.jsonPath.replace(/\[\d+\]/g, ' ')),
+                            value: annotationTarget.jsonPath.replace(/\[\d+\]/g, '')
+                        }
+                    } : {
+                        class: {
+                            label: MakeJsonPathReadableString(annotationTarget.jsonPath.replace(/\[\d+\]/g, ' ')),
+                            value: annotationTarget.jsonPath.replace(/\[\d+\]/g, '')
+                        },
+                        term: undefined
+                    }),
                     jsonPath,
                     motivation: jp.value(superClass, annotationTarget.jsonPath) ? 'oa:editing' : 'ods:adding'
                 })

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Utitlties */
-import { GenerateAnnotationFormFieldProperties, GetAnnotationMotivations } from "app/utilities/AnnotateUtilities";
+import { GenerateAnnotationFormFieldProperties, FormatFieldNameFromJsonPath, FormatJsonPathFromFieldName, GetAnnotationMotivations } from "app/utilities/AnnotateUtilities";
 import { AnnotationWizardTourTrigger } from 'app/utilities/TourUtilities';
 
 /* Import Hooks */
@@ -16,7 +16,7 @@ import { getAnnotationTarget } from 'redux-store/AnnotateSlice';
 import { getAnnotationWizardFormValues } from 'redux-store/TourSlice';
 
 /* Import Types */
-import { AnnotationFormProperty, Dict, DropdownItem, SuperClass } from "app/Types";
+import { AnnotationFormProperty, AnnotationTarget, Dict, DropdownItem, SuperClass } from "app/Types";
 
 /* Import Components */
 import AnnotationFormSegment from './AnnotationFormSegment';
@@ -27,7 +27,9 @@ import { Dropdown, InputTextArea } from "components/elements/customUI/CustomUI";
 type Props = {
     superClass: SuperClass
     schemaName: string,
+    localAnnotationTarget?: AnnotationTarget,
     formValues?: Dict,
+    SetLocalAnnotationTarget: Function,
     SetFieldValue?: Function,
     SetFormValues?: Function
 };
@@ -37,13 +39,13 @@ type Props = {
  * Component that renders the third and final step in the annotation wizard for defining the motivation and actual values
  * @param superClass The selected digital object
  * @param schemaName The name of the 
- * @param formValues The values of the annotation form
+ * @param formValues The values of the annotation 
  * @param SetFieldValue Funtion to set a value to a single field in the form
  * @param SetFormValues Function to set all of the values in the form
  * @returns JSX Component
  */
 const AnnotationFormStep = (props: Props) => {
-    const { superClass, schemaName, formValues, SetFieldValue, SetFormValues } = props;
+    const { superClass, schemaName, localAnnotationTarget, formValues, SetLocalAnnotationTarget, SetFieldValue, SetFormValues } = props;
 
     /* Hooks */
     const trigger = useTrigger();
@@ -72,7 +74,7 @@ const AnnotationFormStep = (props: Props) => {
     /* OnLoad, generate field properties for annotation form */
     trigger.SetTrigger(() => {
         /* Either take JSON path from form values or the annotation target (when editing an annotation) */
-        let jsonPath: string = formValues?.jsonPath ?? annotationTarget?.jsonPath;
+        let jsonPath: string = annotationTarget?.directPath ? annotationTarget.jsonPath : formValues?.jsonPath;
         let localSuperClass: SuperClass = cloneDeep(superClass);
 
         if (formValues && annotationTarget?.annotation) {
@@ -91,27 +93,41 @@ const AnnotationFormStep = (props: Props) => {
 
         /* For selected class, get annotation form field properties and their values */
         GenerateAnnotationFormFieldProperties(jsonPath, localSuperClass, schemaName).then(({ annotationFormFieldProperties, newFormValues }) => {
+            // let parentJsonPath: string = '$';
+
+            // if (FormatFieldNameFromJsonPath(annotationTarget.jsonPath).split('_').length > 1) {
+            //     parentJsonPath = FormatJsonPathFromFieldName(FormatFieldNameFromJsonPath(annotationTarget.jsonPath).split('_').slice(0, -1).join('_'));
+            // }
+
             /* Set form values state with current values, based upon annotation form field properties */
             const newSetFormValues = {
                 ...formValues,
                 annotationValues: {
                     ...newFormValues,
-                    ...formValues?.annotationValues
+                    ...formValues?.annotationValues,
+                    value: (localAnnotationTarget?.jsonPath !== annotationTarget?.jsonPath) ? newFormValues.value : formValues?.annotationValues.value
                 },
-                /* Set JSON path from this checkpoint if editing an annotation */
+                /* Set JSON path and motivation from this checkpoint if editing an annotation */
                 ...(annotationTarget?.annotation && {
-                    jsonPath: jsonPath,
+                    jsonPath,
                     motivation: annotationTarget.annotation.motivation
+                }),
+                /* Set JSON path from this checkpoint if annotation target is a direct target */
+                ...(annotationTarget?.directPath && {
+                    jsonPath,
+                    motivation: jp.value(superClass, annotationTarget.jsonPath) ? 'oa:editing' : 'ods:adding'
                 })
             };
 
             /* Set form values */
             SetFormValues?.(newSetFormValues);
 
+            SetLocalAnnotationTarget(annotationTarget);
+
             /* Set annotation form field properties */
             setAnnotationFormFieldProperties(annotationFormFieldProperties);
         });
-    }, [formValues?.jsonPath]);
+    }, [annotationTarget]);
 
     /* From annotation form field properties, extract base object and its properties */
     if (!isEmpty(annotationFormFieldProperties) && formValues?.jsonPath) {

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSelectInstanceStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSelectInstanceStep.tsx
@@ -50,7 +50,7 @@ const AnnotationSelectInstanceStep = (props: Props) => {
         let jsonTargetPath: string = '';
 
         /* Insert the json path library double dots before every square bracket in order to select everything linked to the path */
-        annotationTarget.jsonPath.split('[').forEach((pathSegment, index) => {
+        annotationTarget.jsonPath.replace(/\[\d+\]/g, '').split('[').forEach((pathSegment, index) => {
             if (index) {
                 jsonTargetPath = jsonTargetPath.concat(`..[${pathSegment}`);
             } else {
@@ -68,8 +68,8 @@ const AnnotationSelectInstanceStep = (props: Props) => {
     /* Conditions for checking if a new or existing instances may be selected */
     const allowForNewInstance: boolean = (!nodes.length && annotationTarget?.type === 'term') ||
     (annotationTarget?.type !== 'term' && !nodes.length) || (
-        jp.parse(annotationTarget?.jsonPath ?? '').slice(-1)[0].expression.value.includes('has') &&
-        jp.parse(annotationTarget?.jsonPath ?? '').slice(-1)[0].expression.value.at(-1) === 's'
+        jp.parse(annotationTarget?.jsonPath.replace(/\[\d+\]/g, '') ?? '').slice(-1)[0].expression.value.includes('has') &&
+        jp.parse(annotationTarget?.jsonPath.replace(/\[\d+\]/g, '') ?? '').slice(-1)[0].expression.value.at(-1) === 's'
     );
 
     const allowForExistingInstances: boolean = !!(nodes.length && ((Array.isArray(nodes[0].value) && nodes[0].value.length)

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/NewInstance.tsx
@@ -75,7 +75,10 @@ const NewInstance = (props: Props) => {
 
         if (annotationTarget) {
             parentClasses = ExtractParentClasses({
-                annotationTarget,
+                annotationTarget: {
+                    ...annotationTarget,
+                    jsonPath: annotationTarget.jsonPath.replace(/\[\d+\]/g, '')
+                },
                 superClass
             });
         }
@@ -118,7 +121,7 @@ const NewInstance = (props: Props) => {
                                     disabled={selected}
                                     className="fs-5 mt-3 py-1 px-3"
                                     OnClick={() => {
-                                        const latestIndex: any = jp.query(superClass, annotationTarget.jsonPath)[0].length;
+                                        const latestIndex: any = jp.query(superClass, annotationTarget.jsonPath)?.[0]?.length ?? 0;
 
                                         /* Reset annotation values */
                                         SetFieldValue?.('annotationValues', {});

--- a/src/components/elements/classProperties/ClassProperties.tsx
+++ b/src/components/elements/classProperties/ClassProperties.tsx
@@ -1,6 +1,7 @@
 /* Import Dependencies */
 import { useState } from 'react';
 import classNames from 'classnames';
+import { upperFirst } from 'lodash';
 import { Card, Row, Col } from 'react-bootstrap';
 
 /* Import Utilities */
@@ -22,7 +23,12 @@ type Props = {
     index?: number,
     title: string,
     taxonAcceptedName?: string,
-    properties: Dict
+    properties: Dict,
+    jsonPaths: {
+        [propertySection: string]: string
+    },
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
@@ -32,10 +38,13 @@ type Props = {
  * @param title The title of the the class properties
  * @param taxonAcceptedName When related to taxonomy, holds the accepted taxonomic name
  * @param properties The class's properties
+ * @param jsonPath The base JSON paths to adhere to for the different targets
+ * @param annotationMode Boolean indicating ig the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
  * @returns JSX Component
  */
 const ClassProperties = (props: Props) => {
-    const { index, title, taxonAcceptedName, properties } = props;
+    const { index, title, taxonAcceptedName, properties, jsonPaths, annotationMode, SetAnnotationTarget } = props;
 
     /* Base variables */
     const [collapsed, setCollapsed] = useState<boolean>(!!(index && index > 0));
@@ -73,6 +82,8 @@ const ClassProperties = (props: Props) => {
                                 {(typeof (properties[Object.keys(properties)[0]]) === 'object') ?
                                     <>
                                         {Object.keys(properties).map(propertyKey => {
+                                            let jsonPath: string = jsonPaths[propertyKey].replace('index', `${index}`);
+
                                             /* Check if level holds an array */
                                             return (
                                                 <div key={propertyKey}>
@@ -80,11 +91,16 @@ const ClassProperties = (props: Props) => {
                                                         properties[propertyKey].map((subInstance: Dict, subIndex: number) => {
                                                             const subKey: string = `subClass_${subIndex}`;
 
+                                                            jsonPath = jsonPath.replace('subIndex', `${subIndex}`);
+
                                                             return (
                                                                 <div key={subKey} className="mt-3">
                                                                     <PropertiesTable
                                                                         title={`${propertyKey} #${subIndex + 1}`}
                                                                         properties={subInstance}
+                                                                        baseJsonPath={jsonPath}
+                                                                        annotationMode={annotationMode}
+                                                                        SetAnnotationTarget={SetAnnotationTarget}
                                                                     />
                                                                 </div>
                                                             );
@@ -93,6 +109,9 @@ const ClassProperties = (props: Props) => {
                                                             <PropertiesTable
                                                                 title={propertyKey}
                                                                 properties={properties[propertyKey as keyof typeof properties] as Dict}
+                                                                baseJsonPath={jsonPath}
+                                                                annotationMode={annotationMode}
+                                                                SetAnnotationTarget={SetAnnotationTarget}
                                                             />
                                                         </div>
                                                     }
@@ -102,6 +121,9 @@ const ClassProperties = (props: Props) => {
                                     </>
                                     : <PropertiesTable title="Properties"
                                         properties={properties}
+                                        baseJsonPath={`${jsonPaths.mainProperties.replace('index', `${index}`)}`}
+                                        annotationMode={annotationMode}
+                                        SetAnnotationTarget={SetAnnotationTarget}
                                     />
                                 }
                             </Col>

--- a/src/components/elements/classProperties/ClassProperties.tsx
+++ b/src/components/elements/classProperties/ClassProperties.tsx
@@ -1,7 +1,6 @@
 /* Import Dependencies */
 import { useState } from 'react';
 import classNames from 'classnames';
-import { upperFirst } from 'lodash';
 import { Card, Row, Col } from 'react-bootstrap';
 
 /* Import Utilities */
@@ -121,7 +120,7 @@ const ClassProperties = (props: Props) => {
                                     </>
                                     : <PropertiesTable title="Properties"
                                         properties={properties}
-                                        baseJsonPath={`${jsonPaths.mainProperties.replace('index', `${index}`)}`}
+                                        baseJsonPath={jsonPaths.mainProperties.replace('index', `${index}`)}
                                         annotationMode={annotationMode}
                                         SetAnnotationTarget={SetAnnotationTarget}
                                     />

--- a/src/components/elements/classProperties/EntityRelationships.tsx
+++ b/src/components/elements/classProperties/EntityRelationships.tsx
@@ -6,6 +6,7 @@ import { Row, Col, Card } from "react-bootstrap";
 
 /* Import Types */
 import { EntityRelationship } from "app/types/EntityRelationship";
+import { Dict } from "app/Types";
 
 /* Import Icons */
 import { faDiagramProject, faTable } from "@fortawesome/free-solid-svg-icons";
@@ -19,25 +20,37 @@ import { Button, RelationalGraph } from "components/elements/customUI/CustomUI";
 type Props = {
     digitalObjectId: string,
     digitalObjectName?: string,
-    digitalObjectEntityRelationships?: EntityRelationship[]
+    digitalObjectEntityRelationships?: EntityRelationship[],
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
 /**
  * Component that renders the entity relationships content block on the digital specimen page
  * @param digitalSpecimen The selected digital specimen
+ * @param annotationMode Boolean indicating ig the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
  * @returns JSX Component
  */
 const EntityRelationships = (props: Props) => {
-    const { digitalObjectId, digitalObjectName, digitalObjectEntityRelationships } = props;
+    const { digitalObjectId, digitalObjectName, digitalObjectEntityRelationships, annotationMode, SetAnnotationTarget } = props;
 
     /* Base variables */
     const [displayMode, setDisplayMode] = useState<'graph' | 'table'>('graph');
-    const entityRelationships: {
+    const visualEntityRelationships: {
         id: string,
         name: string,
         annotation?: boolean
     }[] = [];
+    const entityRelationships: {
+        mainProperties: Dict
+    }[] = [];
+    const jsonPaths: {
+        [propertySection: string]: string
+    } = {
+        mainProperties: "$['ods:hasEntityRelationships'][index]"
+    };
     const centerPiece: {
         id: string,
         label: string
@@ -49,6 +62,10 @@ const EntityRelationships = (props: Props) => {
     /* Craft entity relationships dictionary to iterate over */
     digitalObjectEntityRelationships?.forEach((entityRelationship) => {
         entityRelationships.push({
+            mainProperties: entityRelationship
+        });
+
+        visualEntityRelationships.push({
             id: entityRelationship["ods:relatedResourceURI"] ?? entityRelationship["dwc:relatedResourceID"] ?? entityRelationship["dwc:relationshipOfResource"],
             name: entityRelationship["dwc:relationshipOfResource"] ?? entityRelationship["ods:relatedResourceURI"] ?? entityRelationship["dwc:relatedResourceID"]
         });
@@ -69,15 +86,18 @@ const EntityRelationships = (props: Props) => {
             {displayMode === 'graph' ?
                 <Card className="h-100">
                     <RelationalGraph centerPiece={centerPiece}
-                        relations={entityRelationships}
+                        relations={visualEntityRelationships}
                     />
                 </Card>
                 : <>
                     {entityRelationships.map((entityRelationship, index) => (
-                        <ClassProperties key={entityRelationship.id}
+                        <ClassProperties key={entityRelationship.mainProperties['@id']}
                             index={index}
                             title="entityRelationship"
                             properties={entityRelationship}
+                            jsonPaths={jsonPaths}
+                            annotationMode={annotationMode}
+                            SetAnnotationTarget={SetAnnotationTarget}
                         />
                     ))}
                 </>

--- a/src/components/elements/classProperties/PropertiesTable.tsx
+++ b/src/components/elements/classProperties/PropertiesTable.tsx
@@ -26,7 +26,10 @@ type DataRow = {
 /* Props Typing */
 type Props = {
     title: string,
-    properties: Dict
+    properties: Dict,
+    baseJsonPath: string,
+    annotationMode: boolean,
+    SetAnnotationTarget: Function
 };
 
 
@@ -34,10 +37,13 @@ type Props = {
  * Component that renders a properties table for displaying all properties of a class in key value pairs
  * @param title The title of the class from which the proprties are displayed
  * @param properties The properties dictionary
+ * @param baseJsonPath The base JSON path to build the annotation target from together with the property
+ * @param annotationMode Boolean indicating ig the annotation mode is on
+ * @param SetAnnotationTarget Function to set the annotation target
  * @returns JSX Component
  */
 const PropertiesTable = (props: Props) => {
-    const { title, properties } = props;
+    const { title, properties, baseJsonPath, annotationMode, SetAnnotationTarget } = props;
 
     /* Data table configutation */
     const { columns } = PropertiesTableConfig();
@@ -67,7 +73,7 @@ const PropertiesTable = (props: Props) => {
                         <div className={`${styles.propertiesTable} h-100 overflow-auto position-relative rounded-c}`}>
                             <DataTable columns={columns}
                                 data={tableData}
-                                SelectAction={(_row: DataRow) => {}}
+                                SelectAction={(row: DataRow) => annotationMode && SetAnnotationTarget('term', `${baseJsonPath}['${row.key}']`)}
                             />
                         </div>
                     </Col>

--- a/src/components/elements/topBarActions/TopBarActions.tsx
+++ b/src/components/elements/topBarActions/TopBarActions.tsx
@@ -16,7 +16,7 @@ import { Button, Dropdown } from "../customUI/CustomUI";
 type Props = {
     actionDropdownItems: DropdownItem[],
     annotationMode: boolean,
-    ToggleAnnotationSidePanel: Function
+    ToggleAnnotationMode: Function
 };
 
 
@@ -24,11 +24,11 @@ type Props = {
  * Component that renders the actions of the top bar on the digital specimen and media pages
  * @param actionDropdownItems A list of action items to appear in the actions dropdown
  * @param annotationMode Boolean indicating if annotation mode is on
- * @param ToggleAnnotationSidePanel Function to toggle the annotation side panel
+ * @param ToggleAnnotationMode Function to toggle the annotation mode
  * @returns JSX Component
  */
 const TopBarActions = (props: Props) => {
-    const { actionDropdownItems, annotationMode, ToggleAnnotationSidePanel } = props;
+    const { actionDropdownItems, annotationMode, ToggleAnnotationMode } = props;
 
     return (
         <div>
@@ -50,7 +50,7 @@ const TopBarActions = (props: Props) => {
                 >
                     <Button type="button"
                         variant="primary"
-                        OnClick={() => ToggleAnnotationSidePanel()}
+                        OnClick={() => ToggleAnnotationMode()}
                     >
                         <span>
                             {annotationMode ? 'Stop annotating' : 'Annotate'}

--- a/src/sources/annotationCases/DigitalSpecimenAnnotationCases.json
+++ b/src/sources/annotationCases/DigitalSpecimenAnnotationCases.json
@@ -9,7 +9,7 @@
         {
             "name": "Georeference",
             "type": "class",
-            "jsonPath": "$['ods:hasEvent']['ods:hasLocation']['ods:hasGeoreference']",
+            "jsonPath": "$['ods:hasEvents']['ods:hasLocation']['ods:hasGeoreference']",
             "icon": "faLocationDot"
         },
         {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 
 export default defineConfig({


### PR DESCRIPTION
Adds the annotation mode to the Digital Specimen page to allow for direct targeting of properties from the view.
This includes some slight changes and fixes to the annotation wizard in general.