### PR TITLE
finalized the gallery and table view of the virtual collection details

### DIFF
--- a/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.tsx
+++ b/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.tsx
@@ -17,11 +17,9 @@ export const VirtualCollectionCard = ({ collection, type: viewType }: Props) => 
             { viewType === "details" && 
                 <Card variant="surface" className="gallery-card" asChild>
                     <Link to={`/ds/${collection.id.replace(RetrieveEnvVariable('DOI_URL'), '')}`}>
-                        { !collection.attributes['ods:isKnownToContainMedia'] &&
                         <div className="vc-card-image-container">
-                            <span>No image</span>
+                            <span>{!collection.attributes['ods:isKnownToContainMedia'] ? 'No image' : 'image'}</span>
                         </div>
-                        }
                         <div className="vc-card-content-container">
                             { collection.attributes?.['ods:hasIdentifications']?.[0]?.['dwc:typeStatus'] && 
                             <Badge color="sky" variant="solid">{collection.attributes['ods:hasIdentifications'][0]['dwc:typeStatus']}</Badge>

--- a/src/components/Hero/Hero.scss
+++ b/src/components/Hero/Hero.scss
@@ -103,17 +103,21 @@ header {
 
     #hero-footer {
         .view-toggle {
-            padding: var(--spacing-s) 0;
-            display: flex;
-            justify-content: end;
-
-            button {
-                margin: 0px 2px;
+            display: none;
+            @include smallAndUp {
+                padding: var(--spacing-s) 0;
+                display: flex;
+                justify-content: end;
+    
+                button {
+                    margin: 0px 2px;
+                }
+                
+                .active-view {
+                    background-color: var(--indigo-3);
+                }
             }
             
-            .active-view {
-                background-color: var(--indigo-3);
-            }
         }
     }
 }

--- a/src/components/Hero/Hero.scss
+++ b/src/components/Hero/Hero.scss
@@ -100,4 +100,20 @@ header {
             }
         }
     }
+
+    #hero-footer {
+        .view-toggle {
+            padding: var(--spacing-s) 0;
+            display: flex;
+            justify-content: end;
+
+            button {
+                margin: 0px 2px;
+            }
+            
+            .active-view {
+                background-color: var(--indigo-3);
+            }
+        }
+    }
 }

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -3,7 +3,7 @@ import { useLayoutEffect, useRef, useState } from "react";
 import { format } from "date-fns";
 
 /* Import components */
-import { ArrowLeftIcon, ClipboardCopyIcon, CopyIcon, Pencil2Icon, PlusIcon } from "@radix-ui/react-icons";
+import { ArrowLeftIcon, ClipboardCopyIcon, CopyIcon, GridIcon, ListBulletIcon, Pencil2Icon, PlusIcon } from "@radix-ui/react-icons";
 import { Badge, Button, Dialog, Flex } from "@radix-ui/themes";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -29,6 +29,8 @@ type Props = {
     isHtml?: boolean;
     annotate?: boolean;
     AnnotateHelper?: Function
+    selectedView?: 'table' | 'grid';
+    onViewChange?: (view: 'table' | 'grid') => void;
 }
 
 /**
@@ -42,7 +44,8 @@ type Props = {
  * @param showCreateButton Boolean that indicates if the functionality for creating a VC should be working
  * @returns A JSX element that shows a Hero banner with information and possibly navigation
  */
-export const Hero = ( { title, description, badge, navigateTo, showShareButton, details, showCreateButton, isHtml = false, annotate, AnnotateHelper }: Props) => {
+export const Hero = ( { title, description, badge, navigateTo, showShareButton, details, showCreateButton, isHtml = false, annotate, AnnotateHelper, selectedView,
+    onViewChange }: Props) => {
     /* Hooks */
     const navigate = useNavigate();
     const isAllowedToCreateVC = useHasRole('dissco-virtual-collection');
@@ -186,6 +189,30 @@ export const Hero = ( { title, description, badge, navigateTo, showShareButton, 
                     </div>
                 </>
                 }
+            </div>
+            <div id="hero-footer">
+            {selectedView && onViewChange && (
+                <div aria-label="View switch" className="view-toggle">
+                    <Button
+                        variant="ghost"
+                        type="button"
+                        aria-pressed={selectedView === 'table'}
+                        onClick={() => onViewChange('table')}
+                        className={selectedView === 'table' ? 'active-view' : ''}
+                    >
+                        <ListBulletIcon /> Table
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        type="button"
+                        aria-pressed={selectedView === 'grid'}
+                        onClick={() => onViewChange('grid')}
+                        className={selectedView === 'grid' ? 'active-view' : ''}
+                    >
+                        <GridIcon /> Gallery
+                    </Button>
+                </div>
+            )}
             </div>
         </header>
     )

--- a/src/pages/VirtualCollectionDetails/VirtualCollectionDetails.tsx
+++ b/src/pages/VirtualCollectionDetails/VirtualCollectionDetails.tsx
@@ -23,7 +23,8 @@ import './VirtualCollectionDetails.scss';
 const VirtualCollectionDetails = () => {
     /* Base variables */
     const [currentPage, setCurrentPage] = useState(1);
-    const maxPerPage = 25;
+    const [ selectedView, setSelectedView ] = useState<'table' | 'grid'>('table');
+    const maxPerPage = selectedView === 'table' ? 25 : 9;
 
     /* Calling the Virtual Collection Details hook */
     const { 
@@ -67,8 +68,9 @@ const VirtualCollectionDetails = () => {
                 navigateTo={{pathName: '/virtual-collections', text: 'Virtual Collections'}}
                 showShareButton={true}
                 details={selectedVirtualCollection}
+                selectedView={selectedView}
+                onViewChange={setSelectedView}
             >
-                
             </Hero>
             { currentItems.length > 0 ?
             <main className="virtual-collections-main">
@@ -82,9 +84,17 @@ const VirtualCollectionDetails = () => {
                     </div>
                 </div>
                 <div id="vc-desktop-view">
-                    <VirtualCollectionDetailsTable 
-                        currentItems={currentItems}
-                    />
+                    { selectedView === 'table' ? (
+                        <VirtualCollectionDetailsTable 
+                            currentItems={currentItems}
+                        />
+                    ) : (
+                        <div className="gallery-container">
+                            {currentItems?.map((collection: any) => (
+                                <VirtualCollectionCard key={collection.id} collection={collection} type="details" />
+                            ))}
+                        </div>
+                        )}
                 </div>
                 <Pagination
                     totalAmount={totalAmount}


### PR DESCRIPTION
**In this PR:**
- I've added a gallery view and a table view toggle on the Virtual Collection page. The toggle needs some love at a later moment, because the design for this lacked. But the design for the table view and gallery view are linked below.
- I've added styling.
- Mobile only has gallery view and no table, so on mobile the toggle is not visible.
- Images of the Digital Specimen will be added in a later story

[**Design**](https://www.figma.com/design/CW7NHzRh3Eu5555lxqNrUr/DiSSCover-v2---UX-design?node-id=461-2382&t=ZPy72aMx5sfX6TZL-0)

**What it looks like:**
_Mobile:_
<img width="458" height="947" alt="image" src="https://github.com/user-attachments/assets/54df2bd9-2edd-48ac-a620-6f3f52194405" />

_Desktop table:_
<img width="1369" height="884" alt="image" src="https://github.com/user-attachments/assets/cfddb94a-790c-4c17-897d-f5257e76fc5e" />

_Desktop gallery:_
<img width="1369" height="884" alt="image" src="https://github.com/user-attachments/assets/c0b69a27-8eb7-4ae8-87eb-197a949c716a" />
