### PR TITLE
bug: cleared the digital specimen when closing the id card panel

### DIFF
--- a/src/components/search/components/idCard/IdCard.tsx
+++ b/src/components/search/components/idCard/IdCard.tsx
@@ -81,7 +81,7 @@ const IdCard = () => {
                             variant="blank"
                             className="py-0 px-0"
                             OnClick={() => {
-                                dispatch(setDigitalSpecimenComplete(undefined));
+                                dispatch(setDigitalSpecimenComplete({ digitalSpecimen: undefined, digitalMedia: [], annotations: [] }));
                                 dispatch(setSearchDigitalSpecimen(undefined));
                             }}
                         >


### PR DESCRIPTION
Problem:
Map stayed open when clicking on the close button of the id card in the search results.
I might have been the culprit for this bug however. And the fix turned out to be fairly simple.
I was not clearing the state appropriately.