### PR TITLE
Reset the spacing on a p tag as it was misforming the ui

### DIFF
--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -19,6 +19,8 @@
 p {
     font-weight: var(--regular-font-weight);
     font-size: var(--md-font-size);
+    margin: 0px;
+    padding: 0px;
 }
 
 /* Headings */


### PR DESCRIPTION
**Changed this spacing:**
<img width="194" height="87" alt="image" src="https://github.com/user-attachments/assets/de8e9c09-32c3-4bd0-a2bc-2a71e79f35cf" />

**To this:**
<img width="194" height="87" alt="image" src="https://github.com/user-attachments/assets/709ed799-0bfc-4573-80d9-e73b2743708d" />

