### PR TITLE
Added e2e tests for accessibility and Create Virtual Collection flow without Keycloak mock

### DIFF
--- a/src/components/MultiStepForm/views/AboutView.tsx
+++ b/src/components/MultiStepForm/views/AboutView.tsx
@@ -17,16 +17,6 @@ const AboutView = ({data, onUpdate, wasValidated}: AboutViewProps) => {
     const isTitleInvalid = wasValidated && !data.title.trim();
     const isDescriptionInvalid = wasValidated && !data.description.trim();
 
-    const typeOptions = [
-        {
-          id: 'type-reference',
-          value: 'Reference Collection',
-          title: 'Reference Collection',
-          description: 'When publishing a gold-standard collection for others to use as an identification key.',
-          disabled: false,
-        }
-      ];
-
     return (
         <div id="about-view" className="form-view-container">
             <h2>About this collection</h2>
@@ -71,36 +61,19 @@ const AboutView = ({data, onUpdate, wasValidated}: AboutViewProps) => {
                 </div>
             </div>
 
-            <fieldset className="radio-card-fieldset">
-                {/* Legend provides context for screen readers */}
-                <legend className="form-label">Type</legend>
-                
-                <div className="radio-card-group">
-                    {typeOptions.map((option) => (
-                    <div key={option.id} className={`radio-card-wrapper ${option.disabled ? 'disabled' : ''}`}>
-                        <input
-                            type="radio"
-                            id={option.id}
-                            name="collection-type"
-                            value={option.value}
-                            checked={data.type === option.value}
-                            disabled={option.disabled}
-                            onChange={(e) => onUpdate({ type: e.target.value })}
-                            className="sr-only radio-card-input"
-                        />
-                        
-                        <label htmlFor={option.id} className="radio-card-label">
-                            <p className="radio-card-title">{option.title}</p>
-                            <p className="radio-card-description">{option.description}</p>
-                        </label>
+            <div className="reference-type">
+                <span className="form-label">Type</span>
+                <div className='reference-type-wrapper'>
+                    <div className="reference-type-label">
+                        <p className="reference-type-title">Reference Collection</p>
+                        <p className="reference-type-description">When publishing a gold-standard collection for others to use as an identification key.</p>
                     </div>
-                    ))}
                 </div>
 
                 <p id="form-type-subtitle" className="form-note">
                     Note: only Reference Collections are available at this time. Community Collections will be introduced in a future update.
                 </p>
-            </fieldset>
+            </div>
         </div>
     )
 }

--- a/src/components/MultiStepForm/views/AboutView.tsx
+++ b/src/components/MultiStepForm/views/AboutView.tsx
@@ -90,7 +90,7 @@ const AboutView = ({data, onUpdate, wasValidated}: AboutViewProps) => {
                         />
                         
                         <label htmlFor={option.id} className="radio-card-label">
-                            <h4 className="radio-card-title">{option.title}</h4>
+                            <p className="radio-card-title">{option.title}</p>
                             <p className="radio-card-description">{option.description}</p>
                         </label>
                     </div>

--- a/src/components/MultiStepForm/views/Views.scss
+++ b/src/components/MultiStepForm/views/Views.scss
@@ -47,7 +47,7 @@
         height: var(--general-card-height);
     }
 
-    .radio-card-fieldset {
+    .reference-type {
         border: none;
         padding: 0;
         margin: 0;
@@ -61,57 +61,25 @@
             margin: 0;
         }
 
-        .radio-card-group {
-            display: flex;
-            flex-direction: column;
+        .reference-type-wrapper {
+            max-width: var(--medium-card-width);
 
-            .radio-card-wrapper {
-                max-width: var(--medium-card-width);
+            .reference-type-label {
+                display: block;
+                padding: var(--spacing-m);
+                border: 2px solid var(--indigo-9);
+                border-radius: var(--border-radius-md);
+                text-align: center;
 
-                /* Visually hide input but keep accessible */
-                .radio-card-input {
-                    position: absolute;
-                    width: 1px;
-                    height: 1px;
-                    padding: 0;
-                    overflow: hidden;
-                    white-space: nowrap;
-                    border: 0;
-
-                    &:checked + .radio-card-label {
-                        border: 2px solid var(--indigo-9);
-                    }
-
-                    &:focus-visible + .radio-card-label {
-                        outline: 2px solid var(--indigo-9);
-                    }
-
-                    &:disabled + .radio-card-label {
-                        border-color: var(--medium-gray);
-                        background-color: var(--light-gray);
-                        cursor: not-allowed;
-                        opacity: 0.6;
-                    }
+                .reference-type-title {
+                    font-size: var(--sm-font-size);
+                    font-weight: var(--medium-font-weight);
+                    margin: 0;
                 }
 
-                .radio-card-label {
-                    display: block;
-                    padding: var(--spacing-m);
-                    border: 1px solid var(--medium-gray);
-                    border-radius: var(--border-radius-md);
-                    cursor: pointer;
-                    text-align: center;
-
-                    .radio-card-title {
-                        font-size: var(--sm-font-size);
-                        font-weight: var(--medium-font-weight);
-                        margin: 0;
-                    }
-
-                    .radio-card-description {
-                        color: var(--dark-gray);
-                        font-size: var(--xs-font-size);
-                    }
+                .reference-type-description {
+                    color: var(--dark-gray);
+                    font-size: var(--xs-font-size);
                 }
             }
         }

--- a/tests-e2e/accessibility.spec.ts
+++ b/tests-e2e/accessibility.spec.ts
@@ -72,3 +72,46 @@ test.describe('Accessibility', () => {
 		expect(results.length).toBe(0);
     });
 });
+
+test.describe('Accessibility', () => {
+    test('Create a Virtual Collection form flow', async ({ page }) => {
+        await mockGetVirtualCollections(page);
+		await mockGetSelectedVirtualCollection(page);
+		await mockGetVirtualCollectionDetails(page);
+
+		// When the accessibility suite goes to the create virtual collections page
+		await page.goto(testUrls.createVirtualCollection);
+
+		// Then the header should be visible
+		await expect(page.getByRole('heading', { name: 'Create Virtual Collection' })).toBeVisible();
+
+        // Then the first page should be checked for accessibility violations
+		const resultsViewOne = await checkA11y(page, 'Create Virtual Collection flow view 1');
+
+		// And the results should be 0
+		expect(resultsViewOne.length).toBe(0);
+
+        // When a user fills in title and description for a new virtual collection and clicks next
+        const nextButton = page.getByRole('button', { name: 'Next' });
+        await page.getByLabel('Title').fill('Dinosaur Virtual Collection');
+        await page.getByLabel('Description').fill('This Virtual Collection contains the coolest dinosaurs ever to walk the earth');
+        await nextButton.click();
+
+        // Then the second page should be checked for accessibility violations
+		const resultsViewTwo = await checkA11y(page, 'Create Virtual Collection flow view 2');
+
+		// And the results should be 0
+		expect(resultsViewTwo.length).toBe(0);
+        
+        // When the user fills in a few DOIs and proceeds to the next page
+        const specimenInput = page.getByLabel('Specimen DOIs');
+        await specimenInput.fill('https://doi.org/TEST/JDE-CGV-GNV, https://doi.org/TEST/W34-SKK-58F');
+        await nextButton.click();
+
+        // Then the third page should be checked for accessibility violations
+		const resultsViewThree = await checkA11y(page, 'Create Virtual Collection flow view 3');
+
+		// And the results should be 0
+		expect(resultsViewThree.length).toBe(0);
+    });
+});

--- a/tests-e2e/accessibility.spec.ts
+++ b/tests-e2e/accessibility.spec.ts
@@ -1,15 +1,12 @@
 /* Import test helpers */
 import { test, expect } from '@playwright/test';
-import { checkA11y, testUrls } from './test-utils';
-
-/* Import mock data */
-import { mockGetSelectedVirtualCollection, mockGetVirtualCollectionDetails, mockGetVirtualCollections } from './mocks/routes/routeMocks';
+import { checkA11y, setUpMockData } from './test-utils';
 
 /* Virtual Collections flow E2E test suite */
 test.describe('Accessibility', () => {
     test('About page components', async ({ page }) => {
         // When the accessibility suite goes to the about page
-        await page.goto(testUrls.about);
+        await page.goto('/about');
 
         // Then the navigation and footer should be visible
         await expect(page.getByRole('button', { name: 'Login / Sign-up'})).toBeVisible();
@@ -25,12 +22,10 @@ test.describe('Accessibility', () => {
 
 test.describe('Accessibility', () => {
     test('Virtual Collections page', async ({ page }) => {
-        await mockGetVirtualCollections(page);
-        await mockGetSelectedVirtualCollection(page);
-        await mockGetVirtualCollectionDetails(page);
+        setUpMockData(page);
 
         // When the accessibility suite goes to the virtual collections page
-        await page.goto(testUrls.virtualCollections);
+        await page.goto('/virtual-collections');
 
         // Then the header should be visible
         await expect(page.getByRole('heading', { name: 'Virtual Collections' })).toBeVisible();
@@ -45,12 +40,10 @@ test.describe('Accessibility', () => {
 
 test.describe('Accessibility', () => {
   	test('Virtual Collection Details page', async ({ page }) => {
-		await mockGetVirtualCollections(page);
-		await mockGetSelectedVirtualCollection(page);
-		await mockGetVirtualCollectionDetails(page);
+        setUpMockData(page);
 
 		// When the accessibility suite goes to the virtual collections page
-		await page.goto(testUrls.virtualCollections);
+		await page.goto('/virtual-collections');
 
 		// Then the header should be visible
 		await expect(page.getByRole('heading', { name: 'Virtual Collections' })).toBeVisible();
@@ -75,12 +68,10 @@ test.describe('Accessibility', () => {
 
 test.describe('Accessibility', () => {
     test('Create a Virtual Collection form flow', async ({ page }) => {
-        await mockGetVirtualCollections(page);
-		await mockGetSelectedVirtualCollection(page);
-		await mockGetVirtualCollectionDetails(page);
+        setUpMockData(page);
 
 		// When the accessibility suite goes to the create virtual collections page
-		await page.goto(testUrls.createVirtualCollection);
+		await page.goto('/virtual-collections/create');
 
 		// Then the header should be visible
 		await expect(page.getByRole('heading', { name: 'Create Virtual Collection' })).toBeVisible();

--- a/tests-e2e/accessibility.spec.ts
+++ b/tests-e2e/accessibility.spec.ts
@@ -89,7 +89,7 @@ test.describe('Accessibility', () => {
 		const resultsViewOne = await checkA11y(page, 'Create Virtual Collection flow view 1');
 
 		// And the results should be 0
-		expect(resultsViewOne.length).toBe(0);
+		expect(resultsViewOne).toHaveLength(0);
 
         // When a user fills in title and description for a new virtual collection and clicks next
         const nextButton = page.getByRole('button', { name: 'Next' });
@@ -101,7 +101,7 @@ test.describe('Accessibility', () => {
 		const resultsViewTwo = await checkA11y(page, 'Create Virtual Collection flow view 2');
 
 		// And the results should be 0
-		expect(resultsViewTwo.length).toBe(0);
+		expect(resultsViewTwo).toHaveLength(0);
         
         // When the user fills in a few DOIs and proceeds to the next page
         const specimenInput = page.getByLabel('Specimen DOIs');
@@ -112,6 +112,6 @@ test.describe('Accessibility', () => {
 		const resultsViewThree = await checkA11y(page, 'Create Virtual Collection flow view 3');
 
 		// And the results should be 0
-		expect(resultsViewThree.length).toBe(0);
+		expect(resultsViewThree).toHaveLength(0);
     });
 });

--- a/tests-e2e/accessibility.spec.ts
+++ b/tests-e2e/accessibility.spec.ts
@@ -22,7 +22,7 @@ test.describe('Accessibility', () => {
 
 test.describe('Accessibility', () => {
     test('Virtual Collections page', async ({ page }) => {
-        setUpMockData(page);
+        await setUpMockData(page);
 
         // When the accessibility suite goes to the virtual collections page
         await page.goto('/virtual-collections');
@@ -40,7 +40,7 @@ test.describe('Accessibility', () => {
 
 test.describe('Accessibility', () => {
   	test('Virtual Collection Details page', async ({ page }) => {
-        setUpMockData(page);
+        await setUpMockData(page);
 
 		// When the accessibility suite goes to the virtual collections page
 		await page.goto('/virtual-collections');
@@ -68,7 +68,7 @@ test.describe('Accessibility', () => {
 
 test.describe('Accessibility', () => {
     test('Create a Virtual Collection form flow', async ({ page }) => {
-        setUpMockData(page);
+        await setUpMockData(page);
 
 		// When the accessibility suite goes to the create virtual collections page
 		await page.goto('/virtual-collections/create');

--- a/tests-e2e/mocks/routes/routeMocks.ts
+++ b/tests-e2e/mocks/routes/routeMocks.ts
@@ -8,7 +8,7 @@ import { mockSelectedVirtualCollection } from '../data/mockSelectedVirtualCollec
 
 /* Route mock for the getVirtualCollections service that fulfills the request with a mocked virtualCollections data */
 export async function mockGetVirtualCollections(page: Page) {
-    await page.route('**/virtual-collection/v1', async (route) => {
+    await page.route('**/virtual-collection/v1?pageSize=60&pageNumber=1', async (route) => {
         if(route.request().method() === 'GET') {
             await route.fulfill({
                 status: 200,
@@ -44,6 +44,19 @@ export async function mockGetSelectedVirtualCollection(page: Page) {
                 status: 200,
                 contentType: 'application/json',
                 body: JSON.stringify(mockSelectedVirtualCollection)
+            })
+        } else {
+            await route.continue();
+        }
+    })
+}
+
+/* Route mock for the postNewVirtualCollection service that intercepts the POST during testing and returns a status 200 OK. */
+export async function mockPostNewVirtualCollection(page: Page) {
+    await page.route('**/virtual-collection/v1', async (route) => {
+        if(route.request().method() === 'POST') {
+            await route.fulfill({
+                status: 200
             })
         } else {
             await route.continue();

--- a/tests-e2e/test-utils.ts
+++ b/tests-e2e/test-utils.ts
@@ -1,4 +1,5 @@
 import AxeBuilder from "@axe-core/playwright";
+import { mockGetSelectedVirtualCollection, mockGetVirtualCollectionDetails, mockGetVirtualCollections } from "./mocks/routes/routeMocks";
 
 /**
  * This utility function logs a console.error if any violations in the A11Y scan are found
@@ -34,9 +35,7 @@ export async function checkA11y(page: any, pageName: string, options?: any) {
     return results.violations;
 }
 
-export const testUrls = {
-    home: '/',
-    about: '/about',
-    virtualCollections: '/virtual-collections',
-    createVirtualCollection: '/virtual-collections/create'
+/* Utility function to execute all promises for setting up mock data for testing */
+export async function setUpMockData(page: any) {
+  Promise.all([mockGetVirtualCollections(page), mockGetSelectedVirtualCollection(page), mockGetVirtualCollectionDetails(page)]);
 }

--- a/tests-e2e/test-utils.ts
+++ b/tests-e2e/test-utils.ts
@@ -37,5 +37,6 @@ export async function checkA11y(page: any, pageName: string, options?: any) {
 export const testUrls = {
     home: '/',
     about: '/about',
-    virtualCollections: '/virtual-collections',   
+    virtualCollections: '/virtual-collections',
+    createVirtualCollection: '/virtual-collections/create'
 }

--- a/tests-e2e/test-utils.ts
+++ b/tests-e2e/test-utils.ts
@@ -37,5 +37,5 @@ export async function checkA11y(page: any, pageName: string, options?: any) {
 
 /* Utility function to execute all promises for setting up mock data for testing */
 export async function setUpMockData(page: any) {
-  Promise.all([mockGetVirtualCollections(page), mockGetSelectedVirtualCollection(page), mockGetVirtualCollectionDetails(page)]);
+  await Promise.all([mockGetVirtualCollections(page), mockGetSelectedVirtualCollection(page), mockGetVirtualCollectionDetails(page)]);
 }

--- a/tests-e2e/test-utils.ts
+++ b/tests-e2e/test-utils.ts
@@ -37,5 +37,5 @@ export async function checkA11y(page: any, pageName: string, options?: any) {
 
 /* Utility function to execute all promises for setting up mock data for testing */
 export async function setUpMockData(page: any) {
-  await Promise.all([mockGetVirtualCollections(page), mockGetSelectedVirtualCollection(page), mockGetVirtualCollectionDetails(page)]);
+  return Promise.all([mockGetVirtualCollections(page), mockGetSelectedVirtualCollection(page), mockGetVirtualCollectionDetails(page)]);
 }

--- a/tests-e2e/virtualCollections.spec.ts
+++ b/tests-e2e/virtualCollections.spec.ts
@@ -1,17 +1,14 @@
 /* Import test helpers */
 import { test, expect } from '@playwright/test';
-import { testUrls } from './test-utils';
-import { mockGetSelectedVirtualCollection, mockGetVirtualCollectionDetails, mockGetVirtualCollections } from './mocks/routes/routeMocks';
+import { setUpMockData } from './test-utils';
 
 /* Virtual Collections flow E2E test suite */
 test.describe('Virtual Collections', () => {
     test('should open the content of a virtual collection and route to the digital specimen page of a specific collection', async ({ page }) => {
-        await mockGetVirtualCollections(page);
-        await mockGetSelectedVirtualCollection(page);
-        await mockGetVirtualCollectionDetails(page);
+        setUpMockData(page);
 
         // Given a user goes to the virtual collections page
-        await page.goto(testUrls.virtualCollections);
+        await page.goto('/virtual-collections');
 
         // When the user clicks on the first available card on the virtual collection overview page
         const firstCard = page.getByRole('link', { name: 'Reference Collection Type'});
@@ -28,12 +25,10 @@ test.describe('Virtual Collections', () => {
         await expect(page).toHaveURL(/\/ds\/TEST\//);
     });
     test('should route to the virtual collection details page and back', async ({ page }) => {
-        await mockGetVirtualCollections(page);
-        await mockGetSelectedVirtualCollection(page);
-        await mockGetVirtualCollectionDetails(page);
+        setUpMockData(page);
 
         // Given a user goes to the virtual collections page
-        await page.goto(testUrls.virtualCollections);
+        await page.goto('/virtual-collections');
 
         // When the user clicks on the first available card on the virtual collection overview page
         const firstCard = page.getByRole('link', { name: 'Reference Collection Type'});
@@ -50,12 +45,10 @@ test.describe('Virtual Collections', () => {
         await expect(page).toHaveURL(/\/virtual-collections/);
     });
     test('should use paginator to go through virtual collections', async ({ page }) => {
-        await mockGetVirtualCollections(page);
-        await mockGetSelectedVirtualCollection(page);
-        await mockGetVirtualCollectionDetails(page);
+        setUpMockData(page);
 
         // Given a user goes to the virtual collections page
-        await page.goto(testUrls.virtualCollections);
+        await page.goto('/virtual-collections');
 
         // When the user clicks on the first available card on the virtual collection overview page
         const firstCardAvailable = page.locator('.gallery-card').first();
@@ -74,12 +67,10 @@ test.describe('Virtual Collections', () => {
 
 test.describe('Create a Virtual Collection and everything is successfull', () => {
     test('should go through the \'Create a virtual collection\' flow via the button on the VC page', async ({ page }) => {
-        await mockGetVirtualCollections(page);
-        await mockGetSelectedVirtualCollection(page);
-        await mockGetVirtualCollectionDetails(page);
+        setUpMockData(page);
 
         // Given a user goes to the create a virtual collection page
-        await page.goto(testUrls.createVirtualCollection);
+        await page.goto('/virtual-collections/create');
 
         // When a user fails to fill in anything and clicks on the next
         const nextButton = page.getByRole('button', { name: 'Next' });

--- a/tests-e2e/virtualCollections.spec.ts
+++ b/tests-e2e/virtualCollections.spec.ts
@@ -71,3 +71,51 @@ test.describe('Virtual Collections', () => {
         await expect(secondPagePaginator).toBeVisible();
     });
 });
+
+test.describe('Create a Virtual Collection and everything is successfull', () => {
+    test('should go through the \'Create a virtual collection\' flow via the button on the VC page', async ({ page }) => {
+        await mockGetVirtualCollections(page);
+        await mockGetSelectedVirtualCollection(page);
+        await mockGetVirtualCollectionDetails(page);
+
+        // Given a user goes to the create a virtual collection page
+        await page.goto(testUrls.createVirtualCollection);
+
+        // When a user fails to fill in anything and clicks on the next
+        const nextButton = page.getByRole('button', { name: 'Next' });
+        await nextButton.click();
+
+        // Then the validation for the form should be shown
+        const titleValidation = page.getByText('Please enter a title.');
+        const descriptionValidation = page.getByText('Please describe your virtual collection.');
+        await expect(titleValidation).toBeVisible();
+        await expect(descriptionValidation).toBeVisible();
+
+        // When a user fills in title and description for a new virtual collection
+        await page.getByLabel('Title').fill('Dinosaur Virtual Collection');
+        await page.getByLabel('Description').fill('This Virtual Collection contains the coolest dinosaurs ever to walk the earth');
+
+        // Then the user should be able to proceed to the next page by clicking on the next button
+        await nextButton.click();
+
+        // When a user fails to fill in DOIs and tries to proceed to the next page
+        const specimenInput = page.getByLabel('Specimen DOIs');
+        await expect(specimenInput).toBeVisible();
+        await nextButton.click();
+
+        // Then the validation for the form should be shown
+        const specimenValidation = page.getByText('Please enter the specimen DOIs for this Virtual Collection');
+        await expect(specimenValidation).toBeVisible();
+
+        // When the user fills in a few DOIs and proceeds to the next page
+        await specimenInput.fill('https://doi.org/TEST/JDE-CGV-GNV, https://doi.org/TEST/W34-SKK-58F');
+        await nextButton.click();
+
+        // Then the user should see the confirm page with filled in information
+        await expect(page.getByText('Review and confirm')).toBeVisible();
+
+        // Then the request can be confirmed by clicking on the create collection button
+        const createCollectionButton = page.getByRole('button', { name: 'Create collection' });
+        await createCollectionButton.click();
+    });
+});

--- a/tests-e2e/virtualCollections.spec.ts
+++ b/tests-e2e/virtualCollections.spec.ts
@@ -5,7 +5,7 @@ import { setUpMockData } from './test-utils';
 /* Virtual Collections flow E2E test suite */
 test.describe('Virtual Collections', () => {
     test('should open the content of a virtual collection and route to the digital specimen page of a specific collection', async ({ page }) => {
-        setUpMockData(page);
+        await setUpMockData(page);
 
         // Given a user goes to the virtual collections page
         await page.goto('/virtual-collections');
@@ -25,7 +25,7 @@ test.describe('Virtual Collections', () => {
         await expect(page).toHaveURL(/\/ds\/TEST\//);
     });
     test('should route to the virtual collection details page and back', async ({ page }) => {
-        setUpMockData(page);
+        await setUpMockData(page);
 
         // Given a user goes to the virtual collections page
         await page.goto('/virtual-collections');
@@ -45,7 +45,7 @@ test.describe('Virtual Collections', () => {
         await expect(page).toHaveURL(/\/virtual-collections/);
     });
     test('should use paginator to go through virtual collections', async ({ page }) => {
-        setUpMockData(page);
+        await setUpMockData(page);
 
         // Given a user goes to the virtual collections page
         await page.goto('/virtual-collections');
@@ -67,7 +67,7 @@ test.describe('Virtual Collections', () => {
 
 test.describe('Create a Virtual Collection and everything is successfull', () => {
     test('should go through the \'Create a virtual collection\' flow via the button on the VC page', async ({ page }) => {
-        setUpMockData(page);
+        await setUpMockData(page);
 
         // Given a user goes to the create a virtual collection page
         await page.goto('/virtual-collections/create');


### PR DESCRIPTION
**In this PR:**
- Accessibility test for all 3 views of the multistep form with a fix for one issue
- E2E test for the Create Virtual Collection flow with filling in inputs and testing validation.

**What is not in this PR:**
An adequate mock of the roles in Keycloak. I have not been able to mock this properly, so I found a workaround (go to the /create url directly). I need more time to figure this out.