### PR TITLE
fix: Added a check to not confuse the tour dummy data with the annotation data

### DIFF
--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationSummaryStep.tsx
@@ -12,6 +12,7 @@ import { useAppSelector, useTrigger } from 'app/Hooks';
 /* Import Store */
 import { getAnnotationTarget } from 'redux-store/AnnotateSlice';
 import { getAnnotationWizardFormValues } from 'redux-store/TourSlice';
+import { getTourTopic } from 'redux-store/GlobalSlice';
 
 /* Import Types */
 import { Dict, SuperClass } from 'app/Types';
@@ -47,15 +48,20 @@ const AnnotationSummaryStep = (props: Props) => {
 
     /* Base variables */
     const annotationTarget = useAppSelector(getAnnotationTarget);
+    const tourTopic = useAppSelector(getTourTopic);
     const tourAnnotationWizardFormValues = useAppSelector(getAnnotationWizardFormValues);
     let motivationDescription: string;
 
     /* Trigger for tour annotation wizard form values */
     trigger.SetTrigger(() => {
-        if (tourAnnotationWizardFormValues) {
+        /**
+         * Only apply tour values if the annotation tour is active.
+         * This prevents the tour's dummy data from overwriting the user's real data.
+         */
+        if (tourTopic === 'annotate' && tourAnnotationWizardFormValues) {
             AnnotationWizardTourTrigger(tourAnnotationWizardFormValues, SetFieldValue);
         }
-    }, [tourAnnotationWizardFormValues]);
+    }, [tourAnnotationWizardFormValues, tourTopic]);
 
     /* Define motivation description based upon selected motivation, deleting is not part of this */
     switch (formValues?.motivation) {


### PR DESCRIPTION
Crafty bug.

The tour dummy data was bleeding into the user annotation flow, due to state changes updating components. For now, I've added a safe guard to check whether the tour is active or not, and if not, do nothing. But this brings to light a bigger issue: two different ways of 'state management': props and the redux state, and components still in the DOM handling changes, while not active.

So I'll have to think about this, but since we are redesigning the annotation flow, this does not have any priority.