### PR TITLE
Feature/add doi to specimen

### DIFF
--- a/src/app/config/table/IdentifiersTableConfig.tsx
+++ b/src/app/config/table/IdentifiersTableConfig.tsx
@@ -1,0 +1,34 @@
+/* Import Dependencies */
+import { createColumnHelper } from '@tanstack/react-table';
+
+/* Import Utilities */
+import { RetrieveEnvVariable } from 'app/Utilities';
+
+/**
+ * Config function that sets up the basic table column template for the search results table on the search page
+ * @returns Table columns
+ */
+const IdentifiersTableConfig = () => {
+    /* Search results type */
+    type Identifiers = {
+        DOI: string,
+    };
+
+    /* Base variables */
+    const columnHelper = createColumnHelper<Identifiers>();
+
+    /* Table columns */
+    const columns = [
+        columnHelper.accessor('DOI', {
+            cell: info => info.getValue()?.replace(RetrieveEnvVariable('DOI_URL') as string, ''),
+            meta: {
+                widthInRem: 10,
+                pinned: true
+            }
+        }),
+    ];
+
+    return { columns };
+};
+
+export default IdentifiersTableConfig;

--- a/src/app/config/table/IdentifiersTableConfig.tsx
+++ b/src/app/config/table/IdentifiersTableConfig.tsx
@@ -1,31 +1,37 @@
 /* Import Dependencies */
 import { createColumnHelper } from '@tanstack/react-table';
 
-/* Import Utilities */
-import { RetrieveEnvVariable } from 'app/Utilities';
 
 /**
  * Config function that sets up the basic table column template for the search results table on the search page
  * @returns Table columns
  */
 const IdentifiersTableConfig = () => {
-    /* Search results type */
-    type Identifiers = {
-        DOI: string,
+    /* Property key value pair type */
+    type IdentifierKeyValuePair = {
+        key: string,
+        value: string
     };
 
     /* Base variables */
-    const columnHelper = createColumnHelper<Identifiers>();
+    const columnHelper = createColumnHelper<IdentifierKeyValuePair>();
 
     /* Table columns */
     const columns = [
-        columnHelper.accessor('DOI', {
-            cell: info => info.getValue()?.replace(RetrieveEnvVariable('DOI_URL') as string, ''),
+        columnHelper.accessor('key', {
+            header: 'Identifier type',
             meta: {
                 widthInRem: 10,
                 pinned: true
             }
         }),
+        columnHelper.accessor('value', {
+            header: 'Identifier value',
+            meta: {
+                widthInRem: 10,
+                pinned: true
+            }
+        })
     ];
 
     return { columns };

--- a/src/components/digitalSpecimen/components/contentBlock/ContentBlock.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/ContentBlock.tsx
@@ -9,6 +9,7 @@ import { DigitalSpecimen } from 'app/types/DigitalSpecimen';
 import { Assertions, DigitalSpecimenDigitalMedia, DigitalSpecimenOverview, Events, Identifications } from './ContentBlockComponents';
 import { EntityRelationships } from 'components/elements/Elements';
 import { Tabs } from 'components/elements/customUI/CustomUI';
+import Identifiers from './components/Identifiers';
 
 
 /* Props Type */
@@ -63,7 +64,8 @@ const ContentBlock = (props: Props) => {
                 annotationMode={annotationMode}
                 SetAnnotationTarget={SetAnnotationTarget}
             />
-        })
+        }),
+        'identifiers': <Identifiers digitalSpecimen={digitalSpecimen}/>
     };
 
     return (

--- a/src/components/digitalSpecimen/components/contentBlock/ContentBlock.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/ContentBlock.tsx
@@ -65,7 +65,8 @@ const ContentBlock = (props: Props) => {
                 SetAnnotationTarget={SetAnnotationTarget}
             />
         }),
-        'identifiers': <Identifiers digitalSpecimen={digitalSpecimen}/>
+        'identifiers': <Identifiers digitalSpecimen={digitalSpecimen}
+        />
     };
 
     return (

--- a/src/components/digitalSpecimen/components/contentBlock/components/Identifiers.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/Identifiers.tsx
@@ -1,36 +1,68 @@
-/* Import dependencies */
-import { useState } from 'react';
+/* Import Dependencies */
 import { Card, Row, Col } from 'react-bootstrap';
 
 /* Types */
 import { DigitalSpecimen } from "app/types/DigitalSpecimen";
 
-/* Import Hooks */
-import { useTrigger } from 'app/Hooks';
+/* Import Components */
+import { DataTable } from 'components/elements/customUI/CustomUI';
 
 /* Import Config */
 import IdentifiersTableConfig from 'app/config/table/IdentifiersTableConfig';
 
-/* Import Components */
-import { DataTable } from 'components/elements/customUI/CustomUI';
-
-/* Data table row type */
-type DataRow = {
-    DOI: string,
-};
+/* Import Utilities */
+import { RetrieveEnvVariable } from 'app/Utilities';
 
 /* Props Type */
 type Props = {
     digitalSpecimen: DigitalSpecimen,
 };
 
+/* Identifier key value pair type */
+type DataRow = {
+    key: string | undefined,
+    value: string | undefined
+};
+
 const Identifiers = (props: Props) => {
     const { digitalSpecimen } = props;
 
-    console.log(digitalSpecimen);
+    /* Data table configutation */
+    const { columns } = IdentifiersTableConfig();
+
+    /* Set Table data */
+    const tableData: DataRow[] = [];
+
+    const doi = digitalSpecimen['@id'].replace(RetrieveEnvVariable('DOI_URL'), '');
+    tableData.push({
+        key: 'DOI',
+        value: doi
+    });
+
+    digitalSpecimen['ods:hasIdentifiers']?.forEach((identifier) => {
+        tableData.push({
+            key: identifier['dcterms:type'],
+            value: identifier['@id']
+        });
+    });
+
     return (
         <div className="h-100">
             <Card>
+                <Card.Body>
+                    <Row>
+                        <Col>
+                            <p className="fs-2 fw-lightBold">Identifiers</p>
+                        </Col>
+                    </Row>
+                    <Row className='mt-4'>
+                        <Col>
+                            <DataTable columns={columns}
+                                data={tableData}
+                            />
+                        </Col>
+                    </Row>
+                </Card.Body>
             </Card>
         </div>
     )

--- a/src/components/digitalSpecimen/components/contentBlock/components/Identifiers.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/Identifiers.tsx
@@ -1,0 +1,39 @@
+/* Import dependencies */
+import { useState } from 'react';
+import { Card, Row, Col } from 'react-bootstrap';
+
+/* Types */
+import { DigitalSpecimen } from "app/types/DigitalSpecimen";
+
+/* Import Hooks */
+import { useTrigger } from 'app/Hooks';
+
+/* Import Config */
+import IdentifiersTableConfig from 'app/config/table/IdentifiersTableConfig';
+
+/* Import Components */
+import { DataTable } from 'components/elements/customUI/CustomUI';
+
+/* Data table row type */
+type DataRow = {
+    DOI: string,
+};
+
+/* Props Type */
+type Props = {
+    digitalSpecimen: DigitalSpecimen,
+};
+
+const Identifiers = (props: Props) => {
+    const { digitalSpecimen } = props;
+
+    console.log(digitalSpecimen);
+    return (
+        <div className="h-100">
+            <Card>
+            </Card>
+        </div>
+    )
+}
+
+export default Identifiers;

--- a/src/components/digitalSpecimen/components/topBar/TopBar.tsx
+++ b/src/components/digitalSpecimen/components/topBar/TopBar.tsx
@@ -45,12 +45,15 @@ type Props = {
 const TopBar = (props: Props) => {
     const { digitalSpecimen, annotationMode, ToggleAnnotationMode } = props;
 
+    console.log(digitalSpecimen);
     /* Hooks */
     const navigate = useNavigate();
     const fetch = useFetch();
 
     /* Base variables */
     const [digitalSpecimenVersions, setDigitalSpecimenVersions] = useState<number[] | undefined>();
+    const digitalSpecimenDOI = digitalSpecimen['@id'];
+
     const actionDropdownItems: DropdownItem[] = [
         {
             label: 'View JSON',
@@ -123,6 +126,13 @@ const TopBar = (props: Props) => {
                     <h2 className="fs-pageTitle"
                         dangerouslySetInnerHTML={{ __html: GetSpecimenNameHTMLLabel(digitalSpecimen) }}
                     />
+                </Col>
+            </Row>
+            <Row>
+                <Col>
+                    <span className="fs-4">
+                        {digitalSpecimenDOI.replace(RetrieveEnvVariable('DOI_URL'), '')}
+                    </span>
                 </Col>
             </Row>
             {/* MIDS level, version select, annotations button and actions dropdown */}

--- a/src/components/digitalSpecimen/components/topBar/TopBar.tsx
+++ b/src/components/digitalSpecimen/components/topBar/TopBar.tsx
@@ -45,7 +45,6 @@ type Props = {
 const TopBar = (props: Props) => {
     const { digitalSpecimen, annotationMode, ToggleAnnotationMode } = props;
 
-    console.log(digitalSpecimen);
     /* Hooks */
     const navigate = useNavigate();
     const fetch = useFetch();


### PR DESCRIPTION
Added:
- DOI to the Digital Specimen page in between the title and the MIDS level and version selector
- New tab called identifiers with the DOI and whatever is in 'ods:hasIdentifiers'

What it looks like:
![image](https://github.com/user-attachments/assets/57bb9e69-a451-4381-be76-dc6df33a7355)
