### PR TITLE
bugfix: Added a check for pending annotations when refreshing annotations

### DIFF
--- a/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
+++ b/src/components/elements/annotationSidePanel/AnnotationSidePanel.tsx
@@ -125,7 +125,7 @@ export const AnnotationSidePanel = (props: Props) => {
         const annotations = await GetAnnotations({
             handle: superClass?.['@id'].replace(RetrieveEnvVariable('DOI_URL'), '')
         });
-        superClass['@type'] === 'ods:DigitalSpecimen' ? setAnnotations(annotations.annotations) : setAnnotations(annotations);
+        superClass['@type'] === 'ods:DigitalSpecimen' ? handlePendingAnnotations(annotations.annotations) : handlePendingAnnotations(annotations);
         setLoading(false);
     };
 


### PR DESCRIPTION
Tiniest PR.

Checks on any open pending annotations, instead of setting the state to all annotations returned by the api.