### PR TITLE
bug: Removed the flagsapi and flags images because it does not work with our data

### DIFF
--- a/src/components/digitalSpecimen/components/contentBlock/components/DigitalSpecimenOverview.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/DigitalSpecimenOverview.tsx
@@ -157,14 +157,6 @@ const DigitalSpecimenOverview = (props: Props) => {
                             <Col>
                                 <p className="tc-accent fw-lightBold">Origin</p>
                             </Col>
-                            {collectionEvent?.['ods:hasLocation']?.['dwc:countryCode'] &&
-                                <Col lg="auto">
-                                    <img src={`https://flagsapi.com/${collectionEvent['ods:hasLocation']['dwc:countryCode']}/shiny/64.png`}
-                                        alt="Flag icon of country"
-                                        className={styles.countryFlag}
-                                    />
-                                </Col>
-                            }
                         </Row>
                         {/* Fields */}
                         <Row className="mt-2">

--- a/src/components/digitalSpecimen/components/contentBlock/components/DigitalSpecimenOverview.tsx
+++ b/src/components/digitalSpecimen/components/contentBlock/components/DigitalSpecimenOverview.tsx
@@ -14,9 +14,6 @@ import { Event } from 'app/types/Event';
 /* Import Icons */
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 
-/* Import Styles */
-import styles from './digitalSpecimenOverviewContent/digitalSpecimenOverview.module.scss';
-
 /* Import Components */
 import AcceptedIdentification from './digitalSpecimenOverviewContent/AcceptedIdentification';
 import { Button, OpenStreetMap, Tooltip } from 'components/elements/customUI/CustomUI';

--- a/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/digitalSpecimenOverview.module.scss
+++ b/src/components/digitalSpecimen/components/contentBlock/components/digitalSpecimenOverviewContent/digitalSpecimenOverview.module.scss
@@ -3,7 +3,3 @@
 .taxonomicTreeBranch {
     width: 10px;
 }
-
-.countryFlag {
-    height: 2rem;
-}


### PR DESCRIPTION
Problem:
- Flagsapi expects the Iso alpha 2 country codes (ex.: NL), while we either get Iso alpha 2, alpha 3 (ex. NLD) or no country codes in our data, meaning that the flagsapi doesn't always work.

Solution:
- Instead of writing a condition to make it work with all three known cases, I chose to remove the flagsapi all together, because we are currently working with users. If we get feedback from them that they'd like to have a visual component relating to the country, we can revisit the idea and see if we can figure out a new solution.