### PR TITLE
Mjr creator endpoint doesn't explicitly need orcid

### DIFF
--- a/src/api/masJobRecord/GetCreatorMasJobRecords.ts
+++ b/src/api/masJobRecord/GetCreatorMasJobRecords.ts
@@ -22,7 +22,7 @@ const GetCreatorMasJobRecords = async () => {
         try {
             const result = await axios({
                 method: 'get',
-                url: `mjr/v1/creator/${encodeURIComponent(KeycloakService.GetParsedToken()?.orcid)}`,
+                url: `mjr/v1/creator`,
                 responseType: 'json',
                 headers: {
                     'Content-type': 'application/json',


### PR DESCRIPTION
In the backend, `mjr/v1/creator` endpoint uses the authentication token to get the creator ORCID. Sending the orcid in the uri is incorrect.