### PR TITLE
Feature/mas job records

### DIFF
--- a/src/app/config/table/UserMasJobRecordsTableConfig.tsx
+++ b/src/app/config/table/UserMasJobRecordsTableConfig.tsx
@@ -19,8 +19,8 @@ const UserMasJobRecordsTableConfig = () => {
     /* User annotation record type */
     type UserMasJobRecord = {
         targetId: string,
-        scheduled?: string | undefined,
-        completed?: string | undefined,
+        scheduled: string | undefined,
+        completed: string | undefined,
         state: string
     };
 


### PR DESCRIPTION
**In this PR**
- bugfix for the MasJobRecords table on the profile page breaking when one of the table cell values returns an undefined, in this case the 'completed' column. I've added a check on either a value or an undefined. In case of undefined, we set the value to '', to show that there is no value.

**Note**
Testing for these files currently not set up. I am working on a general testing setup that extends the already existing test setup