### PR TITLE
feat: Added share this list functionality to the search page

### DIFF
--- a/src/components/search/components/topBar/TopBar.tsx
+++ b/src/components/search/components/topBar/TopBar.tsx
@@ -109,7 +109,7 @@ const TopBar = () => {
                                             dispatch(setCompareDigitalSpecimen(compareDigitalSpecimen ? undefined : []))
                                         }}
                                     >
-                                        {!compareDigitalSpecimen ? 'Compare' : 'Cancel Compare'}
+                                        {compareDigitalSpecimen ? 'Cancel Compare' : 'Compare'}
                                     </Button>
                                 </Col>
                             </Row>


### PR DESCRIPTION
**Jira story**: [Here](https://naturalis.atlassian.net/browse/DD-2178?atlOrigin=eyJpIjoiYmZmODY0NjA1YTU3NDIxNThhYmJjZGU2YTA3MTA2YjgiLCJwIjoiaiJ9)

**Design**: [Here] (https://www.figma.com/design/1qmvLLyKGkCOGgCkPnGoNK/Annotation-flow--improvements?node-id=1-29)

What is in this pr:
I added a 'share this list' button with a tooltip and an icon (not exactly the same as in the design, because we already use this one for the citation) that copies the url to the clipboard so that the user can share the exact search query with other people. When you open the url copied, it opens the search of DiSSCover including any selected filters.

**How it looks now:**
https://github.com/user-attachments/assets/2236e73b-99d0-4221-8d63-51e65df8d9ce

