### PR TITLE
bug: Removed css-font-loading-module since typescript already has built in support for this

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
-        "@types/css-font-loading-module": "^0.0.14",
         "@types/cytoscape": "^3.21.8",
         "@types/jsonpath": "^0.2.4",
         "@types/leaflet": "^1.9.15",
@@ -2959,13 +2958,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/css-font-loading-module": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.14.tgz",
-      "integrity": "sha512-+EwJ/RW2vPqbYn0JXRHy593huPCtgmLF/kg57iLK9KUn6neTqGGOTZ0CbssP8Uou/gqT/5XmWKQ8A7ve7xNV6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/cytoscape": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
-    "@types/css-font-loading-module": "^0.0.14",
     "@types/cytoscape": "^3.21.8",
     "@types/jsonpath": "^0.2.4",
     "@types/leaflet": "^1.9.15",


### PR DESCRIPTION
One of the newer versions of TS has built-in support for FontFace. I was running into the issue that type FontFace was now declared twice. So after some research, I found that I can uninstall the module @types/css-font-loading-module.