### PR TITLE
bug: made the hasBody property in annotations optional, because deleting does not have a body

### DIFF
--- a/src/app/Types.ts
+++ b/src/app/Types.ts
@@ -101,7 +101,7 @@ export type AnnotationTarget = {
     annotation?: {
         id: string,
         motivation: string,
-        values: string[]
+        values: string[] | undefined
     }
 };
 

--- a/src/app/types/Annotation.d.ts
+++ b/src/app/types/Annotation.d.ts
@@ -46,7 +46,7 @@ export interface Annotation {
    */
   "oa:motivatedBy"?: string;
   "oa:hasTarget": AnnotationTarget;
-  "oa:hasBody": AnnotationBody;
+  "oa:hasBody"?: AnnotationBody | undefined;
   "dcterms:creator": Agent;
   /**
    * The date and time when the annotation was created, following the ISO Date Time Format yyyy-MM-dd'T'HH:mm:ss.SSSXXX

--- a/src/app/utilities/AnnotateUtilities.ts
+++ b/src/app/utilities/AnnotateUtilities.ts
@@ -431,7 +431,7 @@ const ReformatToAnnotoriousAnnotation = (annotation: Annotation, mediaUrl: strin
             type: 'Annotation',
             body: [{
                 type: 'TextualBody',
-                value: annotation['oa:hasBody']['oa:value'][0] ?? '',
+                value: annotation['oa:hasBody']?.['oa:value'][0] ?? '',
                 purpose: 'commenting',
                 creator: {
                     id: annotation['dcterms:creator']['@id'] ?? ''

--- a/src/components/elements/annotationSidePanel/components/AnnotationCard.tsx
+++ b/src/components/elements/annotationSidePanel/components/AnnotationCard.tsx
@@ -107,7 +107,7 @@ const AnnotationCard = (props: Props) => {
                             {annotation['oa:hasTarget']['oa:hasSelector']?.['@type'] === 'oa:FragmentSelector' && 'Image'}
                         </span>
                     </Col>
-                    {(annotation['oa:hasTarget']['oa:hasSelector']?.['@type'] === 'ods:ClassSelector' && Object.keys(JSON.parse(annotation['oa:hasBody']['oa:value'][0])).length >= 3) &&
+                    {(annotation['oa:hasTarget']['oa:hasSelector']?.['@type'] === 'ods:ClassSelector' && (annotation['oa:hasBody']?.['oa:value']?.[0] ? Object.keys(JSON.parse(annotation['oa:hasBody']['oa:value'][0])).length >= 3 : false)) &&
                         <Col lg="auto">
                             <Button type="button"
                                 variant="blank"
@@ -128,13 +128,14 @@ const AnnotationCard = (props: Props) => {
                         {/* Render annotation content based on target type */}
                         {annotation['oa:hasTarget']['oa:hasSelector']?.['@type'] === 'ods:TermSelector' &&
                             <p className="fs-4">
-                                {annotation['oa:hasBody']['oa:value']}
+                                {annotation['oa:hasBody']?.['oa:value']}
                             </p>
                         }
                         {annotation['oa:hasTarget']['oa:hasSelector']?.['@type'] === 'ods:ClassSelector' &&
                             <div>
-                                {Object.entries(JSON.parse(annotation['oa:hasBody']['oa:value'][0])).map(([key, value], index) => {
-                                    if (showAllValues || index < 3) {
+                                {annotation['oa:hasBody']?.['oa:value']?.[0] &&
+                                    Object.entries(JSON.parse(annotation['oa:hasBody']['oa:value'][0])).map(([key, value], index) => {
+                                        if (showAllValues || index < 3) {
                                         return (
                                             <p key={key}
                                                 className="fs-4"
@@ -145,8 +146,8 @@ const AnnotationCard = (props: Props) => {
                                                 {`${value}`}
                                             </p>
                                         );
-                                    }
-                                })}
+                                        }
+                                    })}
                             </div>
                         }
                     </Col>

--- a/src/components/elements/annotationSidePanel/components/AnnotationsOverview.tsx
+++ b/src/components/elements/annotationSidePanel/components/AnnotationsOverview.tsx
@@ -136,7 +136,7 @@ const AnnotationsOverview = (props: Props) => {
             annotation: {
                 id: annotation["@id"],
                 motivation: annotation["oa:motivation"],
-                values: annotation["oa:hasBody"]["oa:value"]
+                values: annotation["oa:hasBody"]?.["oa:value"]
             }
         }));
 

--- a/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
+++ b/src/components/elements/annotationSidePanel/components/annotationWizard/steps/AnnotationFormStep.tsx
@@ -85,7 +85,7 @@ const AnnotationFormStep = (props: Props) => {
             const countIndication: string = Array.isArray(currentValue) ? `[${currentValue.length}]` : '';
 
             jsonPath = `${jsonPath}${countIndication}`;
-            const value = annotationTarget.annotation.values[0].startsWith('{') ? JSON.parse(annotationTarget.annotation.values[0]) : annotationTarget.annotation.values[0];
+            const value = annotationTarget.annotation.values?.[0].startsWith('{') ? JSON.parse(annotationTarget.annotation.values[0]) : annotationTarget.annotation.values?.[0];
 
             if (jsonPath === '$' && !formValues.annotationValues.value) {
                 formValues.annotationValues.value = value;

--- a/src/components/elements/digitalMedia/ImagePopup.tsx
+++ b/src/components/elements/digitalMedia/ImagePopup.tsx
@@ -69,7 +69,7 @@ const ImagePopup = (props: Props) => {
     const initialFormValues: {
         annotationValue: string
     } = {
-        annotationValue: annotation ? annotation["oa:hasBody"]["oa:value"][0] : ''
+        annotationValue: annotation?.["oa:hasBody"] ? annotation["oa:hasBody"]["oa:value"][0] : ''
     };
     let userTag: string = annotation?.['dcterms:creator']['schema:name'] ?? annotation?.['dcterms:creator']['@id'] ?? '';
 
@@ -165,7 +165,7 @@ const ImagePopup = (props: Props) => {
                                 <Col>
                                     <p className="fs-4">
                                         <span className="fw-bold">Value: </span>
-                                        {annotation["oa:hasBody"]["oa:value"][0]}
+                                        {annotation["oa:hasBody"]?.["oa:value"][0]}
                                     </p>
                                 </Col>
                             </Row>


### PR DESCRIPTION
Problem:
Whenever a digital specimen has an annotation of motivation 'ods:deleting', the hasBody property is missing from the response. This breaks the frontend, since the interface of Annotation is expecting the hasBody property. With 'breaking' I mean that the frontend does not show you anything anymore.

Solution:
I kept the current functionality working by making the hasBody property for Annotations optional. If there is no hasBody, you can now still view the annotation, but it does not show you all the information (which makes sense, because a deleting annotation does not have more info to show you).

How it now looks:
<img width="1794" height="926" alt="image" src="https://github.com/user-attachments/assets/566d1673-78f2-470e-a7a4-ea2bd7c8044e" />
