### PR TITLE
Added copy and annotation functionality

### DIFF
--- a/src/components/Cards/DigitalSpecimenCard/DigitalSpecimenCard.tsx
+++ b/src/components/Cards/DigitalSpecimenCard/DigitalSpecimenCard.tsx
@@ -9,6 +9,7 @@ import './DigitalSpecimenCard.scss';
 
 /* Import types */
 import { UIProperty } from "types/dataMapperTypes";
+import { useClipboard } from "hooks/useClipboard";
 
 type SpecimenField = {
     label: string;
@@ -23,13 +24,24 @@ type Props = {
     copy?: boolean,
     fragment: SpecimenField[],
     georeference?: boolean
-    citation?: boolean
+    citation?: boolean,
+    AnnotateHelper?: Function
 }
 
-export const DigitalSpecimenCard = ({ cardHeader, annotate, copy, fragment, georeference = false, citation = false }: Props) => {
+export const DigitalSpecimenCard = ({ cardHeader, annotate, copy: copyFunctionality, fragment, georeference = false, citation = false, AnnotateHelper }: Props) => {
     /* Base variables */
     const getFieldValueByLabel = (labelName: string) => {
         return fragment.find((item) => item.label === labelName)?.value;
+    };
+    const { copy, hasCopied } = useClipboard();
+
+    /* Craft plain text citation for the copy button */
+    const getCitationText = () => {
+        const orgId = getFieldValueByLabel('Organisation ID');
+        const orgName = getFieldValueByLabel('Organisation Name') ?? orgId ?? '';
+        const digitalSpecimenId = getFieldValueByLabel('DOI') ?? getFieldValueByLabel('Digital Specimen ID') ?? '';
+
+        return `${orgName} (${new Date().getFullYear()}). Distributed System of Scientific Collections. [Dataset]. ${digitalSpecimenId}`.trim();
     };
 
     /* Craft citation based on a number of fields */
@@ -69,15 +81,15 @@ export const DigitalSpecimenCard = ({ cardHeader, annotate, copy, fragment, geor
         <Card className="digital-specimen-card">
             <div className="ds-card-header">
                 <h2>{cardHeader}</h2>
-                { annotate &&
-                    <Button variant="ghost">
+                { annotate && AnnotateHelper &&
+                    <Button variant="ghost" onClick={() => AnnotateHelper()}>
                         Annotate
                         <Pencil2Icon />
                     </Button>
                 }
-                { copy && 
-                    <Button variant="ghost">
-                        Copy
+                { copyFunctionality && 
+                    <Button variant="ghost" onClick={() => copy(getCitationText())}>
+                         {hasCopied ? 'Copied!' : 'Copy'}
                         <CopyIcon />
                     </Button>
                 }

--- a/src/components/Cards/DigitalSpecimenCard/DigitalSpecimenCard.tsx
+++ b/src/components/Cards/DigitalSpecimenCard/DigitalSpecimenCard.tsx
@@ -9,6 +9,9 @@ import './DigitalSpecimenCard.scss';
 
 /* Import types */
 import { UIProperty } from "types/dataMapperTypes";
+import { AnnotationTargetPayload } from 'types/digitalSpecimenTypes';
+
+/* Import hooks */
 import { useClipboard } from "hooks/useClipboard";
 
 type SpecimenField = {
@@ -19,16 +22,26 @@ type SpecimenField = {
 }
 
 type Props = {
-    cardHeader: string,
-    annotate?: boolean,
-    copy?: boolean,
-    fragment: SpecimenField[],
-    georeference?: boolean
-    citation?: boolean,
-    AnnotateHelper?: Function
-}
+    cardHeader: string;
+    annotate?: boolean;
+    copy?: boolean;
+    fragment: SpecimenField[];
+    georeference?: boolean;
+    citation?: boolean;
+    annotationTarget?: AnnotationTargetPayload;
+    AnnotateHelper?: (target?: AnnotationTargetPayload) => void;
+};
 
-export const DigitalSpecimenCard = ({ cardHeader, annotate, copy: copyFunctionality, fragment, georeference = false, citation = false, AnnotateHelper }: Props) => {
+export const DigitalSpecimenCard = ({
+    cardHeader,
+    annotate,
+    copy: copyFunctionality,
+    fragment,
+    georeference = false,
+    citation = false,
+    annotationTarget,
+    AnnotateHelper
+}: Props) => {
     /* Base variables */
     const getFieldValueByLabel = (labelName: string) => {
         return fragment.find((item) => item.label === labelName)?.value;
@@ -82,7 +95,10 @@ export const DigitalSpecimenCard = ({ cardHeader, annotate, copy: copyFunctional
             <div className="ds-card-header">
                 <h2>{cardHeader}</h2>
                 { annotate && AnnotateHelper &&
-                    <Button variant="ghost" onClick={() => AnnotateHelper()}>
+                    <Button 
+                        variant="ghost" 
+                        onClick={() => AnnotateHelper(annotationTarget)}
+                    >
                         Annotate
                         <Pencil2Icon />
                     </Button>

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -28,6 +28,7 @@ type Props = {
     showCreateButton?: boolean;
     isHtml?: boolean;
     annotate?: boolean;
+    AnnotateHelper?: Function
 }
 
 /**
@@ -41,7 +42,7 @@ type Props = {
  * @param showCreateButton Boolean that indicates if the functionality for creating a VC should be working
  * @returns A JSX element that shows a Hero banner with information and possibly navigation
  */
-export const Hero = ( { title, description, badge, navigateTo, showShareButton, details, showCreateButton, isHtml = false, annotate }: Props) => {
+export const Hero = ( { title, description, badge, navigateTo, showShareButton, details, showCreateButton, isHtml = false, annotate, AnnotateHelper }: Props) => {
     /* Hooks */
     const navigate = useNavigate();
     const isAllowedToCreateVC = useHasRole('dissco-virtual-collection');
@@ -85,8 +86,8 @@ export const Hero = ( { title, description, badge, navigateTo, showShareButton, 
                 }
                 </div>
                 <div id="hero-top-buttons-right">
-                {annotate &&
-                    <Button variant="solid">
+                {annotate && AnnotateHelper &&
+                    <Button variant="solid" onClick={() => AnnotateHelper()}>
                         Annotate
                         <Pencil2Icon />
                     </Button>

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.scss
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.scss
@@ -1,23 +1,64 @@
-.digital-specimen-container {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: var(--spacing-l);
+/* Page Wrapper context */
+.digital-specimen-page {
+	position: relative;
+	min-height: 100vh;
 
-	#ds-right-column, #ds-left-column {
-		.digital-specimen-card {
-			margin-block-end: var(--spacing-l);
-			padding: var(--spacing-m);
-
-			.ds-card-header {
-				display: flex;
-				justify-content: space-between;
-				align-items: center;
-
-				h2 {
-					font-size: var(--md-font-size);
-					margin: 0;
+	.digital-specimen-container {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--spacing-l);
+	
+		#ds-right-column, #ds-left-column {
+			.digital-specimen-card {
+				margin-block-end: var(--spacing-l);
+				padding: var(--spacing-m);
+	
+				.ds-card-header {
+					display: flex;
+					justify-content: space-between;
+					align-items: center;
+	
+					h2 {
+						font-size: var(--md-font-size);
+						margin: 0;
+					}
 				}
 			}
 		}
+	}
+
+	.annotation-panel-overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100vw;
+		height: 100vh;
+		background-color: rgba(0, 0, 0, 0.25);
+		z-index: 998;
+		border: none;
+	}
+	.annotation-panel-container {
+		position: fixed;
+		top: 0;
+		right: 0;
+		width: 420px; /* Adjust width as preferred */
+		max-width: 90vw;
+		height: 100vh;
+		background-color: #ffffff;
+		box-shadow: -4px 0 16px rgba(0, 0, 0, 0.15);
+		z-index: 999;
+		overflow-y: auto;
+		
+		/* Smooth enter animation */
+		animation: slideInRight 0.25s ease-out forwards;
+	}
+}
+
+@keyframes slideInRight {
+	from {
+	  transform: translateX(100%);
+	}
+	to {
+	  transform: translateX(0);
 	}
 }

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.scss
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.scss
@@ -1,3 +1,5 @@
+@use "styles/animations.scss" as *;
+
 /* Page Wrapper context */
 .digital-specimen-page {
 	position: relative;
@@ -33,32 +35,20 @@
 		left: 0;
 		width: 100vw;
 		height: 100vh;
-		background-color: rgba(0, 0, 0, 0.25);
-		z-index: 998;
+		background-color: var(--overlay-black);
 		border: none;
 	}
 	.annotation-panel-container {
 		position: fixed;
 		top: 0;
 		right: 0;
-		width: 420px; /* Adjust width as preferred */
-		max-width: 90vw;
+		width: var(--content-spacing);
 		height: 100vh;
-		background-color: #ffffff;
-		box-shadow: -4px 0 16px rgba(0, 0, 0, 0.15);
-		z-index: 999;
+		box-shadow: -4px 0 var(--spacing-m) var(--overlay-black);
+		z-index: 1;
 		overflow-y: auto;
 		
 		/* Smooth enter animation */
 		animation: slideInRight 0.25s ease-out forwards;
-	}
-}
-
-@keyframes slideInRight {
-	from {
-	  transform: translateX(100%);
-	}
-	to {
-	  transform: translateX(0);
 	}
 }

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
@@ -6,7 +6,7 @@ import { Hero } from 'components/Hero/Hero';
 import { useDigitalSpecimenComplete } from 'hooks/useDigitalSpecimen';
 
 /* Import types and enums */
-import { CardCategory, CARD_CONFIGS, LEFT_COLUMN_CATEGORIES } from 'types/digitalSpecimenTypes';
+import { CardCategory, CARD_CONFIGS, LEFT_COLUMN_CATEGORIES, AnnotationTargetPayload } from 'types/digitalSpecimenTypes';
 import { CategoryConfig, MappedCategories, UIProperty } from 'types/dataMapperTypes';
 
 /* Import styling */
@@ -20,17 +20,26 @@ import GetDigitalSpecimenMas from 'api/digitalSpecimen/GetDigitalSpecimenMas';
 import GetDigitalSpecimenMasJobRecords from 'api/digitalSpecimen/GetDigitalSpecimenMasJobRecords';
 import ScheduleDigitalSpecimenMas from 'api/digitalSpecimen/ScheduleDigitalSpecimenMas';
 
-/* Schemas */
+/* Import schemas */
 import DigitalSpecimenSchema from 'sources/dataModel/digitalSpecimen.json';
 import DigitalSpecimenAnnotationCases from 'sources/annotationCases/DigitalSpecimenAnnotationCases.json';
 
+/* Import hooks */
+import { useAppDispatch } from 'app/Hooks';
+
+/* Import store */
+import { setAnnotationTarget } from 'redux-store/AnnotateSlice';
+
 const DigitalSpecimenDetails = () => {
+    /* Hooks */
+    const dispatch = useAppDispatch();
+
     /* Base variables */
     const url = new URL(globalThis.location.href);
     const segments = url.pathname.split('/');
     const identifier = segments.slice(2).join("/");
     const { data: specimen, isLoading, isError } = useDigitalSpecimenComplete({ doi: identifier});
-    const [ annotationMode, setAnnotationMode ] = useState(false);
+    const [annotationMode, setAnnotationMode] = useState(false);
 
     if (isLoading) return <main><p>Retrieving the Digital Specimen Details...</p></main>;
     if (!specimen) return <main><p>No data found</p></main>
@@ -51,6 +60,20 @@ const DigitalSpecimenDetails = () => {
         return getCardFragment(category).find((field: UIProperty) => field.label === label)?.value;
     };
 
+    const handleOpenAnnotation = (target?: AnnotationTargetPayload) => {
+        if (target) {
+            dispatch(setAnnotationTarget(target));
+        } else {
+            /* Fallback if no target is specified, jsonPath resolves to entire class */
+            dispatch(setAnnotationTarget({
+                type: 'class',
+                jsonPath: "",
+                directPath: true
+            }));
+        }
+        setAnnotationMode(true);
+    };
+
     return (
         <div className="digital-specimen-page">
             <Hero
@@ -64,7 +87,7 @@ const DigitalSpecimenDetails = () => {
                     color: 'grass'
                 }]}
                 annotate={true}
-                AnnotateHelper={() => setAnnotationMode(true)}
+                AnnotateHelper={() => handleOpenAnnotation()}
             >
             </Hero>
             <main className="digital-specimen-container">
@@ -74,7 +97,7 @@ const DigitalSpecimenDetails = () => {
                             key={category.name}
                             cardHeader={category.name} 
                             fragment={category.data}
-                            AnnotateHelper={() => setAnnotationMode(true)}
+                            AnnotateHelper={handleOpenAnnotation}
                             {...CARD_CONFIGS[category.name as CardCategory]} 
                         />
                     ))}
@@ -85,7 +108,7 @@ const DigitalSpecimenDetails = () => {
                             key={category.name}
                             cardHeader={category.name} 
                             fragment={category.data}
-                            AnnotateHelper={() => setAnnotationMode(true)}
+                            AnnotateHelper={handleOpenAnnotation}
                             {...CARD_CONFIGS[category.name as CardCategory]} 
                         />
                     ))}

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
@@ -134,7 +134,8 @@ const DigitalSpecimenDetails = () => {
             </main>
             {annotationMode && (
                 <>
-                    <button 
+                    <button
+                        type="button"
                         className="annotation-panel-overlay"
                         tabIndex={0}
                         aria-label="Close annotation panel"

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
@@ -11,6 +11,18 @@ import { CategoryConfig, MappedCategories, UIProperty } from 'types/dataMapperTy
 
 /* Import styling */
 import './DigitalSpecimenOverview.scss';
+import { useState } from 'react';
+import { AnnotationSidePanel } from 'components/elements/Elements';
+
+/* Import API */
+import GetDigitalSpecimenComplete from 'api/digitalSpecimen/GetDigitalSpecimenComplete';
+import GetDigitalSpecimenMas from 'api/digitalSpecimen/GetDigitalSpecimenMas';
+import GetDigitalSpecimenMasJobRecords from 'api/digitalSpecimen/GetDigitalSpecimenMasJobRecords';
+import ScheduleDigitalSpecimenMas from 'api/digitalSpecimen/ScheduleDigitalSpecimenMas';
+
+/* Schemas */
+import DigitalSpecimenSchema from 'sources/dataModel/digitalSpecimen.json';
+import DigitalSpecimenAnnotationCases from 'sources/annotationCases/DigitalSpecimenAnnotationCases.json';
 
 const DigitalSpecimenDetails = () => {
     /* Base variables */
@@ -18,6 +30,7 @@ const DigitalSpecimenDetails = () => {
     const segments = url.pathname.split('/');
     const identifier = segments.slice(2).join("/");
     const { data: specimen, isLoading, isError } = useDigitalSpecimenComplete({ doi: identifier});
+    const [ annotationMode, setAnnotationMode ] = useState(false);
 
     if (isLoading) return <main><p>Retrieving the Digital Specimen Details...</p></main>;
     if (!specimen) return <main><p>No data found</p></main>
@@ -39,7 +52,7 @@ const DigitalSpecimenDetails = () => {
     };
 
     return (
-        <>
+        <div className="digital-specimen-page">
             <Hero
                 title={getFieldValue(CardCategory.Identification, 'Scientific Name')}
                 navigateTo={{ pathName:"/search", text: "Specimens"}}
@@ -51,6 +64,7 @@ const DigitalSpecimenDetails = () => {
                     color: 'grass'
                 }]}
                 annotate={true}
+                AnnotateHelper={() => setAnnotationMode(true)}
             >
             </Hero>
             <main className="digital-specimen-container">
@@ -60,6 +74,7 @@ const DigitalSpecimenDetails = () => {
                             key={category.name}
                             cardHeader={category.name} 
                             fragment={category.data}
+                            AnnotateHelper={() => setAnnotationMode(true)}
                             {...CARD_CONFIGS[category.name as CardCategory]} 
                         />
                     ))}
@@ -69,13 +84,41 @@ const DigitalSpecimenDetails = () => {
                         <DigitalSpecimenCard 
                             key={category.name}
                             cardHeader={category.name} 
-                            fragment={category.data} 
+                            fragment={category.data}
+                            AnnotateHelper={() => setAnnotationMode(true)}
                             {...CARD_CONFIGS[category.name as CardCategory]} 
                         />
                     ))}
                 </div>
             </main>
-        </>
+            {annotationMode && (
+                <>
+                    <button 
+                        className="annotation-panel-overlay"
+                        tabIndex={0}
+                        aria-label="Close annotation panel"
+                        onClick={() => setAnnotationMode(false)} 
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                setAnnotationMode(false);
+                            }
+                        }}
+                    ></button>
+                    <aside className="annotation-panel-container">
+                        <AnnotationSidePanel
+                            superClass={specimen.data.attributes.digitalSpecimen}
+                            schema={DigitalSpecimenSchema}
+                            annotationCases={DigitalSpecimenAnnotationCases.annotationCases}
+                            GetAnnotations={GetDigitalSpecimenComplete}
+                            GetMas={GetDigitalSpecimenMas}
+                            GetMasJobRecords={GetDigitalSpecimenMasJobRecords}
+                            ScheduleMas={ScheduleDigitalSpecimenMas}
+                            HideAnnotationSidePanel={() => setAnnotationMode(false)}
+                        />
+                    </aside>
+                </>
+            )}
+        </div>
     );
 };
 

--- a/src/styles/animations.scss
+++ b/src/styles/animations.scss
@@ -1,0 +1,8 @@
+@keyframes slideInRight {
+	from {
+	  transform: translateX(100%);
+	}
+	to {
+	  transform: translateX(0);
+	}
+}

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -103,4 +103,7 @@
     --light-gray: var(--gray-a2);
     --medium-gray: var(--gray-a5);
     --dark-gray: var(--gray-a11);
+
+    /* Overlays */
+    --overlay-black: #00000044;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -4,3 +4,4 @@
 @use "typography.scss" as *;
 @use "mixins.scss" as *;
 @use "general.scss" as *;
+@use "animations.scss" as *;

--- a/src/types/digitalSpecimenTypes.ts
+++ b/src/types/digitalSpecimenTypes.ts
@@ -19,10 +19,31 @@ export interface CardConfig {
     citation?: boolean;
 }
 
-export const CARD_CONFIGS: Record<CardCategory, Partial<CardConfig>> = {
+export type AnnotationTargetPayload = {
+    type: 'class' | 'term';
+    jsonPath: string;
+    directPath?: boolean;
+};
+
+export const CARD_CONFIGS: Record<CardCategory, Partial<CardConfig> & { annotationTarget?: AnnotationTargetPayload }> = {
     [CardCategory.SpecimenRecord]: {},
-    [CardCategory.Identification]: { annotate: true },
-    [CardCategory.Location]: { annotate: true, georeference: true },
+    [CardCategory.Identification]: { 
+        annotate: true,
+        annotationTarget: {
+            type: 'class',
+            jsonPath: "$['ods:hasIdentifications'][0]['ods:hasTaxonIdentifications'][0]",
+            directPath: true
+        }
+    },
+    [CardCategory.Location]: { 
+        annotate: true, 
+        georeference: true,
+        annotationTarget: {
+            type: 'class',
+            jsonPath: "$['ods:hasEvents'][0]['ods:hasLocation']['ods:hasGeoreference']",
+            directPath: true
+        }
+    },
     [CardCategory.CollectingEvent]: {},
     [CardCategory.CitationAndLicense]: { copy: true, citation: true }
 };


### PR DESCRIPTION
**In this pr:**
- Copy functionality
- Annotation functionality: It slides over the page now, and exiting the flow can be through the X or clicking (or typing) anywhere on the page :)

**Note**: Functionality is partly old and cannot be adjusted yet. I had to hoist in a lot of older code, and I am not happy about it. But the refactor of the annotation flow is a completely different user story.

Jira ticket: https://naturalis.atlassian.net/browse/DD-3085

**What it looks like:**
<img width="1845" height="1116" alt="image" src="https://github.com/user-attachments/assets/2e883b4b-1ab5-41a1-a960-26206f0706b9" />

