### PR TITLE
Fix taxonomy search for annotations

### DIFF
--- a/src/components/elements/annotationSidePanel/utilities/AnnotationMappers.ts
+++ b/src/components/elements/annotationSidePanel/utilities/AnnotationMappers.ts
@@ -29,7 +29,7 @@ const TaxonomicIdentificationMapper = (taxonomicTree: TaxonomicIdentificationIte
             return taxonomicTree?.usage?.name?.infragenericEpithet;
         default:
             if (classificationItem) {
-                return classificationItem.label;
+                return classificationItem.labelHtml;
             }
             return value;
     }

--- a/src/components/elements/annotationSidePanel/utilities/AnnotationMappers.ts
+++ b/src/components/elements/annotationSidePanel/utilities/AnnotationMappers.ts
@@ -29,7 +29,7 @@ const TaxonomicIdentificationMapper = (taxonomicTree: TaxonomicIdentificationIte
             return taxonomicTree?.usage?.name?.infragenericEpithet;
         default:
             if (classificationItem) {
-                return classificationItem.labelHtml;
+                return classificationItem.labelHtml || classificationItem.label;
             }
             return value;
     }


### PR DESCRIPTION
See https://naturalis.atlassian.net/browse/DD-3202

Taxonomy tree search when adding an annotation on identification produced inconsistent results. I found out that I sometimes need to return `label` and sometimes `labelHtml`, so I added both.