### PR TITLE
Bugfix/versions

### DIFF
--- a/src/components/digitalSpecimen/DigitalSpecimen.tsx
+++ b/src/components/digitalSpecimen/DigitalSpecimen.tsx
@@ -67,12 +67,7 @@ const DigitalSpecimen = () => {
     const handle: string = `${params.prefix}/${params.suffix}`;
     const storedHandle: string | undefined = digitalSpecimen?.['@id']?.replace(RetrieveEnvVariable('DOI_URL'), '');
     const isDifferentVersion: boolean = params.version !== digitalSpecimen?.['ods:version'].toString();
-    console.log('params version', params.version, digitalSpecimen?.['ods:version'].toString());
-    console.log(storedHandle !== handle);
-    console.log(location.href);
-    console.log(storedHandle !== handle || isDifferentVersion);
-    console.log(params.version !== digitalSpecimen?.['ods:version'].toString());
-    console.log(isDifferentVersion);
+
     /* OnLoad, fetch digital specimen data if the digitalSpecimen data with the current handle is not already in the store*/
     fetch.FetchMultiple({
         callMethods: (storedHandle !== handle || isDifferentVersion) ? [


### PR DESCRIPTION
Problem:
When selecting another version of a specimen, it didn't do a new call to the /full endpoint with that specific version but stayed on the current version. 

Solution:
This issue occurred due to a missing check on whether the version has changed. There is a condition on retrieving digitalSpecimen info, and if there already is some info in the store, it does not retrieve it again. But the condition didn't check on version changes.
So now I've added a condition on whether the version of the current digitalSpecimen has changed.