### PR TITLE
Added virtual collection images to the digital specimen

### DIFF
--- a/src/components/Cards/DigitalMediaCard/DigitalMediaCard.tsx
+++ b/src/components/Cards/DigitalMediaCard/DigitalMediaCard.tsx
@@ -59,6 +59,7 @@ export const DigitalMediaCard = ({ specimen }: Props ) => {
                 {mainImage ? (
                     <a href={`/dm/${cleanDoiPath}`}>
                         <div 
+                            role="img"
                             style={{ backgroundImage: `url(${mainImage})` }} 
                             className="digital-media-card-image"
                         ></div>

--- a/src/components/Cards/DigitalMediaCard/DigitalMediaCard.tsx
+++ b/src/components/Cards/DigitalMediaCard/DigitalMediaCard.tsx
@@ -60,6 +60,7 @@ export const DigitalMediaCard = ({ specimen }: Props ) => {
                     <a href={`/dm/${cleanDoiPath}`}>
                         <div 
                             role="img"
+                            aria-label={`Image of digital specimen ${activeId}`}
                             style={{ backgroundImage: `url(${mainImage})` }} 
                             className="digital-media-card-image"
                         ></div>

--- a/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.scss
+++ b/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.scss
@@ -12,15 +12,6 @@
         font-size: var(--xs-font-size);
     }
 
-    .vc-card-image-container {
-        width: 100%;
-        background-color: var(--medium-gray);
-        height: var(--image-card-height);
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
-
     .vc-card-content-container {
         padding: var(--spacing-sm);
     }

--- a/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.test.tsx
+++ b/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.test.tsx
@@ -1,9 +1,12 @@
 /* Import test dependencies */
 import { screen, render } from 'tests/test-utils';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /* Import components */
 import { VirtualCollectionCard } from './VirtualCollectionCard';
+
+/* Import custom hook for mocking */
+import { useDigitalSpecimenComplete } from 'hooks/useDigitalSpecimen';
 
 /* Mock external utilities */
 vi.mock('app/Utilities', () => ({
@@ -12,6 +15,11 @@ vi.mock('app/Utilities', () => ({
 
 vi.mock('app/utilities/NomenclaturalUtilities', () => ({
     GetSpecimenNameHTMLLabel: vi.fn((attributes) => `<i>${attributes?.['dwc:scientificName'] || 'Specimen Name'}</i>`),
+}));
+
+/* Mock the hook that VirtualCollectionImage depends on */
+vi.mock('hooks/useDigitalSpecimen', () => ({
+    useDigitalSpecimenComplete: vi.fn()
 }));
 
 /* Mock Data */
@@ -34,26 +42,37 @@ const mockCollection = {
 };
 
 describe('VirtualCollectionCard', () => {
-    it('renders the card details view with sanitized link and attributes', () => {
+    it('renders card details and image background when media is present and loaded', () => {
+        vi.mocked(useDigitalSpecimenComplete).mockReturnValue({
+            data: {
+                digitalMedia: [
+                    {
+                        digitalMediaObject: {
+                            'dcterms:format': 'image/jpeg',
+                            'ac:accessURI': 'https://example.com/specimen.jpg'
+                        }
+                    }
+                ]
+            }
+        } as any);
+
         render(<VirtualCollectionCard collection={mockCollection} type="details" />);
 
         /* Verify DOI is stripped from link */
         const cardLink = screen.getByRole('link');
         expect(cardLink).toHaveAttribute('href', '/ds/10.1234/SAMPLE-123');
 
-        /* Check badge */
+        /* Check badge and metadata details */
         expect(screen.getByText('Holotype')).toBeInTheDocument();
-
-        /* Check inner HTML output from helper */
         expect(screen.getByText('Panthera leo')).toBeInTheDocument();
-
-        /* Check metadata details */
         expect(screen.getByText('Netherlands')).toBeInTheDocument();
         expect(screen.getByText('2023-05-18')).toBeInTheDocument();
         expect(screen.getByText('Naturalis Biodiversity Center')).toBeInTheDocument();
     });
 
     it('displays "No image" fallback container when media flag is false', () => {
+        vi.mocked(useDigitalSpecimenComplete).mockReturnValue({ data: undefined } as any);
+
         const noMediaCollection = {
             ...mockCollection,
             attributes: {
@@ -67,7 +86,28 @@ describe('VirtualCollectionCard', () => {
         expect(screen.getByText('No image')).toBeInTheDocument();
     });
 
+    it('displays "Error loading image" when hasMedia is true but no JPG is returned', () => {
+        vi.mocked(useDigitalSpecimenComplete).mockReturnValue({
+            data: {
+                digitalMedia: [
+                    {
+                        digitalMediaObject: {
+                            'dcterms:format': 'application/pdf',
+                            'ac:accessURI': 'https://example.com/doc.pdf'
+                        }
+                    }
+                ]
+            }
+        } as any);
+
+        render(<VirtualCollectionCard collection={mockCollection} type="details" />);
+
+        expect(screen.getByText('Error loading image')).toBeInTheDocument();
+    });
+
     it('renders "Unknown" for date when eventDate is missing', () => {
+        vi.mocked(useDigitalSpecimenComplete).mockReturnValue({ data: undefined } as any);
+
         const missingDateCollection = {
             ...mockCollection,
             attributes: {

--- a/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.test.tsx
+++ b/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.test.tsx
@@ -1,6 +1,6 @@
 /* Import test dependencies */
 import { screen, render } from 'tests/test-utils';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 /* Import components */
 import { VirtualCollectionCard } from './VirtualCollectionCard';

--- a/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.tsx
+++ b/src/components/Cards/VirtualCollectionCard/VirtualCollectionCard.tsx
@@ -1,7 +1,13 @@
+/* Import dependencies */
+import { Link } from "react-router-dom";
+
+/* Import components */
 import { Badge, Card } from "@radix-ui/themes";
+import { VirtualCollectionImage } from "components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage";
+
+/* Import utils */
 import { RetrieveEnvVariable } from "app/Utilities";
 import { GetSpecimenNameHTMLLabel } from "app/utilities/NomenclaturalUtilities";
-import { Link } from "react-router-dom";
 
 /* Import styling */
 import './VirtualCollectionCard.scss';
@@ -17,9 +23,10 @@ export const VirtualCollectionCard = ({ collection, type: viewType }: Props) => 
             { viewType === "details" && 
                 <Card variant="surface" className="gallery-card" asChild>
                     <Link to={`/ds/${collection.id.replace(RetrieveEnvVariable('DOI_URL'), '')}`}>
-                        <div className="vc-card-image-container">
-                            <span>{!collection.attributes['ods:isKnownToContainMedia'] ? 'No image' : 'image'}</span>
-                        </div>
+
+                        {/* Virtual Collection Image */}
+                        <VirtualCollectionImage collection={collection}></VirtualCollectionImage>
+
                         <div className="vc-card-content-container">
                             { collection.attributes?.['ods:hasIdentifications']?.[0]?.['dwc:typeStatus'] && 
                             <Badge color="sky" variant="solid">{collection.attributes['ods:hasIdentifications'][0]['dwc:typeStatus']}</Badge>

--- a/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.scss
+++ b/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.scss
@@ -1,0 +1,16 @@
+.vc-card-box-container {
+    width: 100%;
+    background-color: var(--medium-gray);
+    height: var(--image-card-height);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.vc-card-image-container {
+    width: 100%;
+    height: var(--image-card-height);
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
+}

--- a/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.test.tsx
+++ b/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.test.tsx
@@ -1,0 +1,111 @@
+/* Import test dependencies */
+import { render, screen } from 'tests/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/* Import component & hook */
+import { VirtualCollectionImage } from './VirtualCollectionImage';
+import { useDigitalSpecimenComplete } from 'hooks/useDigitalSpecimen';
+
+/* Mock dependencies */
+vi.mock('app/Utilities', () => ({
+    RetrieveEnvVariable: vi.fn(() => 'https://doi.org/'),
+}));
+
+vi.mock('hooks/useDigitalSpecimen', () => ({
+    useDigitalSpecimenComplete: vi.fn(),
+}));
+
+/* Base mock collection */
+const baseCollection = {
+    id: 'https://doi.org/10.1234/SAMPLE-123',
+    attributes: {
+        'ods:isKnownToContainMedia': true,
+    },
+};
+
+describe('VirtualCollectionImage', () => {
+    it('renders image container with background image when valid JPEG is present', () => {
+        vi.mocked(useDigitalSpecimenComplete).mockReturnValue({
+            data: {
+                digitalMedia: [
+                    {
+                        digitalMediaObject: {
+                            'dcterms:format': 'image/jpeg',
+                            'ac:accessURI': 'https://example.com/specimen.jpg',
+                        },
+                    },
+                ],
+            },
+        } as any);
+
+        const { container } = render(<VirtualCollectionImage collection={baseCollection} />);
+
+        expect(useDigitalSpecimenComplete).toHaveBeenCalledWith({
+            doi: '10.1234/SAMPLE-123',
+            enabled: true,
+        });
+
+        const imageDiv = container.querySelector('.vc-card-image-container');
+        expect(imageDiv).toBeInTheDocument();
+        expect(imageDiv).toHaveStyle({ backgroundImage: 'url(https://example.com/specimen.jpg)' });
+    });
+
+    it('renders "Error loading image" when hasMedia is true but no JPEG is found', () => {
+        vi.mocked(useDigitalSpecimenComplete).mockReturnValue({
+            data: {
+                digitalMedia: [
+                    {
+                        digitalMediaObject: {
+                            'dcterms:format': 'application/pdf',
+                            'ac:accessURI': 'https://example.com/doc.pdf',
+                        },
+                    },
+                ],
+            },
+        } as any);
+
+        render(<VirtualCollectionImage collection={baseCollection} />);
+
+        expect(screen.getByText('Error loading image')).toBeInTheDocument();
+    });
+
+    it('renders "No image" and disables query when isKnownToContainMedia is false', () => {
+        vi.mocked(useDigitalSpecimenComplete).mockReturnValue({ data: undefined } as any);
+
+        const noMediaCollection = {
+            ...baseCollection,
+            attributes: {
+                'ods:isKnownToContainMedia': false,
+            },
+        };
+
+        render(<VirtualCollectionImage collection={noMediaCollection} />);
+
+        expect(useDigitalSpecimenComplete).toHaveBeenCalledWith({
+            doi: '10.1234/SAMPLE-123',
+            enabled: false,
+        });
+
+        expect(screen.getByText('No image')).toBeInTheDocument();
+    });
+
+    it('handles image/jpg format variant correctly', () => {
+        vi.mocked(useDigitalSpecimenComplete).mockReturnValue({
+            data: {
+                digitalMedia: [
+                    {
+                        digitalMediaObject: {
+                            'dcterms:format': 'image/jpg',
+                            'ac:accessURI': 'https://example.com/specimen_alt.jpg',
+                        },
+                    },
+                ],
+            },
+        } as any);
+
+        const { container } = render(<VirtualCollectionImage collection={baseCollection} />);
+
+        const imageDiv = container.querySelector('.vc-card-image-container');
+        expect(imageDiv).toHaveStyle({ backgroundImage: 'url(https://example.com/specimen_alt.jpg)' });
+    });
+});

--- a/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.test.tsx
+++ b/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.test.tsx
@@ -1,6 +1,6 @@
 /* Import test dependencies */
 import { render, screen } from 'tests/test-utils';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 /* Import component & hook */
 import { VirtualCollectionImage } from './VirtualCollectionImage';

--- a/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.test.tsx
+++ b/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.test.tsx
@@ -38,14 +38,14 @@ describe('VirtualCollectionImage', () => {
             },
         } as any);
 
-        const { container } = render(<VirtualCollectionImage collection={baseCollection} />);
+        render(<VirtualCollectionImage collection={baseCollection} />);
 
         expect(useDigitalSpecimenComplete).toHaveBeenCalledWith({
             doi: '10.1234/SAMPLE-123',
             enabled: true,
         });
 
-        const imageDiv = container.querySelector('.vc-card-image-container');
+        const imageDiv = screen.getByRole('img');
         expect(imageDiv).toBeInTheDocument();
         expect(imageDiv).toHaveStyle({ backgroundImage: 'url(https://example.com/specimen.jpg)' });
     });
@@ -103,9 +103,9 @@ describe('VirtualCollectionImage', () => {
             },
         } as any);
 
-        const { container } = render(<VirtualCollectionImage collection={baseCollection} />);
+        render(<VirtualCollectionImage collection={baseCollection} />);
 
-        const imageDiv = container.querySelector('.vc-card-image-container');
+        const imageDiv = screen.getByRole('img');
         expect(imageDiv).toHaveStyle({ backgroundImage: 'url(https://example.com/specimen_alt.jpg)' });
     });
 });

--- a/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.tsx
+++ b/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.tsx
@@ -20,13 +20,13 @@ export const VirtualCollectionImage = ({ collection }: Props) => {
     /* Find the first jpg/jpeg media item of the digital spacimen */
     const firstJpgItem = specimen?.digitalMedia?.find((item: any) => {
         const format = item?.digitalMediaObject?.['dcterms:format'];
-        return format === 'image/jpeg' || format === 'image/jpg';
+        return ['image/jpeg', 'image/jpg'].includes(format);
     });
     
     const firstJpgUrl = firstJpgItem?.digitalMediaObject?.['ac:accessURI'];
 
     return hasMedia && firstJpgUrl ? (
-        <div className="vc-card-image-container" style={{ backgroundImage: `url(${firstJpgUrl})` }} />
+        <div className="vc-card-image-container" role="img" style={{ backgroundImage: `url(${firstJpgUrl})` }} />
     ) : (
         <div className="vc-card-box-container">
             <span>{hasMedia ? 'Error loading image' : 'No image'}</span>

--- a/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.tsx
+++ b/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.tsx
@@ -26,7 +26,12 @@ export const VirtualCollectionImage = ({ collection }: Props) => {
     const firstJpgUrl = firstJpgItem?.digitalMediaObject?.['ac:accessURI'];
 
     return hasMedia && firstJpgUrl ? (
-        <div className="vc-card-image-container" role="img" style={{ backgroundImage: `url(${firstJpgUrl})` }} />
+        <div 
+            className="vc-card-image-container"
+            role="img"
+            aria-label={`Image of digital specimen ${specimenDoi}`}
+            style={{ backgroundImage: `url(${firstJpgUrl})` }} 
+        />
     ) : (
         <div className="vc-card-box-container">
             <span>{hasMedia ? 'Error loading image' : 'No image'}</span>

--- a/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.tsx
+++ b/src/components/ImageComponents/VirtualCollectionImage/VirtualCollectionImage.tsx
@@ -1,0 +1,35 @@
+import { RetrieveEnvVariable } from "app/Utilities";
+import { useDigitalSpecimenComplete } from "hooks/useDigitalSpecimen";
+
+/* Import styling */
+import './VirtualCollectionImage.scss';
+
+interface Props {
+    collection: any
+}
+
+export const VirtualCollectionImage = ({ collection }: Props) => {
+    const specimenDoi = collection['id'].replace(RetrieveEnvVariable('DOI_URL'), '');
+    const hasMedia = Boolean(collection.attributes?.['ods:isKnownToContainMedia']);
+
+    const { data: specimen } = useDigitalSpecimenComplete({ 
+        doi: specimenDoi,
+        enabled: hasMedia
+    });
+
+    /* Find the first jpg/jpeg media item of the digital spacimen */
+    const firstJpgItem = specimen?.digitalMedia?.find((item: any) => {
+        const format = item?.digitalMediaObject?.['dcterms:format'];
+        return format === 'image/jpeg' || format === 'image/jpg';
+    });
+    
+    const firstJpgUrl = firstJpgItem?.digitalMediaObject?.['ac:accessURI'];
+
+    return hasMedia && firstJpgUrl ? (
+        <div className="vc-card-image-container" style={{ backgroundImage: `url(${firstJpgUrl})` }} />
+    ) : (
+        <div className="vc-card-box-container">
+            <span>{hasMedia ? 'Error loading image' : 'No image'}</span>
+        </div>
+    );
+};

--- a/src/hooks/useDigitalSpecimen.ts
+++ b/src/hooks/useDigitalSpecimen.ts
@@ -6,19 +6,27 @@ import { mapDigitalSpecimen, mapDigitalSpecimenMedia } from 'utils/DataMappers/d
 const staleTime = 1000 * 60 * 5; // How long until the time is stale
 const gcTime = 1000 * 60 * 10; // Cache time: How long to store it in the cache
 
+type UseDigitalSpecimenOptions = {
+    doi: string;
+    version?: number;
+    enabled?: boolean;
+};
+
 /* useQuery hook to retrieve the complete Digital Specimen data object by calling the getDigitalSpecimenComplete service */
-export const useDigitalSpecimenComplete = ({ doi, version }:
-    { doi: string, version?: number }) => {
+export const useDigitalSpecimenComplete = ({ 
+    doi, 
+    version, 
+    enabled = true 
+}: UseDigitalSpecimenOptions) => {
     return useQuery({
         queryKey: ['digitalSpecimen', doi, version],
         queryFn: () => getDigitalSpecimenComplete({ doi, version }),
-        select: (data) => {
-            return {
-                ...data,
-                ...mapDigitalSpecimen(data),
-                ...mapDigitalSpecimenMedia(data)
-            }
-        },
+        select: (data) => ({
+            ...data,
+            ...mapDigitalSpecimen(data),
+            ...mapDigitalSpecimenMedia(data)
+        }),
+        enabled,
         staleTime,
         gcTime
     });


### PR DESCRIPTION
In this PR:
- Using the /full endpoint to retrieve the first jpg image of the digital specimen
- Test suite for components

[Design](https://www.figma.com/design/CW7NHzRh3Eu5555lxqNrUr/DiSSCover-v2---UX-design?node-id=1880-38764&t=UIRxt9md3HgAF8Oc-0)

[Jira link](https://naturalis.atlassian.net/browse/DD-3222)

**What it looks like:**
_On desktop:_
<img width="1848" height="919" alt="image" src="https://github.com/user-attachments/assets/8ce0827d-56cf-4bdd-8b1f-ab096a75b3db" />

_On mobile:_
<img width="530" height="891" alt="image" src="https://github.com/user-attachments/assets/117ce0bd-a3f4-46c8-9e41-042a8b1e43fd" />
