### PR TITLE
bug: Forgetting digital specimen now also when you go to the homepage to clean up

### DIFF
--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -1,13 +1,13 @@
 /* Import Dependencies */
 import { Formik, Form } from 'formik';
 import { capitalize } from 'lodash';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Container, Row, Col } from 'react-bootstrap';
 import CountUp from 'react-countup';
 import { useNavigate } from 'react-router-dom';
 
 /* Import Hooks */
-import { useFetch } from 'app/Hooks';
+import { useAppDispatch, useAppSelector, useFetch } from 'app/Hooks';
 
 /* Import Types */
 import { TourTopic, Dict } from 'app/Types';
@@ -21,6 +21,9 @@ import { Header, Footer } from 'components/elements/Elements';
 import { AdvancedSearch, DatasetDisclaimer, Introduction, SearchBar, TopicFilters } from './components/HomeComponents';
 import { Button } from 'components/elements/customUI/CustomUI';
 
+/* Import Store */
+import { getDigitalSpecimen, setDigitalSpecimenComplete } from 'redux-store/DigitalSpecimenSlice';
+import { setSearchDigitalSpecimen } from 'redux-store/SearchSlice';
 
 /**
  * Base component that renders the Home page
@@ -30,6 +33,7 @@ const Home = () => {
     /* Hooks */
     const navigate = useNavigate();
     const fetch = useFetch();
+    const dispatch = useAppDispatch();
 
     /* Base variables */
     const [digitalSpecimenDisciplines, setDigitalSpecimenDisciplines] = useState<{
@@ -51,6 +55,15 @@ const Home = () => {
         name: 'home',
         title: 'About This Page'
     }];
+    const digitalSpecimen = useAppSelector(getDigitalSpecimen);
+
+    /* Clean up digital specimen in store to start fresh */
+    useEffect(() => {
+        if (digitalSpecimen) {
+            dispatch(setDigitalSpecimenComplete({ digitalSpecimen: undefined, digitalMedia: [], annotations: [] }));
+            dispatch(setSearchDigitalSpecimen(undefined));
+        }; 
+    }, []);
 
     /* OnLoad, fetch digital specimen disciplines */
     fetch.Fetch({

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -23,7 +23,6 @@ import { Button } from 'components/elements/customUI/CustomUI';
 
 /* Import Store */
 import { getDigitalSpecimen, setDigitalSpecimenComplete } from 'redux-store/DigitalSpecimenSlice';
-import { setSearchDigitalSpecimen } from 'redux-store/SearchSlice';
 
 /**
  * Base component that renders the Home page
@@ -61,7 +60,6 @@ const Home = () => {
     useEffect(() => {
         if (digitalSpecimen) {
             dispatch(setDigitalSpecimenComplete({ digitalSpecimen: undefined, digitalMedia: [], annotations: [] }));
-            dispatch(setSearchDigitalSpecimen(undefined));
         }; 
     }, []);
 


### PR DESCRIPTION
The selected digital specimen was remembered throughout the app. In some cases this is what we want, in other cases it leads to side effects.
One of those side effects is that the geoMap is not properly cleaned up, since it is based on data in the digitalSpecimen object in the store.
I had fixed this already for when you navigate to the search page, but now I've also fixed it for when you go to the homepage. It is the same fix: set the DigitalSpecimen object in the store to undefined when we go to the homepage.
Ideally we want to reuse this functionality a bit nicer, but I had a hard time finding a good spot for it.