### PR TITLE
Added the POST service for the Create Virtual Collection flow

### DIFF
--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -115,7 +115,7 @@ export const Hero = ( { title, description, badge, navigateTo, showShareButton, 
                     <h1>{ title }</h1>
                 )}
                 {showCreateButton &&
-                    <Button variant="solid" disabled={!isAllowedToCreateVC}>
+                    <Button variant="solid" disabled={!isAllowedToCreateVC} onClick={() => navigate('/virtual-collections/create')}>
                         Create
                         <PlusIcon />
                     </Button>

--- a/src/components/MultiStepForm/views/SpecimensView.tsx
+++ b/src/components/MultiStepForm/views/SpecimensView.tsx
@@ -4,6 +4,9 @@ import { ChangeEvent } from "react";
 /* Import styling */
 import "./Views.scss";
 
+/* Import utils */
+import { cleanAndValidateDOIs } from "utils/Utils";
+
 /* SpecimenView interface */
 interface SpecimenViewProps {
     data: {
@@ -29,12 +32,7 @@ const SpecimenView = ({data, onUpdate, wasValidated}: SpecimenViewProps) => {
 
     /* Function to transform string to array of strings, clean it and check for duplicate items */
     const handleOnBlurTextarea = () => {
-        /* Regex depicts a split on either new line, comma or semicolon */
-        const rawArray = data.specimenRawList.split(/[\n,;]+/);
-        const cleanArray = rawArray
-            .map((item) => item.trim())
-            .filter((item) => item.length > 0);
-        const uniqueDOIs = [...new Set(cleanArray)];
+        const uniqueDOIs = cleanAndValidateDOIs(data.specimenRawList);
         
         onUpdate({ specimens: uniqueDOIs });
     }
@@ -50,7 +48,7 @@ const SpecimenView = ({data, onUpdate, wasValidated}: SpecimenViewProps) => {
 
             {/* SPECIMEN FIELD */}
             <fieldset className="input-group">
-                <label htmlFor="form-specimen">Specimen DOIs</label>
+                <label htmlFor="form-specimen" className="form-label">Specimen DOIs</label>
                 <textarea 
                     id="form-specimen" 
                     name="specimen" 

--- a/src/hooks/useVirtualCollections.ts
+++ b/src/hooks/useVirtualCollections.ts
@@ -7,6 +7,9 @@ import { getSelectedVirtualCollection } from 'services/virtualCollectionService/
 import { getVirtualCollectionDetails } from 'services/virtualCollectionService/getVirtualCollectionDetails';
 import { postNewVirtualCollection } from 'services/virtualCollectionService/postNewVirtualCollection';
 
+/* Import types */
+import { NewVirtualCollectionRequest } from 'types/Types';
+
 /* Base constants */
 const staleTime = 1000 * 60 * 5; // How long until the time is stale
 const gcTime = 1000 * 60 * 10; // Cache time: How long to store it in the cache
@@ -68,7 +71,7 @@ export const useSelectedVirtualCollection = ({ identifier }: { identifier: strin
  */
 export const useCreateVirtualCollection = () => {
     return useMutation({
-        mutationFn: (requestBody: any) => {
+        mutationFn: (requestBody: NewVirtualCollectionRequest) => {
             return postNewVirtualCollection(requestBody);
         }
     })

--- a/src/hooks/useVirtualCollections.ts
+++ b/src/hooks/useVirtualCollections.ts
@@ -1,10 +1,11 @@
 /* Import dependencies */
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 /* Import services */
 import { getAllVirtualCollections } from 'services/virtualCollectionService/getAllVirtualCollections';
 import { getSelectedVirtualCollection } from 'services/virtualCollectionService/getSelectedVirtualCollection';
 import { getVirtualCollectionDetails } from 'services/virtualCollectionService/getVirtualCollectionDetails';
+import { postNewVirtualCollection } from 'services/virtualCollectionService/postNewVirtualCollection';
 
 /* Base constants */
 const staleTime = 1000 * 60 * 5; // How long until the time is stale
@@ -59,4 +60,16 @@ export const useSelectedVirtualCollection = ({ identifier }: { identifier: strin
         staleTime,
         gcTime,
     });
+}
+
+/**
+ * Hook that calls the postNewVirtualCollection service that creates a new Virtual Collection
+ * @returns The response of the service
+ */
+export const useCreateVirtualCollection = () => {
+    return useMutation({
+        mutationFn: (requestBody: any) => {
+            return postNewVirtualCollection(requestBody);
+        }
+    })
 }

--- a/src/pages/CreateVirtualCollection/CreateVirtualCollection.tsx
+++ b/src/pages/CreateVirtualCollection/CreateVirtualCollection.tsx
@@ -1,15 +1,17 @@
-/* Import components */
+/* Import dependencies */
 import { RetrieveEnvVariable } from 'app/Utilities';
+import { useState } from 'react';
+
+/* Import components */
 import { Hero } from 'components/Hero/Hero';
 import MultiStepForm from 'components/MultiStepForm/MultiStepForm';
 import AboutView from 'components/MultiStepForm/views/AboutView';
 import ConfirmView from 'components/MultiStepForm/views/ConfirmView';
 import SpecimenView from 'components/MultiStepForm/views/SpecimensView';
-import { useCreateVirtualCollection } from 'hooks/useVirtualCollections';
-import { useState } from 'react';
 
 /* Import hooks */
 import { useNavigate } from 'react-router-dom';
+import { useCreateVirtualCollection } from 'hooks/useVirtualCollections';
 
 /* Interface VirtualCollectionData */
 interface VirtualCollectionData {

--- a/src/pages/CreateVirtualCollection/CreateVirtualCollection.tsx
+++ b/src/pages/CreateVirtualCollection/CreateVirtualCollection.tsx
@@ -55,7 +55,7 @@ const CreateVirtualCollection = () => {
                     "ltc:description": collectionData.description,
                     "ltc:basisOfScheme": collectionData.type,
                     "ods:hasTargetDigitalObjectFilter": {
-                        "ods:predicateType": "in",
+                        "ods:predicateType": "equals",
                         "ods:predicateKey": "$['dcterms:identifier']",
                         "ods:predicateValues": collectionData.specimens
                     }

--- a/src/pages/CreateVirtualCollection/CreateVirtualCollection.tsx
+++ b/src/pages/CreateVirtualCollection/CreateVirtualCollection.tsx
@@ -1,9 +1,11 @@
 /* Import components */
+import { RetrieveEnvVariable } from 'app/Utilities';
 import { Hero } from 'components/Hero/Hero';
 import MultiStepForm from 'components/MultiStepForm/MultiStepForm';
 import AboutView from 'components/MultiStepForm/views/AboutView';
 import ConfirmView from 'components/MultiStepForm/views/ConfirmView';
 import SpecimenView from 'components/MultiStepForm/views/SpecimensView';
+import { useCreateVirtualCollection } from 'hooks/useVirtualCollections';
 import { useState } from 'react';
 
 /* Import hooks */
@@ -42,8 +44,32 @@ const CreateVirtualCollection = () => {
         }));
     }
 
+    const { mutate } = useCreateVirtualCollection();
+
     const handleFormSubmit = () => {
-        navigate('/virtual-collections');
+        const requestBody = {
+            data: {
+                type: "ods:VirtualCollection",
+                attributes: {
+                    "ltc:collectionName": collectionData.title,
+                    "ltc:description": collectionData.description,
+                    "ltc:basisOfScheme": collectionData.type,
+                    "ods:hasTargetDigitalObjectFilter": {
+                        "ods:predicateType": "in",
+                        "ods:predicateKey": "$['dcterms:identifier']",
+                        "ods:predicateValues": collectionData.specimens
+                    }
+                }
+            }
+        }
+        mutate(requestBody, {
+            onSuccess: (response) => {
+                navigate(`${'/virtual-collections/' + response.id.replace(RetrieveEnvVariable('HANDLE_URL'), '')}`);
+            },
+            onError: (error) => {
+                console.error("Failed to create collection:", error);
+            }
+        });
     }
 
     /* Form steps */

--- a/src/pages/CreateVirtualCollection/CreateVirtualCollection.tsx
+++ b/src/pages/CreateVirtualCollection/CreateVirtualCollection.tsx
@@ -66,7 +66,7 @@ const CreateVirtualCollection = () => {
         }
         mutate(requestBody, {
             onSuccess: (response) => {
-                navigate(`${'/virtual-collections/' + response.id.replace(RetrieveEnvVariable('HANDLE_URL'), '')}`);
+                navigate(`/virtual-collections/${response.id.replace(RetrieveEnvVariable('HANDLE_URL'), '')}`);
             },
             onError: (error) => {
                 console.error("Failed to create collection:", error);

--- a/src/pages/VirtualCollectionOverview/VirtualCollectionsOverview.scss
+++ b/src/pages/VirtualCollectionOverview/VirtualCollectionsOverview.scss
@@ -8,6 +8,7 @@
         grid-template-columns: repeat(auto-fill, minmax(var(--general-card-width), 1fr));
         gap: var(--spacing-l);
         grid-auto-rows: 1fr;
+        padding-block-end: var(--spacing-l);
 
         .gallery-card {
             height: 100%;

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -2,7 +2,7 @@ import KeycloakService from 'app/Keycloak';
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: `${globalThis.location.protocol}//${globalThis.location.hostname}${globalThis.location.port ? ':' + globalThis.location.port : ''}/api`,
+  baseURL: `${globalThis.location.origin}/api`,
   headers: {
     'Content-Type': 'application/json'
   },

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,9 +1,28 @@
+import KeycloakService from 'app/Keycloak';
 import axios from 'axios';
 
 const api = axios.create({
   baseURL: `${globalThis.location.protocol}//${globalThis.location.hostname}${globalThis.location.port ? ':' + globalThis.location.port : ''}/api`,
-  headers: { 'Content-Type': 'application/json' },
+  headers: {
+    'Content-Type': 'application/json'
+  },
 });
+
+/* Request Interceptor to inject the token dynamically */
+api.interceptors.request.use(
+  (config) => {
+    const token = KeycloakService.GetToken();
+    
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+    
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
 
 /* Initial setup error handling */
 api.interceptors.response.use(

--- a/src/services/virtualCollectionService/postNewVirtualCollection.ts
+++ b/src/services/virtualCollectionService/postNewVirtualCollection.ts
@@ -17,7 +17,7 @@ export const postNewVirtualCollection = async (requestBody: any) => {
             throw new Error('Incorrect response format');
         }
 
-        /* Return response data */
+        /* Return response data with status of POST */
         return response.data.data;
     } catch (error) {
         /* If error, throw error with generic error message */

--- a/src/services/virtualCollectionService/postNewVirtualCollection.ts
+++ b/src/services/virtualCollectionService/postNewVirtualCollection.ts
@@ -1,10 +1,13 @@
 import apiClient from 'services/apiClient';
 
+/* Import types */
+import { NewVirtualCollectionRequest } from 'types/Types';
+
 /**
  * Service that creates a new Virtual Collection by POST through the apiClient
  * @returns The result of the create, either successful or error
  */
-export const postNewVirtualCollection = async (requestBody: any) => {
+export const postNewVirtualCollection = async (requestBody: NewVirtualCollectionRequest) => {
     try {
         /* Call service and wait for response */
         const response = await apiClient.post(

--- a/src/services/virtualCollectionService/postNewVirtualCollection.ts
+++ b/src/services/virtualCollectionService/postNewVirtualCollection.ts
@@ -1,0 +1,29 @@
+import apiClient from 'services/apiClient';
+
+/**
+ * Service that creates a new Virtual Collection by POST through the apiClient
+ * @returns The result of the create, either successful or error
+ */
+export const postNewVirtualCollection = async (requestBody: any) => {
+    try {
+        /* Call service and wait for response */
+        const response = await apiClient.post(
+            '/virtual-collection/v1',
+            requestBody,
+        );
+
+        /* Throw error if response is not as expected */
+        if(!response.data?.data) {
+            throw new Error('Incorrect response format');
+        }
+
+        /* Return response data */
+        return response.data.data;
+    } catch (error) {
+        /* If error, throw error with generic error message */
+        console.error('Error fetching virtual collections:', error);
+
+        /* Rethrow error for useQuery */
+        throw error;
+    }
+}

--- a/src/types/Types.d.ts
+++ b/src/types/Types.d.ts
@@ -1,0 +1,16 @@
+/* Interface for the POST request for creating a new Virtual Collection */
+export interface NewVirtualCollectionRequest {
+    data: {
+        type: string,
+        attributes: {
+            "ltc:collectionName": string,
+            "ltc:description": string,
+            "ltc:basisOfScheme": string,
+            "ods:hasTargetDigitalObjectFilter": {
+                "ods:predicateType": string,
+                "ods:predicateKey": string,
+                "ods:predicateValues": string[]
+            }
+        }
+    }
+}

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -43,3 +43,23 @@ export const paginateItems = <T>(items: T[] | undefined, currentPage: number, ma
 export const sanitizeHtmlWrapper = (htmlString: string) => {
     return DOMPurify.sanitize(htmlString);
 }
+
+/**
+ * Util function to clean up and validate DOIs in string and convert to array
+ * @param doiInputString User input string
+ * @returns An array of cleaned up and validated DOIs that adhere to the provided regex
+ */
+export const cleanAndValidateDOIs = (doiInputString: string) => {
+    if (!doiInputString) return [];
+
+    /* Split by newline, comma or semicolon and trim whitespaces */
+    const rawDois = doiInputString
+        .split(/[n,;]+/)
+        .map((doi) => doi.trim())
+        .filter(doi => doi.length > 0);
+
+    /* DOI regex to check if string adheres to https://doi.org/TEST|SANDBOX|10.xxxx/xxx-xxx-xxx */
+    const doiRegex = /^(https?:\/\/(dx\.)?doi\.org\/)?(10\.\d{4,9}|TEST|SANDBOX)\/[-._;()/:A-Z0-9]+$/i;
+
+    return rawDois.filter(doi => doiRegex.test(doi));
+}


### PR DESCRIPTION
In this PR:
- POST service via Axios
- useMutation hook
- Available 'create' button that now works :smile: 

When a user goes through the Create a VC form flow, a new VC will now be created if the information the form contains is correct!