### PR TITLE
Mobile & a11y check for the Digital Specimen Overview

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -22,6 +22,9 @@ CVE-2026-12143
 # js-yaml is a dependency of json-schema-to-typescript and cannot be updated Jul-22-2026
 CVE-2026-59869
 
+# React-router-dom needs to be upgraded from 7 to 8 Jul-28-2926
+GHSA-qwww-vcr4-c8h2
+
 # Vulnerabilities in Image
 # libcrypto3 included in the image, cannot fix Jun-12-2026
 CVE-2026-45447

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "react-leaflet": "^4.2.1",
         "react-markdown": "^10.1.0",
         "react-redux": "^9.1.2",
-        "react-router-dom": "^7.16.0",
+        "react-router-dom": "^7.18.1",
         "react-select": "^5.8.3",
         "react-tabs": "^6.0.2",
         "rehype-raw": "^7.0.0",
@@ -11060,9 +11060,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -11082,12 +11082,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-leaflet": "^4.2.1",
     "react-markdown": "^10.1.0",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^7.16.0",
+    "react-router-dom": "^7.18.1",
     "react-select": "^5.8.3",
     "react-tabs": "^6.0.2",
     "rehype-raw": "^7.0.0",

--- a/src/components/Cards/DigitalMediaCard/DigitalMediaCard.scss
+++ b/src/components/Cards/DigitalMediaCard/DigitalMediaCard.scss
@@ -1,6 +1,13 @@
+@use "styles/mixins.scss" as *;
+
 .digital-media-container {
-    position: sticky;
-    top: 0;
+    position: initial;
+
+    @include mediumAndUp {
+        position: sticky;
+        top: 0;
+    }
+
     .digital-media-card { 
         a {
             .digital-media-card-image {
@@ -15,8 +22,7 @@
     
     .digital-media-list {
         display: flex;
-        margin-block-start: var(--spacing-sm);
-        position: sticky;
+        margin-block: var(--spacing-m) var(--spacing-l);
 
         .digital-media-thumb-btn {
             border: none;

--- a/src/components/Cards/DigitalSpecimenCard/DigitalSpecimenCard.scss
+++ b/src/components/Cards/DigitalSpecimenCard/DigitalSpecimenCard.scss
@@ -1,3 +1,5 @@
+@use "styles/mixins.scss" as *;
+
 .digital-specimen-card {
     .ds-card-header {
         margin-bottom: var(--spacing-m);
@@ -25,9 +27,13 @@
         }
     }
     .ds-card-body {
-        display: grid;
-        grid-template-columns: var(--general-card-height) 1fr;
-        gap: var(--spacing-sm) var(--spacing-m);
-        align-items: start;
+        display: block;
+    
+        @include smallAndUp {
+            display: grid;
+            grid-template-columns: var(--general-card-height) 1fr;
+            gap: var(--spacing-sm) var(--spacing-m);
+            align-items: start;
+        }
     }
 }

--- a/src/components/LabelValuePair/LabelValuePair.scss
+++ b/src/components/LabelValuePair/LabelValuePair.scss
@@ -1,3 +1,5 @@
+@use "styles/mixins.scss" as *;
+
 .property-row-fragment {
     display: contents;
 
@@ -13,7 +15,11 @@
     .property-value {
         font-size: var(--sm-font-size);
         font-weight: var(--regular-font-weight);
+        margin-block-end: var(--spacing-m);
 
+        @include smallAndUp {
+            margin-block-end: var(--spacing-sm);
+        }
         a {
             svg {
                 margin-inline-start: var(--spacing-xs);

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.scss
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.scss
@@ -1,4 +1,5 @@
 @use "styles/animations.scss" as *;
+@use "styles/mixins.scss" as *;
 
 /* Page Wrapper context */
 .digital-specimen-page {
@@ -6,28 +7,43 @@
 	min-height: 100vh;
 
 	.digital-specimen-container {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: var(--spacing-l);
-	
-		#ds-right-column, #ds-left-column {
-			.digital-specimen-card {
-				margin-block-end: var(--spacing-l);
-				padding: var(--spacing-m);
-	
-				.ds-card-header {
-					display: flex;
-					justify-content: space-between;
-					align-items: center;
-	
-					h2 {
-						font-size: var(--md-font-size);
-						margin: 0;
-					}
-				}
-			}
-		}
-	}
+        gap: var(--spacing-l);
+
+        #ds-right-column, #ds-left-column {
+            .digital-specimen-card {
+                margin-block-end: var(--spacing-l);
+                padding: var(--spacing-m);
+
+                .ds-card-header {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+
+                    h2 {
+                        font-size: var(--md-font-size);
+                        margin: 0;
+                    }
+                }
+            }
+        }
+    }
+
+    #ds-mobile-view {
+        display: block;
+
+        @include mediumAndUp {
+            display: none;
+        }
+    }
+
+    #ds-desktop-view {
+        display: none;
+
+        @include mediumAndUp {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+        }
+    }
 
 	.annotation-panel-overlay {
 		position: fixed;

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
@@ -104,7 +104,8 @@ const DigitalSpecimenDetails = () => {
                 AnnotateHelper={() => handleOpenAnnotation()}
             >
             </Hero>
-            <main className="digital-specimen-container">
+            {/* Desktop view */}
+            <main className="digital-specimen-container" id="ds-desktop-view">
                 <div id="ds-left-column">
                     { hasImages ? (
                         <ImageCard specimen={specimen}></ImageCard>
@@ -130,6 +131,24 @@ const DigitalSpecimenDetails = () => {
                             {...CARD_CONFIGS[category.name as CardCategory]} 
                         />
                     ))}
+                </div>
+            </main>
+            {/* Mobile view */}
+            <main className="digital-specimen-container" id="ds-mobile-view">
+                <div id="ds-left-column">
+                    { hasImages &&
+                        <ImageCard specimen={specimen}></ImageCard>
+                    }
+                    {actualData.map((category: MappedCategories) => (
+                        <DigitalSpecimenCard 
+                            key={category.name}
+                            cardHeader={category.name} 
+                            fragment={category.data}
+                            AnnotateHelper={handleOpenAnnotation}
+                            {...CARD_CONFIGS[category.name as CardCategory]} 
+                        />
+                    ))}
+                    
                 </div>
             </main>
             {annotationMode && (


### PR DESCRIPTION
**In this PR:**
- The mobile view for the digital specimen overview
- Trivyignore for react-router-dom. I added a story to my sprint to address the upgrade from 7 to 8.

**Design**: https://www.figma.com/design/CW7NHzRh3Eu5555lxqNrUr/DiSSCover-v2---UX-design?node-id=519-23133&t=Qq3Chw87fwYZRLRD-0

**Jira ticket**: https://naturalis.atlassian.net/browse/DD-3189

**What it looks like:**
<img width="535" height="964" alt="image" src="https://github.com/user-attachments/assets/2bf03541-2f82-4328-9208-f702c545fad0" />

<img width="509" height="1155" alt="image" src="https://github.com/user-attachments/assets/ab82731d-7f62-4490-82c6-4eed479f5ca4" />
