### PR TITLE
bug: forget the digital specimen if I close search

### DIFF
--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -21,6 +21,7 @@ import { Header, Footer } from 'components/elements/Elements';
 import { AdvancedSearch, DatasetDisclaimer, Introduction, SearchBar, TopicFilters } from './components/HomeComponents';
 import { Button } from 'components/elements/customUI/CustomUI';
 
+
 /**
  * Base component that renders the Home page
  * @returns JSX Component

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -1,12 +1,14 @@
 /* Import Dependencies */
 import classNames from 'classnames';
 import { Container, Row, Col } from 'react-bootstrap';
+import { useEffect } from 'react';
 
 /* Import Hooks */
 import { useAppDispatch, useAppSelector, usePagination } from 'app/Hooks';
 
 /* Import Store */
 import { getSearchDigitalSpecimen, getCompareDigitalSpecimen, setSearchDigitalSpecimen } from 'redux-store/SearchSlice';
+import { getDigitalSpecimen, setDigitalSpecimenComplete } from 'redux-store/DigitalSpecimenSlice';
 
 /* Import Types */
 import { TourTopic } from 'app/Types';
@@ -22,8 +24,6 @@ import SearchTourSteps from './tourSteps/SearchTourSteps';
 import CompareTourSteps from './tourSteps/CompareTourSteps';
 import { CompareDigitalSpecimenMenu, IdCard, SearchFiltersMenu, SearchResults, TopBar } from './components/SearchComponents';
 import { BreadCrumbs, Footer, Header } from "components/elements/Elements";
-import { useEffect } from 'react';
-import { getDigitalSpecimen, setDigitalSpecimenComplete } from 'redux-store/DigitalSpecimenSlice';
 
 
 /**
@@ -31,6 +31,9 @@ import { getDigitalSpecimen, setDigitalSpecimenComplete } from 'redux-store/Digi
  * @returns JSX Component
  */
 const Search = () => {
+    /* Hooks */
+    const dispatch = useAppDispatch();
+
     /* Base variables */
     const searchDigitalSpecimen = useAppSelector(getSearchDigitalSpecimen);
     const compareDigitalSpecimen = useAppSelector(getCompareDigitalSpecimen);
@@ -50,9 +53,6 @@ const Search = () => {
             dispatch(setSearchDigitalSpecimen(undefined));
         }; 
     }, []);
-
-    /* Hooks */
-    const dispatch = useAppDispatch();
 
     /* OnLoad: setup pagination */
     const pagination = usePagination({


### PR DESCRIPTION
Problem:
Whenever we use the search of disscover, and we select a digital specimen, that digital specimen is saved in the store of the app. This is expected behavior. However, when we return to the homepage or do something else in the application besides searching, selecting and viewing a digital specimen, that specific digital specimen that I selected earlier is still saved.

Solution:
I want to clean up the selected digital specimen when I go out of the search flow. I don't need to remember which specimen I selected earlier, if I am already in a different flow.
