### PR TITLE
feat: Added export description and adjusted syntax and styling a bit

### DIFF
--- a/src/components/dataExport/DataExport.tsx
+++ b/src/components/dataExport/DataExport.tsx
@@ -31,7 +31,10 @@ const DataExport = () => {
     const trigger = useTrigger();
 
     /* Content */
-    const description = ['The data export function supports downloading a list of digital specimen DOIs together with their physical specimen identifiers for a dataset from a DiSSCo facility. This provides an easy way for DiSSCo facility to download and import the DOIs for their specimens in their catalogs and to provide these with their DarwinCore or ABCD datasets.', 'This ensures a stable link between the specimen record in these datasets and the digital specimen, even if the physical specimen identifier changes. This is important as the specimen record from a DiSSCo facility may be updated and that update should be included in the digital specimen without creating a new digital specimen.']
+    const description = [
+        { paragraph: 'The data export function supports downloading a list of digital specimen DOIs together with their physical specimen identifiers for a dataset from a DiSSCo facility. This provides an easy way for DiSSCo facility to download and import the DOIs for their specimens in their catalogs and to provide these with their DarwinCore or ABCD datasets.', key: 'paragraph-one'},
+        { paragraph: 'This ensures a stable link between the specimen record in these datasets and the digital specimen, even if the physical specimen identifier changes. This is important as the specimen record from a DiSSCo facility may be updated and that update should be included in the digital specimen without creating a new digital specimen.', key: 'paragraph-two'},
+    ]
 
     /* Base variables */
     const [sourceSystemDropdownItems, setSourceSystemDropdownItems] = useState<DropdownItem[]>([]);
@@ -128,9 +131,9 @@ const DataExport = () => {
                                                 <h2 className="fs-2 mb-4 fw-lightBold">
                                                     Export Data
                                                 </h2>
-                                                {description.map((item, index) => (
-                                                    <p className="fs-4 mb-4 mt-2" key={'paragraph-' + index}>
-                                                        {item}
+                                                {description.map((item) => (
+                                                    <p className="fs-4 mb-4 mt-2" key={item.key}>
+                                                        {item.paragraph}
                                                     </p>
                                                 ))}
                                             </Col>

--- a/src/components/dataExport/DataExport.tsx
+++ b/src/components/dataExport/DataExport.tsx
@@ -32,8 +32,18 @@ const DataExport = () => {
 
     /* Content */
     const description = [
-        { paragraph: 'The data export function supports downloading a list of digital specimen DOIs together with their physical specimen identifiers for a dataset from a DiSSCo facility. This provides an easy way for DiSSCo facility to download and import the DOIs for their specimens in their catalogs and to provide these with their DarwinCore or ABCD datasets.', key: 'paragraph-one'},
-        { paragraph: 'This ensures a stable link between the specimen record in these datasets and the digital specimen, even if the physical specimen identifier changes. This is important as the specimen record from a DiSSCo facility may be updated and that update should be included in the digital specimen without creating a new digital specimen.', key: 'paragraph-two'},
+        { 
+            paragraph: 'Here, you may schedule an export of DiSSCo data. The data export function provides an easy way for the DiSSCo facility to download and import identifiers for their specimens in their catalogs and to integrate these with their DarwinCore or ABCD datasets.', 
+            key: 'paragraph-one'
+        },
+        { 
+            paragraph: 'This ensures a stable link between the specimen record in these datasets and the digital specimen, even if the physical specimen identifier changes, ensuring an always up to date digital specimen.', 
+            key: 'paragraph-two'
+        },
+        { 
+            paragraph: 'Select a type of data export for more information. When available, a download link is sent to your email address. No email? Check your spam folder.', 
+            key: 'paragraph-three'
+        },
     ]
 
     /* Base variables */
@@ -141,18 +151,23 @@ const DataExport = () => {
                                         {/* Eport type dropdown */}
                                         <Row className="mt-3">
                                             <Col>
-                                                <p className="fs-4 mb-1">
+                                                <p className="fs-4 mb-1 fw-lightBold">
                                                     Select an export type:
                                                 </p>
                                                 <Dropdown items={exportTypeDropdownItems}
                                                     OnChange={(exportTypeOption: DropdownItem) => setFieldValue('exportType', exportTypeOption.value)}
                                                 />
+                                                {values.exportType === 'DOI_LIST' &&
+                                                    <p className="fs-5 mb-1 mt-3">
+                                                        You will receive a download link to a CSV file with two columns: <code className="tc-primary">dcterms:identifier</code>, which is the DOI of the specimen, and <code className="tc-primary">ods:physicalSpecimenID</code>, the local catalog number used by the source system. This provides a mechanism to match the DiSSCo assigned DOIs with the institutional identifiers.
+                                                    </p>
+                                                }
                                             </Col>
                                         </Row>
                                         {/* Source system dropdown */}
                                         <Row className="mt-3">
                                             <Col>
-                                                <p className="fs-4 mb-1">
+                                                <p className="fs-4 mb-1 fw-lightBold">
                                                     Select a Source System to export from:
                                                 </p>
                                                 {!isEmpty(sourceSystemDropdownItems) &&

--- a/src/components/dataExport/DataExport.tsx
+++ b/src/components/dataExport/DataExport.tsx
@@ -30,7 +30,7 @@ const DataExport = () => {
     const notification = useNotification();
     const trigger = useTrigger();
 
-    /* Content */
+    /* Export type content */
     const description = [
         { 
             paragraph: 'Here, you may schedule an export of digital specimen data. Currently we only support the export of a list of digital specimen DOIs. This provides an easy way for institutions to download and import these in a collection management system or to include these with their DarwinCore or ABCD datasets for e.g. publication in GBIF.', 

--- a/src/components/dataExport/DataExport.tsx
+++ b/src/components/dataExport/DataExport.tsx
@@ -129,7 +129,7 @@ const DataExport = () => {
                                                     Export Data
                                                 </h2>
                                                 {description.map((item, index) => (
-                                                    <p className="fs-4 mb-4 mt-2" key={index}>
+                                                    <p className="fs-4 mb-4 mt-2" key={'paragraph-' + index}>
                                                         {item}
                                                     </p>
                                                 ))}

--- a/src/components/dataExport/DataExport.tsx
+++ b/src/components/dataExport/DataExport.tsx
@@ -30,6 +30,9 @@ const DataExport = () => {
     const notification = useNotification();
     const trigger = useTrigger();
 
+    /* Content */
+    const description = ['The data export function supports downloading a list of digital specimen DOIs together with their physical specimen identifiers for a dataset from a DiSSCo facility. This provides an easy way for DiSSCo facility to download and import the DOIs for their specimens in their catalogs and to provide these with their DarwinCore or ABCD datasets.', 'This ensures a stable link between the specimen record in these datasets and the digital specimen, even if the physical specimen identifier changes. This is important as the specimen record from a DiSSCo facility may be updated and that update should be included in the digital specimen without creating a new digital specimen.']
+
     /* Base variables */
     const [sourceSystemDropdownItems, setSourceSystemDropdownItems] = useState<DropdownItem[]>([]);
     const exportTypeDropdownItems: DropdownItem[] = [
@@ -79,7 +82,7 @@ const DataExport = () => {
 
             <Container fluid className="flex-grow-1 overflow-hidden py-5">
                 <Row className="h-100">
-                    <Col lg={{ span: 4, offset: 4 }}
+                    <Col lg={{ span: 6, offset: 3 }}
                         className="h-100 d-flex align-items-center"
                     >
                         <Formik initialValues={initialValues}
@@ -118,16 +121,18 @@ const DataExport = () => {
                             {({ setFieldValue, values }) => (
                                 <Form>
                                     {/* Data export card */}
-                                    <Card className="w-100 px-3 py-2">
+                                    <Card className="w-100 px-5 py-5">
                                         {/* Title and description */}
                                         <Row>
                                             <Col>
-                                                <p className="fs-2 fw-lightBold">
+                                                <h2 className="fs-2 mb-4 fw-lightBold">
                                                     Export Data
-                                                </p>
-                                                <p className="fs-4 mt-2">
-                                                    Receive a CSV of physical specimen IDs and DiSSCo managed DOIs
-                                                </p>
+                                                </h2>
+                                                {description.map((item, index) => (
+                                                    <p className="fs-4 mb-4 mt-2" key={index}>
+                                                        {item}
+                                                    </p>
+                                                ))}
                                             </Col>
                                         </Row>
                                         {/* Eport type dropdown */}

--- a/src/components/dataExport/DataExport.tsx
+++ b/src/components/dataExport/DataExport.tsx
@@ -33,15 +33,15 @@ const DataExport = () => {
     /* Content */
     const description = [
         { 
-            paragraph: 'Here, you may schedule an export of DiSSCo data. The data export function provides an easy way for the DiSSCo facility to download and import identifiers for their specimens in their catalogs and to integrate these with their DarwinCore or ABCD datasets.', 
+            paragraph: 'Here, you may schedule an export of digital specimen data. Currently we only support the export of a list of digital specimen DOIs. This provides an easy way for institutions to download and import these in a collection management system or to include these with their DarwinCore or ABCD datasets for e.g. publication in GBIF.', 
             key: 'paragraph-one'
         },
         { 
-            paragraph: 'This ensures a stable link between the specimen record in these datasets and the digital specimen, even if the physical specimen identifier changes, ensuring an always up to date digital specimen.', 
+            paragraph: 'This ensures a stable link between the specimen record in these datasets and the digital specimen, even if the physical specimen identifier changes, to avoid digital specimen duplicates.', 
             key: 'paragraph-two'
         },
         { 
-            paragraph: 'Select a type of data export for more information. When available, a download link is sent to your email address. No email? Check your spam folder.', 
+            paragraph: 'Select a data export type to view more information. Once your export is ready, a download link will be sent to your email. Didn’t receive an email? Be sure to check your spam folder.', 
             key: 'paragraph-three'
         },
     ]
@@ -159,7 +159,7 @@ const DataExport = () => {
                                                 />
                                                 {values.exportType === 'DOI_LIST' &&
                                                     <p className="fs-5 mb-1 mt-3">
-                                                        You will receive a download link to a CSV file with two columns: <code className="tc-primary">dcterms:identifier</code>, which is the DOI of the specimen, and <code className="tc-primary">ods:physicalSpecimenID</code>, the local catalog number used by the source system. This provides a mechanism to match the DiSSCo assigned DOIs with the institutional identifiers.
+                                                        You will receive a download link to a CSV file with two columns: <code className="tc-primary">dcterms:identifier</code>, which represents the DOI assigned to the digital specimen, and <code className="tc-primary">ods:physicalSpecimenID</code>, the institutional identifier provided by the source system. This file enables you to match DiSSCo-assigned DOIs with the corresponding institutional identifiers.
                                                     </p>
                                                 }
                                             </Col>


### PR DESCRIPTION
What it now looks like:
![Screenshot from 2025-06-04 11-26-25](https://github.com/user-attachments/assets/3bd81ffe-e011-4cad-bbfa-0320bb29340b)

- Adjusted styling a bit
- Added description and optional description
- Changed syntax to make it more semantic (only a bit)

**Note**
Sourcesystems is not properly mocked locally, only on dev and sandbox, so locally the second dropdown does not work at all.