### PR TITLE
feat: reduced calls to /full by checking if the data is available already

### DIFF
--- a/src/components/digitalSpecimen/DigitalSpecimen.tsx
+++ b/src/components/digitalSpecimen/DigitalSpecimen.tsx
@@ -4,6 +4,9 @@ import { useState } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 
+/* Import Utilities */
+import { RetrieveEnvVariable } from 'app/Utilities';
+
 /* Import Hooks */
 import { useAppSelector, useAppDispatch, useFetch } from 'app/Hooks';
 
@@ -61,25 +64,29 @@ const DigitalSpecimen = () => {
             title: 'Machine Annotation Services'
         }
     ];
+    const handle: string = `${params.prefix}/${params.suffix}`;
+    const storedHandle: string | undefined = digitalSpecimen?.['@id']?.replace(RetrieveEnvVariable('DOI_URL'), '');
 
-    /* OnLoad, fetch digital specimen data */
+    /* OnLoad, fetch digital specimen data if the digitalSpecimen data with the current handle is not already in the store*/
     fetch.FetchMultiple({
-        callMethods: [
+        callMethods: (storedHandle !== handle) ? [
             {
                 alias: 'digitalSpecimenComplete',
                 params: {
-                    handle: `${params.prefix}/${params.suffix}`,
+                    handle,
                     version: params.version
                 },
                 Method: GetDigitalSpecimenComplete
             },
-        ],
-        triggers: [params.version],
+        ] : [],
+        triggers: [handle, params.version],
         Handler: (results: {
-            digitalSpecimenComplete: DigitalSpecimenCompleteResult,
+            digitalSpecimenComplete?: DigitalSpecimenCompleteResult,
         }) => {
-            /* Dispatch digital specimen */
-            dispatch(setDigitalSpecimenComplete(results.digitalSpecimenComplete));
+            if (results.digitalSpecimenComplete) {
+                /* Dispatch digital specimen */
+                dispatch(setDigitalSpecimenComplete(results.digitalSpecimenComplete));
+            }
         }
     });
     


### PR DESCRIPTION
**Problem**:
Amount of calls to /full endpoint (to retrieve all Digital Specimen data of one individual specimen) needed to be reduced, because this endpoint was called more than 3 times for no reason.

**Solution**:
I've added a condition to the fetch hook in DigitalSpecimen.tsx. It checks whether the data of a specific DOI is in the store, and if so, it will not call the method GetDigitalSpecimenComplete.

**Notes**:
The fetch is still for multiple and not for a single fetch call. Apparently the single fetch.fetch has a hard time with conditions. 