### PR TITLE
feat: Added catalog number if existent to the Digital Specimen Overview page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -150,6 +150,10 @@ button {
   font-weight: 500;
 }
 
+.fw-bold {
+  font-weight: 700;
+}
+
 /* Text overflow */
 .horizontalScroll {
   overflow-x: auto;

--- a/src/components/digitalSpecimen/components/topBar/TopBar.tsx
+++ b/src/components/digitalSpecimen/components/topBar/TopBar.tsx
@@ -13,7 +13,7 @@ import { GetSpecimenNameHTMLLabel } from "app/utilities/NomenclaturalUtilities";
 import { useFetch } from "app/Hooks";
 
 /* Import Types */
-import { DigitalSpecimen } from "app/types/DigitalSpecimen";
+import { DigitalSpecimen, Identifier2 } from "app/types/DigitalSpecimen";
 import { DropdownItem } from "app/Types";
 
 /* Import Icons */
@@ -63,6 +63,7 @@ const TopBar = (props: Props) => {
             action: () => DownloadDigitalSpecimenAsJSON()
         }
     ];
+    const catalogNumber: Identifier2 | undefined = digitalSpecimen['ods:hasIdentifiers']?.find(item => item['dcterms:title'] === 'dwc:catalogNumber');
 
     /* Construct version dropdown items */
     const versionDropdownItems: DropdownItem[] | undefined = digitalSpecimenVersions?.map(digitalSpecimenVersion => ({
@@ -125,11 +126,24 @@ const TopBar = (props: Props) => {
                     />
                 </Col>
             </Row>
-            <Row>
-                <Col>
-                    <span className="fs-4">
-                        {digitalSpecimen['@id'].replace(RetrieveEnvVariable('DOI_URL'), '')}
-                    </span>
+            <Row className="mt-2">
+                <Col lg={{ span: 3 }}>
+                    <Row>
+                        <Col lg="auto">
+                            <span className="fw-bold fs-4">DOI: </span>
+                            <span className="fs-4">
+                                {digitalSpecimen['@id'].replace(RetrieveEnvVariable('DOI_URL'), '')}
+                            </span>
+                        </Col>
+                        {catalogNumber &&
+                            <Col lg="auto">
+                                <span className="fw-bold fs-4">Catalog Number: </span>
+                                <span className="fs-4">
+                                    {catalogNumber?.['dcterms:identifier']}
+                                </span>
+                            </Col>
+                        }
+                    </Row>
                 </Col>
             </Row>
             {/* MIDS level, version select, annotations button and actions dropdown */}


### PR DESCRIPTION
Users want to see not only the DOI of a digital specimen, but also the local identifier. In this case, we are showing the catalog number, if there is any. 

The way it looks:
<img width="719" height="442" alt="image" src="https://github.com/user-attachments/assets/c542a949-7a8c-4a78-9b17-02c851ca09b8" />
