### PR TITLE
[Feature/class annotation panel] Replace annotations for a single identification term with annotations for the entire identification class

### DIFF
--- a/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.test.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.test.tsx
@@ -9,7 +9,6 @@ import { Identification } from "app/types/Identification";
 /* Import Components to be tested */
 import AcceptedIdentification from '../digitalSpecimenOverviewContent/AcceptedIdentification';
 
-
 /**
  * Description of unit tests to validate the Accepted Identification component
  */

--- a/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.test.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.test.tsx
@@ -1,7 +1,7 @@
 /* Import Dependencies */
 import "@testing-library/react/dont-cleanup-after-each";
 import { screen, render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /* Import Types */
 import { Identification } from "app/types/Identification";
@@ -29,7 +29,7 @@ describe("Accepted Identification", () => {
                     'dwc:class': 'Dinosauria',
                     'dwc:order': 'Sauropodomorpha',
                     'dwc:family': 'Diplodocidae',
-                    'dwc:genus': 'Diplodocus'
+                    'dwc:genus': ''
                 }
             ]
         } as Identification,
@@ -39,9 +39,7 @@ describe("Accepted Identification", () => {
         SetAnnotationTarget: vi.fn(),
     };
 
-
-
-    it('renders the Accepted Identification of a digital specimen', async () => {
+    beforeEach(() => {
         render(
             <AcceptedIdentification 
                 acceptedIdentification={mockProps.acceptedIdentification}
@@ -51,12 +49,18 @@ describe("Accepted Identification", () => {
                 SetAnnotationTarget={mockProps.SetAnnotationTarget}
             />
         );
+    })
+
+    it('renders the Accepted Identification of a digital specimen', async () => {
         expect(await screen.findByText('Diplodocus Longus')).toBeInTheDocument();
         expect(await screen.findByText('Animalia')).toBeInTheDocument();
         expect(await screen.findByText('Chordata')).toBeInTheDocument();
         expect(await screen.findByText('Dinosauria')).toBeInTheDocument();
         expect(await screen.findByText('Sauropodomorpha')).toBeInTheDocument();
         expect(await screen.findByText('Diplodocidae')).toBeInTheDocument();
-        expect(await screen.findByText('Diplodocus')).toBeInTheDocument();
+    });
+
+    it('renders a rank available in the data even when it does not have a value', async () => {
+        expect(await screen.findByText('Genus:')).toBeInTheDocument();
     });
 });

--- a/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.test.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.test.tsx
@@ -1,0 +1,62 @@
+/* Import Dependencies */
+import "@testing-library/react/dont-cleanup-after-each";
+import { screen, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+/* Import Types */
+import { Identification } from "app/types/Identification";
+
+/* Import Components to be tested */
+import AcceptedIdentification from '../digitalSpecimenOverviewContent/AcceptedIdentification';
+
+
+/**
+ * Description of unit tests to validate the Accepted Identification component
+ */
+describe("Accepted Identification", () => {
+    const mockProps = {
+        acceptedIdentification: {
+            '@type': 'ods:Identification',
+            'dwc:verbatimIdentification': 'Diplodocus Longus, Marsh 1878',
+            'ods:isVerifiedIdentification': true,
+            'ods:hasTaxonIdentifications': [
+                {
+                    '@type': 'ods:TaxonIdentification',
+                    'dwc:scientificName': 'Diplodocus Longus',
+                    'dwc:scientificNameAuthorship': 'Marsh 1878',
+                    'dwc:kingdom': 'Animalia',
+                    'dwc:phylum': 'Chordata',
+                    'dwc:class': 'Dinosauria',
+                    'dwc:order': 'Sauropodomorpha',
+                    'dwc:family': 'Diplodocidae',
+                    'dwc:genus': 'Diplodocus'
+                }
+            ]
+        } as Identification,
+        acceptedIdentificationIndex: 0,
+        annotationMode: false,
+        digitalSpecimenName: 'Diplodocus Longus',
+        SetAnnotationTarget: vi.fn(),
+    };
+
+
+
+    it('renders the Accepted Identification of a digital specimen', async () => {
+        render(
+            <AcceptedIdentification 
+                acceptedIdentification={mockProps.acceptedIdentification}
+                acceptedIdentificationIndex={mockProps.acceptedIdentificationIndex}
+                digitalSpecimenName={mockProps.digitalSpecimenName}
+                annotationMode={mockProps.annotationMode}
+                SetAnnotationTarget={mockProps.SetAnnotationTarget}
+            />
+        );
+        expect(await screen.findByText('Diplodocus Longus')).toBeInTheDocument();
+        expect(await screen.findByText('Animalia')).toBeInTheDocument();
+        expect(await screen.findByText('Chordata')).toBeInTheDocument();
+        expect(await screen.findByText('Dinosauria')).toBeInTheDocument();
+        expect(await screen.findByText('Sauropodomorpha')).toBeInTheDocument();
+        expect(await screen.findByText('Diplodocidae')).toBeInTheDocument();
+        expect(await screen.findByText('Diplodocus')).toBeInTheDocument();
+    });
+});

--- a/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.tsx
@@ -79,7 +79,7 @@ const AcceptedIdentification = (props: Props) => {
                                 <button type="button"
                                     className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
                                     onClick={() => annotationMode &&
-                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:kingdom']`)
+                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
                                     }
                                 >
                                     <p className="fs-4 textOverflow">
@@ -95,7 +95,7 @@ const AcceptedIdentification = (props: Props) => {
                                 <button type="button"
                                     className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
                                     onClick={() => annotationMode &&
-                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:phylum']`)
+                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
                                     }
                                 >
                                     <p className="fs-4 textOverflow">
@@ -111,7 +111,7 @@ const AcceptedIdentification = (props: Props) => {
                                 <button type="button"
                                     className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
                                     onClick={() => annotationMode &&
-                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:class']`)
+                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
                                     }
                                 >
                                     <p className="fs-4 textOverflow">
@@ -127,7 +127,7 @@ const AcceptedIdentification = (props: Props) => {
                                 <button type="button"
                                     className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
                                     onClick={() => annotationMode &&
-                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:order']`)
+                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
                                     }
                                 >
                                     <p className="fs-4 textOverflow">
@@ -143,7 +143,7 @@ const AcceptedIdentification = (props: Props) => {
                                 <button type="button"
                                     className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
                                     onClick={() => annotationMode &&
-                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:family']`)
+                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
                                     }
                                 >
                                     <p className="fs-4 textOverflow">
@@ -159,7 +159,7 @@ const AcceptedIdentification = (props: Props) => {
                                 <button type="button"
                                     className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
                                     onClick={() => annotationMode &&
-                                        SetAnnotationTarget('term', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]['ods:hasTaxonIdentifications'][0]['dwc:genus']`)
+                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
                                     }
                                 >
                                     <p className="fs-4 textOverflow">

--- a/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/AcceptedIdentification.tsx
@@ -21,6 +21,9 @@ type Props = {
     SetAnnotationTarget: Function
 };
 
+/* Taxonomic Rank Type */
+type TaxonomicRank = 'kingdom' | 'phylum' | 'class' | 'order' | 'family' | 'genus';
+
 
 /**
  * Component that renders the accepted identification in the digital specimen overview on the digital specimen page
@@ -40,6 +43,30 @@ const AcceptedIdentification = (props: Props) => {
         'hover-grey mc-pointer': annotationMode,
         'mc-default': !annotationMode
     });
+
+    const renderTaxonomicRank = (displayName: string, rank: TaxonomicRank, isGenus: boolean = false) => (
+            <Row>
+                <Col>
+                    <button type="button"
+                        className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
+                        onClick={() => annotationMode &&
+                            SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
+                        }
+                    >
+                        {isGenus && 
+                        <p className="fs-4 textOverflow">
+                            <span className="fw-lightBold">{displayName}: </span>
+                            <span dangerouslySetInnerHTML={{__html: GetSpecimenGenusLabel(acceptedIdentification)}} />
+                        </p>}
+                        {!isGenus && 
+                        <p className="fs-4 textOverflow">
+                            <span className="fw-lightBold">{displayName}: </span>
+                            {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0][`dwc:${rank}`]}
+                        </p>}
+                    </button>
+                </Col>
+            </Row>
+    );
 
     return (
         <div className="h-100 d-flex flex-column">
@@ -74,101 +101,17 @@ const AcceptedIdentification = (props: Props) => {
                 >
                     <div className="h-100 d-flex flex-column justify-content-between">
                         {/* Kingdom */}
-                        <Row>
-                            <Col>
-                                <button type="button"
-                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
-                                    onClick={() => annotationMode &&
-                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
-                                    }
-                                >
-                                    <p className="fs-4 textOverflow">
-                                        <span className="fw-lightBold">Kingdom: </span>
-                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:kingdom"]}
-                                    </p>
-                                </button>
-                            </Col>
-                        </Row>
+                        {renderTaxonomicRank('Kingdom', 'kingdom')}
                         {/* Phylum */}
-                        <Row>
-                            <Col>
-                                <button type="button"
-                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
-                                    onClick={() => annotationMode &&
-                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
-                                    }
-                                >
-                                    <p className="fs-4 textOverflow">
-                                        <span className="fw-lightBold">Phylum: </span>
-                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:phylum"]}
-                                    </p>
-                                </button>
-                            </Col>
-                        </Row>
+                        {renderTaxonomicRank('Phylum', 'phylum')}
                         {/* Class */}
-                        <Row>
-                            <Col>
-                                <button type="button"
-                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
-                                    onClick={() => annotationMode &&
-                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
-                                    }
-                                >
-                                    <p className="fs-4 textOverflow">
-                                        <span className="fw-lightBold">Class: </span>
-                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:class"]}
-                                    </p>
-                                </button>
-                            </Col>
-                        </Row>
+                        {renderTaxonomicRank('Class', 'class')}
                         {/* Order */}
-                        <Row>
-                            <Col>
-                                <button type="button"
-                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
-                                    onClick={() => annotationMode &&
-                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
-                                    }
-                                >
-                                    <p className="fs-4 textOverflow">
-                                        <span className="fw-lightBold">Order: </span>
-                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:order"]}
-                                    </p>
-                                </button>
-                            </Col>
-                        </Row>
+                        {renderTaxonomicRank('Order', 'order')}
                         {/* Family */}
-                        <Row>
-                            <Col>
-                                <button type="button"
-                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
-                                    onClick={() => annotationMode &&
-                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
-                                    }
-                                >
-                                    <p className="fs-4 textOverflow">
-                                        <span className="fw-lightBold">Family: </span>
-                                        {acceptedIdentification["ods:hasTaxonIdentifications"]?.[0]["dwc:family"]}
-                                    </p>
-                                </button>
-                            </Col>
-                        </Row>
+                        {renderTaxonomicRank('Family', 'family')}
                         {/* Genus */}
-                        <Row>
-                            <Col>
-                                <button type="button"
-                                    className={`${overviewItemButtonClass} button-no-style textOverflow px-0 py-0 overflow-hidden`}
-                                    onClick={() => annotationMode &&
-                                        SetAnnotationTarget('class', `$['ods:hasIdentifications'][${acceptedIdentificationIndex}]`)
-                                    }
-                                >
-                                    <p className="fs-4 textOverflow">
-                                        <span className="fw-lightBold">Genus: </span>
-                                        <span dangerouslySetInnerHTML={{__html: GetSpecimenGenusLabel(acceptedIdentification)}} />
-                                    </p>
-                                </button>
-                            </Col>
-                        </Row>
+                        {renderTaxonomicRank('Genus', 'genus', true)}
                     </div>
                 </Col>
             </Row>


### PR DESCRIPTION
**In this PR:**
- Changed the annotationTarget in AcceptedIdentification.tsx from a single specific term to the more generic identification class as part of our first change towards a new annotation flow.
- Added a unit test file to simply test whether the AcceptedIdentification.tsx component is rendering the accepted identification values of a digital specimen.
- Made the render function in AcceptedIdentification.tsx a bit shorter.
