### PR TITLE
Added Radix tabs (from Themes) to the Digital Specimen page

### DIFF
--- a/src/components/Cards/DigitalSpecimenCard/DigitalSpecimenCard.tsx
+++ b/src/components/Cards/DigitalSpecimenCard/DigitalSpecimenCard.tsx
@@ -29,7 +29,7 @@ type Props = {
     georeference?: boolean;
     citation?: boolean;
     annotationTarget?: AnnotationTargetPayload;
-    AnnotateHelper?: (target?: AnnotationTargetPayload) => void;
+    AnnotateHelper?: Function
 };
 
 export const DigitalSpecimenCard = ({

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -1,0 +1,6 @@
+/* Overwriting styling of Radix Tabs component*/
+.rt-TabsRoot {
+    .rt-TabsList {
+        padding: 0 var(--spacing-xl);
+    }
+}

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -24,15 +24,13 @@ export const DigitalSpecimenTabs = ({ defaultValue, tabs }: Props) => {
                 })}
             </Tabs.List>
 
-            <main>
-                { tabs.map((tab) => {
-                    return (
-                        <Tabs.Content key={'second-' + tab.value} value={tab.value}>
-                            {tab.component}
-                        </Tabs.Content>
-                    )
-                })}
-            </main>
+            { tabs.map((tab) => {
+                return (
+                    <Tabs.Content key={'second-' + tab.value} value={tab.value}>
+                        {tab.component}
+                    </Tabs.Content>
+                )
+            })}
         </Tabs.Root>
     )
 }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -24,7 +24,7 @@ export const DigitalSpecimenTabs = ({ defaultValue, tabs }: Props) => {
                 })}
             </Tabs.List>
 
-            <div>
+            <main>
                 { tabs.map((tab) => {
                     return (
                         <Tabs.Content key={'second-' + tab.value} value={tab.value}>
@@ -32,7 +32,7 @@ export const DigitalSpecimenTabs = ({ defaultValue, tabs }: Props) => {
                         </Tabs.Content>
                     )
                 })}
-            </div>
+            </main>
         </Tabs.Root>
     )
 }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,38 @@
+import { Tabs } from "@radix-ui/themes";
+import { ReactNode } from "react";
+
+/* Import styling */
+import "./Tabs.scss";
+
+interface Props {
+    defaultValue: string,
+    tabs: {
+        value: string,
+        title: string,
+        component: ReactNode,
+    }[]
+}
+
+export const DigitalSpecimenTabs = ({ defaultValue, tabs }: Props) => {
+    return (
+        <Tabs.Root defaultValue={defaultValue}>
+            <Tabs.List>
+                { tabs.map((tab) => {
+                    return (
+                        <Tabs.Trigger key={tab.value} value={tab.value}>{tab.title}</Tabs.Trigger>
+                    )
+                })}
+            </Tabs.List>
+
+            <div>
+                { tabs.map((tab) => {
+                    return (
+                        <Tabs.Content key={'second-' + tab.value} value={tab.value}>
+                            {tab.component}
+                        </Tabs.Content>
+                    )
+                })}
+            </div>
+        </Tabs.Root>
+    )
+}

--- a/src/hooks/useAnnotationHooks.ts
+++ b/src/hooks/useAnnotationHooks.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+import { useAppDispatch } from 'app/Hooks';
+import { setAnnotationTarget } from 'redux-store/AnnotateSlice';
+import { AnnotationTargetPayload } from 'types/digitalSpecimenTypes';
+
+const DefaultTarget: AnnotationTargetPayload = {
+    type: 'class',
+    jsonPath: '',
+    directPath: true,
+};
+
+/**
+ * Hook to set the annotationMode
+ * @param setAnnotationMode Local state 
+ * @returns Boolean
+ */
+export const useAnnotationHandler = (setAnnotationMode: (active: boolean) => void) => {
+    const dispatch = useAppDispatch();
+
+    const handleOpenAnnotation = useCallback((target?: AnnotationTargetPayload) => {
+        dispatch(setAnnotationTarget(target ?? DefaultTarget));
+        setAnnotationMode(true);
+    }, [dispatch, setAnnotationMode]);
+
+    return handleOpenAnnotation;
+};

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.scss
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.scss
@@ -5,30 +5,6 @@
 	position: relative;
 	min-height: 100vh;
 
-	.digital-specimen-container {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: var(--spacing-l);
-	
-		#ds-right-column, #ds-left-column {
-			.digital-specimen-card {
-				margin-block-end: var(--spacing-l);
-				padding: var(--spacing-m);
-	
-				.ds-card-header {
-					display: flex;
-					justify-content: space-between;
-					align-items: center;
-	
-					h2 {
-						font-size: var(--md-font-size);
-						margin: 0;
-					}
-				}
-			}
-		}
-	}
-
 	.annotation-panel-overlay {
 		position: fixed;
 		top: 0;

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
@@ -2,17 +2,16 @@
 import { useState } from 'react';
 
 /* Import components */
-import { DigitalSpecimenCard } from 'components/Cards/DigitalSpecimenCard/DigitalSpecimenCard';
 import { Hero } from 'components/Hero/Hero';
-import { ImageCard } from 'components/Cards/DigitalMediaCard/DigitalMediaCard';
 import { AnnotationSidePanel } from 'components/elements/Elements';
+import { DigitalSpecimenTabs } from 'components/Tabs/Tabs';
 
 /* Import hooks */
 import { useDigitalSpecimenComplete } from 'hooks/useDigitalSpecimen';
 
 /* Import types and enums */
-import { CardCategory, CARD_CONFIGS, LEFT_COLUMN_CATEGORIES, AnnotationTargetPayload } from 'types/digitalSpecimenTypes';
-import { CategoryConfig, MappedCategories, UIProperty } from 'types/dataMapperTypes';
+import { CardCategory } from 'types/digitalSpecimenTypes';
+import { CategoryConfig, UIProperty } from 'types/dataMapperTypes';
 
 /* Import styling */
 import './DigitalSpecimenOverview.scss';
@@ -28,41 +27,25 @@ import DigitalSpecimenSchema from 'sources/dataModel/digitalSpecimen.json';
 import DigitalSpecimenAnnotationCases from 'sources/annotationCases/DigitalSpecimenAnnotationCases.json';
 
 /* Import hooks */
-import { useAppDispatch } from 'app/Hooks';
+import { useAnnotationHandler } from 'hooks/useAnnotationHooks';
 
 /* Import store */
-import { setAnnotationTarget } from 'redux-store/AnnotateSlice';
+import { DigitalSpecimenDetails } from './SubPages/DigitalSpecimenDetails';
 
-const DigitalSpecimenDetails = () => {
-    /* Hooks */
-    const dispatch = useAppDispatch();
-
+const DigitalSpecimenOverview = () => {
     /* Base variables */
     const url = new URL(globalThis.location.href);
     const segments = url.pathname.split('/');
     const identifier = segments.slice(2).join("/");
     const { data: specimen, isLoading, isError } = useDigitalSpecimenComplete({ doi: identifier});
     const [annotationMode, setAnnotationMode] = useState(false);
-    const hasImages = specimen?.digitalMedia?.length > 0;
+
+    /* Hooks */
+    const handleOpenAnnotation = useAnnotationHandler(setAnnotationMode);
 
     if (isLoading) return <main><p>Retrieving the Digital Specimen Details...</p></main>;
     if (!specimen) return <main><p>No data found</p></main>
     if (isError) return <main><p>Something went wrong with fetching the Digital Specimen. Please try again later.</p></main>;
-
-    /* Human readable data mapped from the JSON data to use in UI*/
-    const actualData = specimen?.mappedData || [];
-
-    /* Set the columns based on whether an image can be found */
-    let leftColumnCards = [];
-    let rightColumnCards = [];
-    
-    if (hasImages) {
-        leftColumnCards = []; 
-        rightColumnCards = actualData; 
-    } else {
-        leftColumnCards = actualData.filter((category: MappedCategories) => LEFT_COLUMN_CATEGORIES.has(category.name));
-        rightColumnCards = actualData.filter((category: MappedCategories) => !LEFT_COLUMN_CATEGORIES.has(category.name));
-    }
 
     /* Helper to get raw data array by Category Enum */
     const getCardFragment = (category: CardCategory) => {
@@ -74,19 +57,14 @@ const DigitalSpecimenDetails = () => {
         return getCardFragment(category).find((field: UIProperty) => field.label === label)?.value;
     };
 
-    const handleOpenAnnotation = (target?: AnnotationTargetPayload) => {
-        if (target) {
-            dispatch(setAnnotationTarget(target));
-        } else {
-            /* Fallback if no target is specified, jsonPath resolves to entire class */
-            dispatch(setAnnotationTarget({
-                type: 'class',
-                jsonPath: "",
-                directPath: true
-            }));
+    /* Tabs */
+    const tabs = [
+        {
+            value: 'overview',
+            title: 'Overview',
+            component: <DigitalSpecimenDetails specimen={specimen} onAnnotate={handleOpenAnnotation}></DigitalSpecimenDetails>
         }
-        setAnnotationMode(true);
-    };
+    ]
 
     return (
         <div className="digital-specimen-page">
@@ -104,34 +82,10 @@ const DigitalSpecimenDetails = () => {
                 AnnotateHelper={() => handleOpenAnnotation()}
             >
             </Hero>
-            <main className="digital-specimen-container">
-                <div id="ds-left-column">
-                    { hasImages ? (
-                        <ImageCard specimen={specimen}></ImageCard>
-                    ) : (
-                        leftColumnCards.map((category: MappedCategories) => (
-                            <DigitalSpecimenCard 
-                                key={category.name}
-                                cardHeader={category.name} 
-                                fragment={category.data}
-                                {...CARD_CONFIGS[category.name as CardCategory]} 
-                            />
-                        ))
-                    )}
-                    
-                </div>
-                <div id="ds-right-column">
-                    {rightColumnCards.map((category: MappedCategories) => (
-                        <DigitalSpecimenCard 
-                            key={category.name}
-                            cardHeader={category.name} 
-                            fragment={category.data}
-                            AnnotateHelper={handleOpenAnnotation}
-                            {...CARD_CONFIGS[category.name as CardCategory]} 
-                        />
-                    ))}
-                </div>
-            </main>
+
+            {/* Tabs of the Digital Specimen */}
+            <DigitalSpecimenTabs defaultValue="overview" tabs={tabs}></DigitalSpecimenTabs>
+
             {annotationMode && (
                 <>
                     <button
@@ -164,4 +118,4 @@ const DigitalSpecimenDetails = () => {
     );
 };
 
-export default DigitalSpecimenDetails;
+export default DigitalSpecimenOverview;

--- a/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
+++ b/src/pages/DigitalSpecimenOverview/DigitalSpecimenOverview.tsx
@@ -83,8 +83,10 @@ const DigitalSpecimenOverview = () => {
             >
             </Hero>
 
-            {/* Tabs of the Digital Specimen */}
-            <DigitalSpecimenTabs defaultValue="overview" tabs={tabs}></DigitalSpecimenTabs>
+            <main>
+                {/* Tabs of the Digital Specimen */}
+                <DigitalSpecimenTabs defaultValue="overview" tabs={tabs}></DigitalSpecimenTabs>
+            </main>
 
             {annotationMode && (
                 <>

--- a/src/pages/DigitalSpecimenOverview/SubPages/DigitalSpecimenDetails.scss
+++ b/src/pages/DigitalSpecimenOverview/SubPages/DigitalSpecimenDetails.scss
@@ -1,0 +1,23 @@
+.digital-specimen-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-l);
+
+    #ds-right-column, #ds-left-column {
+        .digital-specimen-card {
+            margin-block-end: var(--spacing-l);
+            padding: var(--spacing-m);
+
+            .ds-card-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+
+                h2 {
+                    font-size: var(--md-font-size);
+                    margin: 0;
+                }
+            }
+        }
+    }
+}

--- a/src/pages/DigitalSpecimenOverview/SubPages/DigitalSpecimenDetails.tsx
+++ b/src/pages/DigitalSpecimenOverview/SubPages/DigitalSpecimenDetails.tsx
@@ -1,0 +1,66 @@
+/* Import components */
+import { ImageCard } from "components/Cards/DigitalMediaCard/DigitalMediaCard";
+import { DigitalSpecimenCard } from "components/Cards/DigitalSpecimenCard/DigitalSpecimenCard";
+
+/* Import types */
+import { MappedCategories } from "types/dataMapperTypes";
+import { AnnotationTargetPayload, CARD_CONFIGS, CardCategory, LEFT_COLUMN_CATEGORIES } from "types/digitalSpecimenTypes";
+
+/* Import styling */
+import "./DigitalSpecimenDetails.scss";
+
+interface Props {
+    specimen: any,
+    onAnnotate?: (target?: AnnotationTargetPayload) => void;
+}
+
+export const DigitalSpecimenDetails = ({ specimen, onAnnotate }: Props ) => {
+    /* Base variables */
+    const hasImages = specimen?.digitalMedia?.length > 0;
+    /* Human readable data mapped from the JSON data to use in UI*/
+    const actualData = specimen?.mappedData || [];
+
+    /* Set the columns based on whether an image can be found */
+    let leftColumnCards = [];
+    let rightColumnCards = [];
+    
+    if (hasImages) {
+        leftColumnCards = []; 
+        rightColumnCards = actualData; 
+    } else {
+        leftColumnCards = actualData.filter((category: MappedCategories) => LEFT_COLUMN_CATEGORIES.has(category.name));
+        rightColumnCards = actualData.filter((category: MappedCategories) => !LEFT_COLUMN_CATEGORIES.has(category.name));
+    }
+
+    return (
+        <main className="digital-specimen-container">
+                <div id="ds-left-column">
+                    { hasImages ? (
+                        <ImageCard specimen={specimen}></ImageCard>
+                    ) : (
+                        leftColumnCards.map((category: MappedCategories) => (
+                            <DigitalSpecimenCard 
+                                key={category.name}
+                                cardHeader={category.name} 
+                                fragment={category.data}
+                                AnnotateHelper={onAnnotate}
+                                {...CARD_CONFIGS[category.name as CardCategory]} 
+                            />
+                        ))
+                    )}
+                    
+                </div>
+                <div id="ds-right-column">
+                    {rightColumnCards.map((category: MappedCategories) => (
+                        <DigitalSpecimenCard 
+                            key={category.name}
+                            cardHeader={category.name} 
+                            fragment={category.data}
+                            AnnotateHelper={onAnnotate}
+                            {...CARD_CONFIGS[category.name as CardCategory]} 
+                        />
+                    ))}
+                </div>
+            </main>
+    )
+}

--- a/src/pages/DigitalSpecimenOverview/SubPages/DigitalSpecimenDetails.tsx
+++ b/src/pages/DigitalSpecimenOverview/SubPages/DigitalSpecimenDetails.tsx
@@ -35,7 +35,7 @@ export const DigitalSpecimenDetails = ({ specimen, onAnnotate }: Props ) => {
     return (
         <>
             {/* Desktop view */}
-            <section  className="digital-specimen-container" id="ds-desktop-view">
+            <section className="digital-specimen-container" id="ds-desktop-view">
                 <div id="ds-left-column">
                     { hasImages ? (
                         <DigitalMediaCard specimen={specimen}></DigitalMediaCard>

--- a/src/pages/DigitalSpecimenOverview/SubPages/DigitalSpecimenDetails.tsx
+++ b/src/pages/DigitalSpecimenOverview/SubPages/DigitalSpecimenDetails.tsx
@@ -35,7 +35,7 @@ export const DigitalSpecimenDetails = ({ specimen, onAnnotate }: Props ) => {
     return (
         <>
             {/* Desktop view */}
-            <main className="digital-specimen-container" id="ds-desktop-view">
+            <section  className="digital-specimen-container" id="ds-desktop-view">
                 <div id="ds-left-column">
                     { hasImages ? (
                         <DigitalMediaCard specimen={specimen}></DigitalMediaCard>
@@ -63,9 +63,9 @@ export const DigitalSpecimenDetails = ({ specimen, onAnnotate }: Props ) => {
                         />
                     ))}
                 </div>
-            </main>
+            </section>
             {/* Mobile view */}
-            <main className="digital-specimen-container" id="ds-mobile-view">
+            <section className="digital-specimen-container" id="ds-mobile-view">
                 <div id="ds-left-column">
                     { hasImages &&
                         <DigitalMediaCard specimen={specimen}></DigitalMediaCard>
@@ -81,7 +81,7 @@ export const DigitalSpecimenDetails = ({ specimen, onAnnotate }: Props ) => {
                     ))}
                     
                 </div>
-            </main>
+            </section>
         </>
     )
 }

--- a/src/pages/VirtualCollectionDetails/VirtualCollectionDetails.tsx
+++ b/src/pages/VirtualCollectionDetails/VirtualCollectionDetails.tsx
@@ -72,7 +72,7 @@ const VirtualCollectionDetails = () => {
             </Hero>
             { currentItems.length > 0 ?
             <main className="virtual-collections-main">
-                <div id="vc-mobile-view">
+                <section id="vc-mobile-view">
                     <div className="gallery-container">
                         {currentItems?.map((collection: any) => {
                             return (
@@ -80,19 +80,21 @@ const VirtualCollectionDetails = () => {
                             )
                         })}
                     </div>
-                </div>
-                <div id="vc-desktop-view">
+                </section>
+                <section id="vc-desktop-view">
                     <VirtualCollectionDetailsTable 
                         currentItems={currentItems}
                     />
-                </div>
-                <Pagination
-                    totalAmount={totalAmount}
-                    onPageChange={(page) => setCurrentPage(page)}
-                    currentPage={currentPage}
-                    maxPerPage={maxPerPage}
-                    content="items"
-                />
+                </section>
+                <section>
+                    <Pagination
+                        totalAmount={totalAmount}
+                        onPageChange={(page) => setCurrentPage(page)}
+                        currentPage={currentPage}
+                        maxPerPage={maxPerPage}
+                        content="items"
+                    />
+                </section>
             </main>
             : <main>
                 <p>This Virtual Collection is currently empty.</p>

--- a/src/pages/VirtualCollectionOverview/VirtualCollectionsOverview.tsx
+++ b/src/pages/VirtualCollectionOverview/VirtualCollectionsOverview.tsx
@@ -46,7 +46,7 @@ const VirtualCollections = () => {
             >
             </Hero>
             <main className="virtual-collections-main">
-                <div className="gallery-container">
+                <section className="gallery-container">
                     {currentItems?.map((collection: any) => {
                         return (
                             <Card variant="surface" className="gallery-card" key={collection.id} asChild>
@@ -58,14 +58,16 @@ const VirtualCollections = () => {
                             </Card>
                         )
                     })}
-                </div>
-                <Pagination
-                    totalAmount={totalAmount}
-                    onPageChange={(page) => setCurrentPage(page)}
-                    currentPage={currentPage}
-                    maxPerPage={maxPerPage}
-                    content="collections"
-                />
+                </section>
+                <section>
+                    <Pagination
+                        totalAmount={totalAmount}
+                        onPageChange={(page) => setCurrentPage(page)}
+                        currentPage={currentPage}
+                        maxPerPage={maxPerPage}
+                        content="collections"
+                    />
+                </section>
             </main> 
         </>
     );

--- a/src/styles/general.scss
+++ b/src/styles/general.scss
@@ -8,13 +8,12 @@ header {
     }
 }
 
-main {
+section {
     padding: var(--spacing-l) var(--spacing-m);
     background-color: var(--background-gray);
 
     @include smallAndUp {
         padding: var(--spacing-l) var(--spacing-xl);
-        min-height: 40vh;
     }
 }
 


### PR DESCRIPTION
**In this PR:**
- Added Radix Tabs to the Digital Specimen page, but made it a reusable component still

**[Design for the tabs](https://www.figma.com/design/CW7NHzRh3Eu5555lxqNrUr/DiSSCover-v2---UX-design?node-id=73-11256&t=fNwpZ9kYoytDPhSL-0)** 

**Jira link:** https://naturalis.atlassian.net/browse/DD-2999

**What it looks like:**
<img width="1612" height="984" alt="image" src="https://github.com/user-attachments/assets/32c2c0af-38a2-4503-a654-ad0b7711b73b" />

<img width="722" height="1129" alt="image" src="https://github.com/user-attachments/assets/bf7188eb-5132-4945-a1c1-5fe447b67e81" />
