### PR TITLE
Refactor of GetDigitalSpecimenComplete service and setup of data mapper to UI

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -22,3 +22,6 @@ CVE-2026-33671
 # Vulnerability in image dependency libpng that is included in the image and we cannot fix Apr-1-2026
 CVE-2026-33416
 CVE-2026-33636
+
+# lodash-es is pinned as a dependency on a vulnerable version in formik and cannot be upgraded by us Apr-3-2026
+CVE-2026-4800

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-query": "^5.90.20",
         "@tanstack/react-table": "^8.20.5",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "bootstrap": "^5.3.3",
         "bootstrap-css": "^4.0.0-alpha.5",
         "classnames": "^2.5.1",
@@ -5716,14 +5716,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -10604,10 +10604,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "jsonpath": "^1.1.1",
         "keycloak-js": "^26.0.7",
         "leaflet": "^1.9.4",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "moment": "^2.30.1",
         "msw": "^2.6.7",
         "openseadragon": "^5.0.0",
@@ -9043,9 +9043,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "cytoscape": "3.30.4",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
-        "formik": "^2.4.6",
+        "formik": "^2.4.9",
         "i18next": "^24.0.5",
         "intro.js": "^7.2.0",
         "intro.js-react": "^1.0.0",
@@ -7521,9 +7521,9 @@
       }
     },
     "node_modules/formik": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
-      "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.9.tgz",
+      "integrity": "sha512-5nI94BMnlFDdQRBY4Sz39WkhxajZJ57Fzs8wVbtsQlm5ScKIR1QLYqv/ultBnobObtlUyxpxoLodpixrsf36Og==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cytoscape": "3.30.4",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
-    "formik": "^2.4.6",
+    "formik": "^2.4.9",
     "i18next": "^24.0.5",
     "intro.js": "^7.2.0",
     "intro.js-react": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@tanstack/match-sorter-utils": "^8.19.4",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-table": "^8.20.5",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "bootstrap": "^5.3.3",
     "bootstrap-css": "^4.0.0-alpha.5",
     "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jsonpath": "^1.1.1",
     "keycloak-js": "^26.0.7",
     "leaflet": "^1.9.4",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "moment": "^2.30.1",
     "msw": "^2.6.7",
     "openseadragon": "^5.0.0",

--- a/src/hooks/useDigitalSpecimen.ts
+++ b/src/hooks/useDigitalSpecimen.ts
@@ -7,11 +7,11 @@ const staleTime = 1000 * 60 * 5; // How long until the time is stale
 const gcTime = 1000 * 60 * 10; // Cache time: How long to store it in the cache
 
 /* useQuery hook to retrieve the complete Digital Specimen data object by calling the getDigitalSpecimenComplete service */
-export const useDigitalSpecimenComplete = ({ handle, version }:
-    { handle: string, version?: number }) => {
+export const useDigitalSpecimenComplete = ({ doi, version }:
+    { doi: string, version?: number }) => {
     return useQuery({
-        queryKey: ['digitalSpecimen', handle, version],
-        queryFn: () => getDigitalSpecimenComplete({ handle, version }),
+        queryKey: ['digitalSpecimen', doi, version],
+        queryFn: () => getDigitalSpecimenComplete({ doi, version }),
         select: (data) => {
             return {
                 ...data,

--- a/src/hooks/useDigitalSpecimen.ts
+++ b/src/hooks/useDigitalSpecimen.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { getDigitalSpecimenComplete } from 'services/digitalSpecimenService/getDigitalSpecimenComplete';
+import { mapDigitalSpecimen } from 'utils/DataMappers/digitalSpecimenDataMapper';
+
+/* Base constants */
+const staleTime = 1000 * 60 * 5; // How long until the time is stale
+const gcTime = 1000 * 60 * 10; // Cache time: How long to store it in the cache
+
+/* useQuery hook to retrieve the complete Digital Specimen data object by calling the getDigitalSpecimenComplete service */
+export const useDigitalSpecimenComplete = ({ handle, version }:
+    { handle: string, version?: number }) => {
+    return useQuery({
+        queryKey: ['digitalSpecimen', handle, version],
+        queryFn: () => getDigitalSpecimenComplete({ handle, version }),
+        select: (data) => {
+            return {
+                ...data,
+                ...mapDigitalSpecimen(data),
+            }
+        },
+        staleTime,
+        gcTime
+    });
+};

--- a/src/services/digitalSpecimenService/getDigitalSpecimenComplete.ts
+++ b/src/services/digitalSpecimenService/getDigitalSpecimenComplete.ts
@@ -1,0 +1,40 @@
+import apiClient from '../apiClient';
+
+/**
+ * Service that retrieves the complete digital specimen details through the apiClient
+ * Takes handle and version as a parameter object
+ * @returns An array with complete digital specimen data on specimen, media and annotations
+ */
+export const getDigitalSpecimenComplete = async ({ handle, version }:
+    { handle: string, version?: number }) => {
+    let endPoint: string;
+
+    if (version) {
+        endPoint = `digital-specimen/v1/${handle}/${version}/full`;
+    } else {
+        endPoint = `digital-specimen/v1/${handle}/full`;
+    }
+    try {
+        /* Call service and wait for response */
+        const response = await apiClient.get(endPoint, {
+            params: {
+                handle,
+                version
+            }
+        });
+
+        /* Throw error if response is not as expected */
+        if(!response.data?.data) {
+            throw new Error('Incorrect response format');
+        }
+
+        /* Return response data */
+        return response.data;
+    } catch (error) {
+        /* If error, throw error with generic error message */
+        console.error('Error fetching the digital specimen:', error);
+
+        /* Rethrow error for useQuery */
+        throw error;
+    }
+}

--- a/src/services/digitalSpecimenService/getDigitalSpecimenComplete.ts
+++ b/src/services/digitalSpecimenService/getDigitalSpecimenComplete.ts
@@ -2,23 +2,23 @@ import apiClient from '../apiClient';
 
 /**
  * Service that retrieves the complete digital specimen details through the apiClient
- * Takes handle and version as a parameter object
+ * Takes doi and version as a parameter object
  * @returns An array with complete digital specimen data on specimen, media and annotations
  */
-export const getDigitalSpecimenComplete = async ({ handle, version }:
-    { handle: string, version?: number }) => {
+export const getDigitalSpecimenComplete = async ({ doi, version }:
+    { doi: string, version?: number }) => {
     let endPoint: string;
 
     if (version) {
-        endPoint = `digital-specimen/v1/${handle}/${version}/full`;
+        endPoint = `digital-specimen/v1/${doi}/${version}/full`;
     } else {
-        endPoint = `digital-specimen/v1/${handle}/full`;
+        endPoint = `digital-specimen/v1/${doi}/full`;
     }
     try {
         /* Call service and wait for response */
         const response = await apiClient.get(endPoint, {
             params: {
-                handle,
+                doi,
                 version
             }
         });

--- a/src/utils/DataMappers/digitalSpecimenDataMapper.ts
+++ b/src/utils/DataMappers/digitalSpecimenDataMapper.ts
@@ -23,7 +23,7 @@ const getAcceptedIdentification = (ds: any) => {
 /**
  * Function to retrieve the primary event once
  * @param ds The digital specimen object
- * @returns Either the primary event or null
+ * @returns Either the primary event if there is one or null
  */
 const getPrimaryEvent = (ds: any) => {
     return ds["ods:hasEvents"]?.[0] ?? null;

--- a/src/utils/DataMappers/digitalSpecimenDataMapper.ts
+++ b/src/utils/DataMappers/digitalSpecimenDataMapper.ts
@@ -1,21 +1,8 @@
 /* Import schemas */
 import DIGITAL_SPECIMEN_SCHEMA_MAP from "./schemas/DigitalSpecimenSchema";
 
-/* Define interfaces */
-interface UIProperty {
-    label: string;
-    value: any;
-    isHtml: boolean;
-    type: string;
-}
-
-interface DigitalSpecimenUIModel {
-    SPECIMEN_RECORD: Record<string, UIProperty>;
-    IDENTIFICATION: Record<string, UIProperty>;
-    LOCATION: Record<string, UIProperty>;
-    COLLECTING_EVENT: Record<string, UIProperty>;
-    CITATION_LICENSE: Record<string, UIProperty>;
-}
+/* Import types */
+import { DigitalSpecimenUIModel, SchemaMap, UIProperty } from "./types/dataMapperTypes";
 
 /**
  * Transforms raw Digital Specimen data into a UI-ready model 
@@ -24,23 +11,22 @@ interface DigitalSpecimenUIModel {
  */
 export const mapDigitalSpecimen = (rawData: any): DigitalSpecimenUIModel | null => {
     const ds = rawData?.data?.attributes?.digitalSpecimen;
-    
     if (!ds) return null;
-  
-    let digitalSpecimenUiDataModel = {};
-  
-    Object.entries(DIGITAL_SPECIMEN_SCHEMA_MAP).forEach(([fragmentKey, fields]) => {
-		digitalSpecimenUiDataModel[fragmentKey] = {};
-	
-		Object.entries(fields).forEach(([fieldKey, config]) => {
-			digitalSpecimenUiDataModel[fragmentKey][fieldKey] = {
+
+    // Use reduce to build the object cleanly
+    return Object.entries(DIGITAL_SPECIMEN_SCHEMA_MAP as SchemaMap).reduce((acc, [groupKey, fields]) => {
+        const mappedFields: Record<string, UIProperty> = {};
+
+        Object.entries(fields).forEach(([fieldKey, config]) => {
+            mappedFields[fieldKey] = {
                 label: config.label,
                 value: config.resolve(ds),
-                isHtml: config.isHtml || false,
+                isHtml: !!config.isHtml,
                 type: config.type || 'base',
-			};
-		});
-    });
+            };
+        });
 
-    return digitalSpecimenUiDataModel as DigitalSpecimenUIModel;
+        acc[groupKey as keyof DigitalSpecimenUIModel] = mappedFields;
+        return acc;
+    }, {} as DigitalSpecimenUIModel);
 };

--- a/src/utils/DataMappers/digitalSpecimenDataMapper.ts
+++ b/src/utils/DataMappers/digitalSpecimenDataMapper.ts
@@ -7,14 +7,26 @@ import { DigitalSpecimenUIModel, SchemaMap, UIProperty } from "./types/dataMappe
 /**
  * Function to get the accepted identification or the first one it can find
  * @param ds The digital specimen object
- * @returns Either the accepted identification or, if there is none, the first identification it can find
+ * @returns Either the accepted identification, the first identification it can find or null in the edge case that there is none
  */
 const getAcceptedIdentification = (ds: any) => {
     const identifications = ds["ods:hasIdentifications"];
-    if (identifications) {
-        const availableIdentification = identifications.find((item: any) => item["ods:isVerifiedIdentification"]) || identifications[0];
-        return availableIdentification?.["ods:hasTaxonIdentifications"]?.[0];
-    }
+    
+    /* Find verified identification or fallback to first identification */
+    const primary = identifications?.find((item: any) => item["ods:isVerifiedIdentification"]) 
+        ?? identifications?.[0];
+
+    /* Return the taxon identification or null if for some reason there is no identification*/
+    return primary?.["ods:hasTaxonIdentifications"]?.[0] ?? null;
+}
+
+/**
+ * Function to retrieve the primary event once
+ * @param ds The digital specimen object
+ * @returns Either the primary event or null
+ */
+const getPrimaryEvent = (ds: any) => {
+    return ds["ods:hasEvents"]?.[0] ?? null;
 }
 
 /**
@@ -28,20 +40,23 @@ export const mapDigitalSpecimen = (rawData: any): DigitalSpecimenUIModel | null 
 
     /* Find acceptedIdentification or second best option */
     const acceptedIdentification = getAcceptedIdentification(ds);
+    const primaryEvent = getPrimaryEvent(ds);
 
-    return Object.entries(DIGITAL_SPECIMEN_SCHEMA_MAP as SchemaMap).reduce((accumulator, [groupKey, fields]) => {
-        const mappedFields: Record<string, UIProperty> = {};
+    return Object.fromEntries(
+        Object.entries(DIGITAL_SPECIMEN_SCHEMA_MAP as SchemaMap).map(([groupKey, fields]) => {
+            const mappedFields: Record<string, UIProperty> = Object.fromEntries(
+                Object.entries(fields).map(([fieldKey, config]) => [
+                    fieldKey,
+                    {
+                        label: config.label,
+                        value: config.resolve(ds, {acceptedIdentification, primaryEvent}),
+                        isHtml: Boolean(config.isHtml),
+                        type: config.type || 'base',
+                    }
+                ])
+            );
 
-        Object.entries(fields).forEach(([fieldKey, config]) => {
-            mappedFields[fieldKey] = {
-                label: config.label,
-                value: config.resolve(ds, acceptedIdentification),
-                isHtml: !!config.isHtml,
-                type: config.type || 'base',
-            };
-        });
-
-        accumulator[groupKey as keyof DigitalSpecimenUIModel] = mappedFields;
-        return accumulator;
-    }, {} as DigitalSpecimenUIModel);
+            return [groupKey, mappedFields];
+        })
+    ) as unknown as DigitalSpecimenUIModel;
 };

--- a/src/utils/DataMappers/digitalSpecimenDataMapper.ts
+++ b/src/utils/DataMappers/digitalSpecimenDataMapper.ts
@@ -5,6 +5,19 @@ import DIGITAL_SPECIMEN_SCHEMA_MAP from "./schemas/DigitalSpecimenSchema";
 import { DigitalSpecimenUIModel, SchemaMap, UIProperty } from "./types/dataMapperTypes";
 
 /**
+ * Function to get the accepted identification or the first one it can find
+ * @param ds The digital specimen object
+ * @returns Either the accepted identification or, if there is none, the first identification it can find
+ */
+const getAcceptedIdentification = (ds: any) => {
+    const identifications = ds["ods:hasIdentifications"];
+    if (identifications) {
+        const availableIdentification = identifications.find((item: any) => item["ods:isVerifiedIdentification"]) || identifications[0];
+        return availableIdentification?.["ods:hasTaxonIdentifications"]?.[0];
+    }
+}
+
+/**
  * Transforms raw Digital Specimen data into a UI-ready model 
  * based on the DIGITAL_SPECIMEN_SCHEMA_MAP definitions.
  * It is executed in the useDigitalSpecimen hook immediately when the call is being done.
@@ -13,20 +26,22 @@ export const mapDigitalSpecimen = (rawData: any): DigitalSpecimenUIModel | null 
     const ds = rawData?.data?.attributes?.digitalSpecimen;
     if (!ds) return null;
 
-    // Use reduce to build the object cleanly
-    return Object.entries(DIGITAL_SPECIMEN_SCHEMA_MAP as SchemaMap).reduce((acc, [groupKey, fields]) => {
+    /* Find acceptedIdentification or second best option */
+    const acceptedIdentification = getAcceptedIdentification(ds);
+
+    return Object.entries(DIGITAL_SPECIMEN_SCHEMA_MAP as SchemaMap).reduce((accumulator, [groupKey, fields]) => {
         const mappedFields: Record<string, UIProperty> = {};
 
         Object.entries(fields).forEach(([fieldKey, config]) => {
             mappedFields[fieldKey] = {
                 label: config.label,
-                value: config.resolve(ds),
+                value: config.resolve(ds, acceptedIdentification),
                 isHtml: !!config.isHtml,
                 type: config.type || 'base',
             };
         });
 
-        acc[groupKey as keyof DigitalSpecimenUIModel] = mappedFields;
-        return acc;
+        accumulator[groupKey as keyof DigitalSpecimenUIModel] = mappedFields;
+        return accumulator;
     }, {} as DigitalSpecimenUIModel);
 };

--- a/src/utils/DataMappers/digitalSpecimenDataMapper.ts
+++ b/src/utils/DataMappers/digitalSpecimenDataMapper.ts
@@ -1,0 +1,46 @@
+/* Import schemas */
+import DIGITAL_SPECIMEN_SCHEMA_MAP from "./schemas/DigitalSpecimenSchema";
+
+/* Define interfaces */
+interface UIProperty {
+    label: string;
+    value: any;
+    isHtml: boolean;
+    type: string;
+}
+
+interface DigitalSpecimenUIModel {
+    SPECIMEN_RECORD: Record<string, UIProperty>;
+    IDENTIFICATION: Record<string, UIProperty>;
+    LOCATION: Record<string, UIProperty>;
+    COLLECTING_EVENT: Record<string, UIProperty>;
+    CITATION_LICENSE: Record<string, UIProperty>;
+}
+
+/**
+ * Transforms raw Digital Specimen data into a UI-ready model 
+ * based on the DIGITAL_SPECIMEN_SCHEMA_MAP definitions.
+ * It is executed in the useDigitalSpecimen hook immediately when the call is being done.
+ */
+export const mapDigitalSpecimen = (rawData: any): DigitalSpecimenUIModel | null => {
+    const ds = rawData?.data?.attributes?.digitalSpecimen;
+    
+    if (!ds) return null;
+  
+    let digitalSpecimenUiDataModel = {};
+  
+    Object.entries(DIGITAL_SPECIMEN_SCHEMA_MAP).forEach(([fragmentKey, fields]) => {
+		digitalSpecimenUiDataModel[fragmentKey] = {};
+	
+		Object.entries(fields).forEach(([fieldKey, config]) => {
+			digitalSpecimenUiDataModel[fragmentKey][fieldKey] = {
+                label: config.label,
+                value: config.resolve(ds),
+                isHtml: config.isHtml || false,
+                type: config.type || 'base',
+			};
+		});
+    });
+
+    return digitalSpecimenUiDataModel as DigitalSpecimenUIModel;
+};

--- a/src/utils/DataMappers/schemas/DigitalSpecimenSchema.ts
+++ b/src/utils/DataMappers/schemas/DigitalSpecimenSchema.ts
@@ -37,13 +37,20 @@ const DIGITAL_SPECIMEN_SCHEMA_MAP: Record<string, Record<string, FieldConfig>> =
     IDENTIFICATION: {
         scientificName: {
             label: 'Scientific Name',
-            isHtml: true,
-            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["ods:scientificNameHTMLLabel"] || acceptedIdentification?.["dwc:scientificName"]
+            resolve: (_, { acceptedIdentification }) => {
+                const htmlLabel = acceptedIdentification?.["ods:scientificNameHTMLLabel"];
+                const fallbackLabel = acceptedIdentification?.["dwc:scientificName"];
+                
+                return {
+                    value: htmlLabel || fallbackLabel,
+                    isHtml: !!htmlLabel
+                };
+            }
         },
         taxonomicStatus: {
             label: 'Taxonomic Status',
             type: 'url',
-            resolve: (_, { acceptedIdentification: acc }) => acc?.["@id"]
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["@id"]
         },
         verbatimName: {
             label: 'Identification Verbatim',
@@ -87,7 +94,7 @@ const DIGITAL_SPECIMEN_SCHEMA_MAP: Record<string, Record<string, FieldConfig>> =
             resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:specificEpithet"]
         },
         nomenClaturalCode: {
-            label: 'Nomen/Clatural Code',
+            label: 'Nomenclatural Code',
             resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:nomenclaturalCode"]
         },
         scientificNameAuthorship: {
@@ -99,35 +106,35 @@ const DIGITAL_SPECIMEN_SCHEMA_MAP: Record<string, Record<string, FieldConfig>> =
     LOCATION: {
         country: {
             label: 'Country',
-            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasLocation"]?.["dwc:country"]
+            resolve: (_, { primaryEvent }) => primaryEvent?.["ods:hasLocation"]?.["dwc:country"]
         },
         locality: {
             label: 'Locality',
-            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasLocation"]?.["dwc:locality"]
+            resolve: (_, { primaryEvent }) => primaryEvent?.["ods:hasLocation"]?.["dwc:locality"]
         },
         verbatimLocality: { 
             label: 'Locality Verbatim', 
             type: 'verbatim',
-            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasLocation"]?.["dwc:verbatimLocality"],
+            resolve: (_, { primaryEvent }) => primaryEvent?.["ods:hasLocation"]?.["dwc:verbatimLocality"],
         },
         geodeticDatum: {
             label: 'Geodetic Datum',
-            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasLocation"]?.["dwc:geodeticDatum"]
+            resolve: (_, { primaryEvent }) => primaryEvent?.["ods:hasLocation"]?.["ods:hasGeoreference"]["dwc:geodeticDatum"]
         }
     },
   
     COLLECTING_EVENT: {
         collector: {
             label: 'Collector',
-            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasAgents"]?.[0]?.["schema:name"]
+            resolve: (_, { primaryEvent }) => primaryEvent?.["ods:hasAgents"]?.[0]?.["schema:name"]
         },
         date: {
             label: 'Date',
-            resolve: (_, { primaryEvent: ev }) => ev?.["dwc:eventDate"]
+            resolve: (_, { primaryEvent }) => primaryEvent?.["dwc:eventDate"]
         },
         verbatimDate: {
             label: 'Date verbatim',
-            resolve: (_, { primaryEvent: ev }) => ev?.["dwc:verbatimEventDate"],
+            resolve: (_, { primaryEvent }) => primaryEvent?.["dwc:verbatimEventDate"],
             type: 'verbatim'
         }
     },

--- a/src/utils/DataMappers/schemas/DigitalSpecimenSchema.ts
+++ b/src/utils/DataMappers/schemas/DigitalSpecimenSchema.ts
@@ -117,7 +117,7 @@ const DIGITAL_SPECIMEN_SCHEMA_MAP = {
             }
         },
         species: {
-            label: 'Kingdom',
+            label: 'Species',
             resolve: (ds: any) => {
                 const acceptedIdentification = getAcceptedIdentification(ds);
                 return acceptedIdentification?.["dwc:species"];

--- a/src/utils/DataMappers/schemas/DigitalSpecimenSchema.ts
+++ b/src/utils/DataMappers/schemas/DigitalSpecimenSchema.ts
@@ -1,0 +1,192 @@
+/**
+ * Function to get the accepted identification or the first one it can find
+ * @param ds The digital specimen object
+ * @returns Either the accepted identification or, if there is none, the first identification it can find
+ */
+const getAcceptedIdentification = (ds: any) => {
+    const identifications = ds["ods:hasIdentifications"];
+    if (identifications) {
+        const availableIdentification = identifications.find((item: any) => item["ods:isVerifiedIdentification"]) || identifications[0];
+        return availableIdentification?.["ods:hasTaxonIdentifications"]?.[0];
+    }
+}
+
+/* Data schema to map Digital Specimen data that we use in the UI, managed from one central data mapper */
+const DIGITAL_SPECIMEN_SCHEMA_MAP = {
+    SPECIMEN_RECORD: {
+		doi: {
+			label: 'DOI',
+			resolve: (ds: any) => ds["@id"],
+            type: 'copy'
+		},
+		catalogNumber: {
+			label: 'Catalog Number',
+			resolve: (ds: any) => {
+				const catalog = ds["ods:hasIdentifiers"].find((id: any) => id["dcterms:title"] === "dwc:catalogNumber");
+				const fallBack = ds["ods:hasIdentifiers"].find((id: any) => id["dcterms:title"] === "dwca:ID");
+				return catalog?.["dwc:catalogNumber"] || fallBack?.["dwca:id"];
+			}
+		},
+		specimenProvider: {
+			label: 'Specimen Provider',
+			resolve: (ds: any) => ds["ods:organisationName"]
+		},
+		sourceSystem: {
+			label: 'Source System',
+			resolve: (ds: any) => ds["ods:sourceSystemName"]
+		},
+		basisOfRecord: {
+			label: 'Basis of Record',
+			resolve: (ds: any) => ds["dwc:basisOfRecord"]
+		},
+		discipline: {
+			label: 'Discipline',
+			resolve: (ds: any) => ds["dwc:topicDiscipline"]
+		}
+    },
+  
+    IDENTIFICATION: {
+        scientificName: {
+            label: 'Scientific Name',
+            isHtml: true,
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["ods:scientificNameHTMLLabel"] || acceptedIdentification?.["dwc:scientificName"];
+            }
+        },
+        taxonomicStatus: {
+            label: 'Taxonomic Status',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["@id"];
+            },
+            type: 'url'
+        },
+        verbatimName: {
+            label: 'Identification Verbatim',
+            resolve: (ds: any) => ds["ods:hasIdentifications"]?.[0]?.["dwc:verbatimIdentification"],
+            type: 'verbatim'
+        },
+        kingdom: {
+            label: 'Kingdom',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:kingdom"];
+            }
+        },
+        phylum: {
+            label: 'Phylum',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:phylum"];
+            }
+        },
+        class: {
+            label: 'Class',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:class"];
+            }
+        },
+        order: {
+            label: 'Order',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:order"];
+            }
+        },
+        family: {
+            label: 'Family',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:family"];
+            }
+        },
+        subFamily: {
+            label: 'Sub-family',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:subfamily"];
+            }
+        },
+        genus: {
+            label: 'Genus',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:genus"];
+            }
+        },
+        species: {
+            label: 'Kingdom',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:species"];
+            }
+        },
+        specificEpithet: {
+            label: 'Specific Epithet',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:specificEpithet"];
+            }
+        },
+        nomenClaturalCode: {
+            label: 'Nomen/Clatural Code',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:nomenclaturalCode"];
+            }
+        },
+        scientificNameAuthorship: {
+            label: 'Scientific Name Authorship',
+            resolve: (ds: any) => {
+                const acceptedIdentification = getAcceptedIdentification(ds);
+                return acceptedIdentification?.["dwc:scientificNameAuthorship"];
+            }
+        },
+    },
+  
+    LOCATION: {
+		country: {
+			label: 'Country',
+			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasLocation"]?.["dwc:country"]
+		},
+		locality: {
+			label: 'Locality',
+			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasLocation"]?.["dwc:locality"]
+		},
+        verbatimLocality: {
+            label: 'Locality Verbatim',
+            resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasLocation"]?.["dwc:verbatimLocality"],
+            type: 'verbatim'
+        },
+		geodeticDatum: {
+			label: 'Geodetic Datum',
+			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasLocation"]?.["dwc:geodeticDatum"]
+		}
+    },
+  
+    COLLECTING_EVENT: {
+		collector: {
+			label: 'Collector',
+			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasAgents"]?.[0]?.["schema:name"]
+		},
+		date: {
+			label: 'Date',
+			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["dwc:eventDate"]
+		},
+		verbatimDate: {
+			label: 'Date verbatim',
+			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["dwc:verbatimEventDate"]
+		}
+    },
+  
+    CITATION_LICENSE: {
+		license: {
+			label: 'License Agreement',
+			resolve: (ds:any) => ds["dcterms:license"]
+		}
+    }
+};
+
+export default DIGITAL_SPECIMEN_SCHEMA_MAP;

--- a/src/utils/DataMappers/schemas/DigitalSpecimenSchema.ts
+++ b/src/utils/DataMappers/schemas/DigitalSpecimenSchema.ts
@@ -1,191 +1,142 @@
-/**
- * Function to get the accepted identification or the first one it can find
- * @param ds The digital specimen object
- * @returns Either the accepted identification or, if there is none, the first identification it can find
- */
-const getAcceptedIdentification = (ds: any) => {
-    const identifications = ds["ods:hasIdentifications"];
-    if (identifications) {
-        const availableIdentification = identifications.find((item: any) => item["ods:isVerifiedIdentification"]) || identifications[0];
-        return availableIdentification?.["ods:hasTaxonIdentifications"]?.[0];
-    }
-}
+import { FieldConfig } from "../types/dataMapperTypes";
 
 /* Data schema to map Digital Specimen data that we use in the UI, managed from one central data mapper */
-const DIGITAL_SPECIMEN_SCHEMA_MAP = {
+const DIGITAL_SPECIMEN_SCHEMA_MAP: Record<string, Record<string, FieldConfig>> = {
     SPECIMEN_RECORD: {
-		doi: {
-			label: 'DOI',
-			resolve: (ds: any) => ds["@id"],
+        doi: {
+            label: 'DOI',
+            resolve: (ds) => ds["@id"],
             type: 'copy'
-		},
-		catalogNumber: {
-			label: 'Catalog Number',
-			resolve: (ds: any) => {
-				const catalog = ds["ods:hasIdentifiers"].find((id: any) => id["dcterms:title"] === "dwc:catalogNumber");
-				const fallBack = ds["ods:hasIdentifiers"].find((id: any) => id["dcterms:title"] === "dwca:ID");
-				return catalog?.["dwc:catalogNumber"] || fallBack?.["dwca:id"];
-			}
-		},
-		specimenProvider: {
-			label: 'Specimen Provider',
-			resolve: (ds: any) => ds["ods:organisationName"]
-		},
-		sourceSystem: {
-			label: 'Source System',
-			resolve: (ds: any) => ds["ods:sourceSystemName"]
-		},
-		basisOfRecord: {
-			label: 'Basis of Record',
-			resolve: (ds: any) => ds["dwc:basisOfRecord"]
-		},
-		discipline: {
-			label: 'Discipline',
-			resolve: (ds: any) => ds["dwc:topicDiscipline"]
-		}
+        },
+        catalogNumber: {
+            label: 'Catalog Number',
+            resolve: (ds) => {
+                const catalog = ds["ods:hasIdentifiers"]?.find((id: any) => id["dcterms:title"] === "dwc:catalogNumber");
+                const fallBack = ds["ods:hasIdentifiers"]?.find((id: any) => id["dcterms:title"] === "dwca:ID");
+                return catalog?.["dwc:catalogNumber"] || fallBack?.["dwca:id"];
+            }
+        },
+        specimenProvider: {
+            label: 'Specimen Provider',
+            resolve: (ds) => ds["ods:organisationName"]
+        },
+        sourceSystem: {
+            label: 'Source System',
+            resolve: (ds) => ds["ods:sourceSystemName"]
+        },
+        basisOfRecord: {
+            label: 'Basis of Record',
+            resolve: (ds) => ds["dwc:basisOfRecord"]
+        },
+        discipline: {
+            label: 'Discipline',
+            resolve: (ds) => ds["dwc:topicDiscipline"]
+        }
     },
   
     IDENTIFICATION: {
         scientificName: {
             label: 'Scientific Name',
             isHtml: true,
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["ods:scientificNameHTMLLabel"] || acceptedIdentification?.["dwc:scientificName"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["ods:scientificNameHTMLLabel"] || acceptedIdentification?.["dwc:scientificName"]
         },
         taxonomicStatus: {
             label: 'Taxonomic Status',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["@id"];
-            },
-            type: 'url'
+            type: 'url',
+            resolve: (_, { acceptedIdentification: acc }) => acc?.["@id"]
         },
         verbatimName: {
             label: 'Identification Verbatim',
-            resolve: (ds: any) => ds["ods:hasIdentifications"]?.[0]?.["dwc:verbatimIdentification"],
-            type: 'verbatim'
+            type: 'verbatim',
+            resolve: (ds) => ds["ods:hasIdentifications"]?.[0]?.["dwc:verbatimIdentification"]
         },
         kingdom: {
             label: 'Kingdom',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:kingdom"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:kingdom"]
         },
         phylum: {
             label: 'Phylum',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:phylum"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:phylum"]
         },
         class: {
             label: 'Class',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:class"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:class"]
         },
         order: {
             label: 'Order',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:order"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:order"]
         },
         family: {
             label: 'Family',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:family"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:family"]
         },
         subFamily: {
             label: 'Sub-family',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:subfamily"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:subfamily"]
         },
         genus: {
             label: 'Genus',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:genus"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:genus"]
         },
         species: {
             label: 'Species',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:species"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:species"]
         },
         specificEpithet: {
             label: 'Specific Epithet',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:specificEpithet"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:specificEpithet"]
         },
         nomenClaturalCode: {
             label: 'Nomen/Clatural Code',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:nomenclaturalCode"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:nomenclaturalCode"]
         },
         scientificNameAuthorship: {
             label: 'Scientific Name Authorship',
-            resolve: (ds: any) => {
-                const acceptedIdentification = getAcceptedIdentification(ds);
-                return acceptedIdentification?.["dwc:scientificNameAuthorship"];
-            }
+            resolve: (_, { acceptedIdentification }) => acceptedIdentification?.["dwc:scientificNameAuthorship"]
         },
     },
   
     LOCATION: {
-		country: {
-			label: 'Country',
-			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasLocation"]?.["dwc:country"]
-		},
-		locality: {
-			label: 'Locality',
-			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasLocation"]?.["dwc:locality"]
-		},
-        verbatimLocality: {
-            label: 'Locality Verbatim',
-            resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasLocation"]?.["dwc:verbatimLocality"],
-            type: 'verbatim'
+        country: {
+            label: 'Country',
+            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasLocation"]?.["dwc:country"]
         },
-		geodeticDatum: {
-			label: 'Geodetic Datum',
-			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasLocation"]?.["dwc:geodeticDatum"]
-		}
+        locality: {
+            label: 'Locality',
+            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasLocation"]?.["dwc:locality"]
+        },
+        verbatimLocality: { 
+            label: 'Locality Verbatim', 
+            type: 'verbatim',
+            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasLocation"]?.["dwc:verbatimLocality"],
+        },
+        geodeticDatum: {
+            label: 'Geodetic Datum',
+            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasLocation"]?.["dwc:geodeticDatum"]
+        }
     },
   
     COLLECTING_EVENT: {
-		collector: {
-			label: 'Collector',
-			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["ods:hasAgents"]?.[0]?.["schema:name"]
-		},
-		date: {
-			label: 'Date',
-			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["dwc:eventDate"]
-		},
-		verbatimDate: {
-			label: 'Date verbatim',
-			resolve: (ds: any) => ds["ods:hasEvents"]?.[0]?.["dwc:verbatimEventDate"]
-		}
+        collector: {
+            label: 'Collector',
+            resolve: (_, { primaryEvent: ev }) => ev?.["ods:hasAgents"]?.[0]?.["schema:name"]
+        },
+        date: {
+            label: 'Date',
+            resolve: (_, { primaryEvent: ev }) => ev?.["dwc:eventDate"]
+        },
+        verbatimDate: {
+            label: 'Date verbatim',
+            resolve: (_, { primaryEvent: ev }) => ev?.["dwc:verbatimEventDate"],
+            type: 'verbatim'
+        }
     },
   
     CITATION_LICENSE: {
-		license: {
-			label: 'License Agreement',
-			resolve: (ds:any) => ds["dcterms:license"]
-		}
+        license: {
+            label: 'License Agreement',
+            resolve: (ds) => ds["dcterms:license"]
+        }
     }
 };
 

--- a/src/utils/DataMappers/types/dataMapperTypes.ts
+++ b/src/utils/DataMappers/types/dataMapperTypes.ts
@@ -1,0 +1,32 @@
+/* UI Property interface to map data to */
+interface UIProperty {
+    label: string;
+    value: any;
+    isHtml: boolean;
+    type: string;
+}
+
+/* Corresponding field config interface for DigitalSpecimen schema */
+interface FieldConfig {
+    label: string;
+    resolve: (ds: any) => any;
+    isHtml?: boolean;
+    type?: string;
+}
+
+/* Result of the Digital Specimen data mapper */
+interface DigitalSpecimenUIModel {
+    SPECIMEN_RECORD: Record<string, UIProperty>;
+    IDENTIFICATION: Record<string, UIProperty>;
+    LOCATION: Record<string, UIProperty>;
+    COLLECTING_EVENT: Record<string, UIProperty>;
+    CITATION_LICENSE: Record<string, UIProperty>;
+}
+
+/* Generic map to handle schemas for the digitalSpecimenUIModel */
+type SchemaMap = {
+    [Key in keyof DigitalSpecimenUIModel]: Record<string, FieldConfig>;
+};
+
+export type { UIProperty, FieldConfig, DigitalSpecimenUIModel, SchemaMap };
+

--- a/src/utils/DataMappers/types/dataMapperTypes.ts
+++ b/src/utils/DataMappers/types/dataMapperTypes.ts
@@ -1,3 +1,9 @@
+/* MapperContext to set the context of the data, e.g. acceptedIdentification */
+interface MapperContext {
+    acceptedIdentification?: any;
+    primaryEvent?: any;
+}
+
 /* UI Property interface to map data to */
 interface UIProperty {
     label: string;
@@ -9,7 +15,7 @@ interface UIProperty {
 /* Corresponding field config interface for DigitalSpecimen schema */
 interface FieldConfig {
     label: string;
-    resolve: (ds: any) => any;
+    resolve: (ds: any, context: MapperContext) => any;
     isHtml?: boolean;
     type?: string;
 }

--- a/src/utils/DataMappers/types/dataMapperTypes.ts
+++ b/src/utils/DataMappers/types/dataMapperTypes.ts
@@ -4,7 +4,7 @@ interface MapperContext {
     primaryEvent?: any;
 }
 
-/* UI Property interface to map data to */
+/* UI Property interface to map data */
 interface UIProperty {
     label: string;
     value: any;


### PR DESCRIPTION
In this PR:
- Rewrote service getDigitalSpecimenComplete to use tanstack and execute dataMapper for digital specimen
- Added data mapper function to map data to UI in one general place, instead of multiple places in the app

This service and data mapper is not used yet, but is tested. Implementation to UI will follow this PR due to complexity.